### PR TITLE
Fix a link in the contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Here are some ways *you* can contribute:
 * by closing [issues][]
 * by reviewing patches
 
-[issues]: https://github.com/thoughtbot/factory_bot/issues
+[issues]: https://github.com/luckyframework/lucky/issues
 
 ## Submitting an Issue
 


### PR DESCRIPTION
It looks like the readme was copied from FactoryBot. Having done this countless times myself, I thought I'd fix the link and save some confusion!