### PR TITLE
Generate Action contents with Teeplate

### DIFF
--- a/spec/tasks/gen/action_spec.cr
+++ b/spec/tasks/gen/action_spec.cr
@@ -3,25 +3,29 @@ require "../../spec_helper"
 describe Gen::Action do
   it "generates a basic action" do
     begin
-      ARGV.push("Users::Index")
+      valid_action_name = "Users::Index"
+      ARGV.push(valid_action_name)
+
       Gen::Action.new.call
 
-      File.exists?("src/actions/users/index.cr").should be_true
+      File.read("./src/actions/users/index.cr").
+        should contain(valid_action_name)
     ensure
-      ARGV.pop
-      FileUtils.rm_rf "src/actions/users/index.cr"
+      cleanup
     end
   end
 
   it "generates a nested action" do
     begin
-      ARGV.push("Users::Announcements::Index")
+      valid_nested_action_name = "Users::Announcements::Index"
+      ARGV.push(valid_nested_action_name)
+
       Gen::Action.new.call
 
-      File.exists?("src/actions/users/announcements/index.cr").should be_true
+      File.read("src/actions/users/announcements/index.cr").
+        should contain(valid_nested_action_name)
     ensure
-      ARGV.pop
-      FileUtils.rm_rf "src/actions/users/announcements/index.cr"
+      cleanup
     end
   end
 
@@ -37,14 +41,20 @@ describe Gen::Action do
   it "displays an error if given only one class" do
     begin
       io = IO::Memory.new
-      ARGV.push("Users")
+      invalid_action_name = "Users"
+      ARGV.push(invalid_action_name)
 
       Gen::Action.new.call(io)
       message = "\e[31mThat's not a valid Action.  Example: lucky gen.action Users::Index\e[0m"
 
       io.to_s.strip.should eq(message)
     ensure
-      ARGV.pop
+      ARGV.clear
     end
   end
+end
+
+def cleanup
+  ARGV.clear
+  FileUtils.rm_rf("./src/actions")
 end

--- a/spec/tasks/gen/action_spec.cr
+++ b/spec/tasks/gen/action_spec.cr
@@ -3,25 +3,37 @@ require "../../spec_helper"
 describe Gen::Action do
   it "generates a basic action" do
     with_cleanup do
+      io = IO::Memory.new
       valid_action_name = "Users::Index"
       ARGV.push(valid_action_name)
 
-      Gen::Action.new.call
+      Gen::Action.new.call(io)
+      expected_path = "/src/actions/users"
+      expected_message =
+        "Done generating #{valid_action_name.colorize(:green)}" \
+        " in #{expected_path.colorize(:green)}"
 
       File.read("./src/actions/users/index.cr").
         should contain(valid_action_name)
+      io.to_s.strip.should eq(expected_message)
     end
   end
 
   it "generates a nested action" do
     with_cleanup do
+      io = IO::Memory.new
       valid_nested_action_name = "Users::Announcements::Index"
       ARGV.push(valid_nested_action_name)
 
-      Gen::Action.new.call
+      Gen::Action.new.call(io)
+      expected_path = "/src/actions/users/announcements"
+      expected_message =
+        "Done generating #{valid_nested_action_name.colorize(:green)}" \
+        " in #{expected_path.colorize(:green)}"
 
       File.read("src/actions/users/announcements/index.cr").
         should contain(valid_nested_action_name)
+      io.to_s.strip.should eq(expected_message)
     end
   end
 

--- a/spec/tasks/gen/action_spec.cr
+++ b/spec/tasks/gen/action_spec.cr
@@ -53,7 +53,7 @@ describe Gen::Action do
       ARGV.push(invalid_action_name)
 
       Gen::Action.new.call(io)
-      message = "\e[31mThat's not a valid Action.  Example: lucky gen.action Users::Index\e[0m"
+      message = "\e[31mThat's not a valid Action. Example: lucky gen.action Users::Index\e[0m"
 
       io.to_s.strip.should eq(message)
     end

--- a/spec/tasks/gen/action_spec.cr
+++ b/spec/tasks/gen/action_spec.cr
@@ -2,7 +2,7 @@ require "../../spec_helper"
 
 describe Gen::Action do
   it "generates a basic action" do
-    begin
+    with_cleanup do
       valid_action_name = "Users::Index"
       ARGV.push(valid_action_name)
 
@@ -10,13 +10,11 @@ describe Gen::Action do
 
       File.read("./src/actions/users/index.cr").
         should contain(valid_action_name)
-    ensure
-      cleanup
     end
   end
 
   it "generates a nested action" do
-    begin
+    with_cleanup do
       valid_nested_action_name = "Users::Announcements::Index"
       ARGV.push(valid_nested_action_name)
 
@@ -24,8 +22,6 @@ describe Gen::Action do
 
       File.read("src/actions/users/announcements/index.cr").
         should contain(valid_nested_action_name)
-    ensure
-      cleanup
     end
   end
 
@@ -39,7 +35,7 @@ describe Gen::Action do
   end
 
   it "displays an error if given only one class" do
-    begin
+    with_cleanup do
       io = IO::Memory.new
       invalid_action_name = "Users"
       ARGV.push(invalid_action_name)
@@ -48,8 +44,6 @@ describe Gen::Action do
       message = "\e[31mThat's not a valid Action.  Example: lucky gen.action Users::Index\e[0m"
 
       io.to_s.strip.should eq(message)
-    ensure
-      ARGV.clear
     end
   end
 end
@@ -57,4 +51,12 @@ end
 private def cleanup
   ARGV.clear
   FileUtils.rm_rf("./src/actions")
+end
+
+private def with_cleanup
+  begin
+    yield
+  ensure
+    cleanup
+  end
 end

--- a/spec/tasks/gen/action_spec.cr
+++ b/spec/tasks/gen/action_spec.cr
@@ -54,7 +54,7 @@ describe Gen::Action do
   end
 end
 
-def cleanup
+private def cleanup
   ARGV.clear
   FileUtils.rm_rf("./src/actions")
 end

--- a/spec/tasks/gen/action_spec.cr
+++ b/spec/tasks/gen/action_spec.cr
@@ -8,14 +8,11 @@ describe Gen::Action do
       ARGV.push(valid_action_name)
 
       Gen::Action.new.call(io)
-      expected_path = "/src/actions/users"
-      expected_message =
-        "Done generating #{valid_action_name.colorize(:green)}" \
-        " in #{expected_path.colorize(:green)}"
 
       File.read("./src/actions/users/index.cr").
         should contain(valid_action_name)
-      io.to_s.strip.should eq(expected_message)
+      io.to_s.should contain(valid_action_name)
+      io.to_s.should contain("/src/actions/users")
     end
   end
 
@@ -26,14 +23,11 @@ describe Gen::Action do
       ARGV.push(valid_nested_action_name)
 
       Gen::Action.new.call(io)
-      expected_path = "/src/actions/users/announcements"
-      expected_message =
-        "Done generating #{valid_nested_action_name.colorize(:green)}" \
-        " in #{expected_path.colorize(:green)}"
 
       File.read("src/actions/users/announcements/index.cr").
         should contain(valid_nested_action_name)
-      io.to_s.strip.should eq(expected_message)
+      io.to_s.should contain(valid_nested_action_name)
+      io.to_s.should contain("/src/actions/users/announcements")
     end
   end
 
@@ -41,9 +35,8 @@ describe Gen::Action do
     io = IO::Memory.new
 
     Gen::Action.new.call(io)
-    message = "\e[31mAction name is required. Example: lucky gen.action Users::Index\e[0m"
 
-    io.to_s.strip.should eq(message)
+    io.to_s.should contain("Action name is required.")
   end
 
   it "displays an error if given only one class" do
@@ -53,9 +46,8 @@ describe Gen::Action do
       ARGV.push(invalid_action_name)
 
       Gen::Action.new.call(io)
-      message = "\e[31mThat's not a valid Action. Example: lucky gen.action Users::Index\e[0m"
 
-      io.to_s.strip.should eq(message)
+      io.to_s.should contain("That's not a valid Action.")
     end
   end
 end

--- a/tasks/gen/action.cr
+++ b/tasks/gen/action.cr
@@ -46,11 +46,7 @@ class Gen::Action < LuckyCli::Task
   end
 
   private def output_path
-    Dir.current + app_directory_path
-  end
-
-  private def app_directory_path
-    "/src/actions/#{path}"
+    "./src/actions/#{path}"
   end
 
   private def path
@@ -62,6 +58,6 @@ class Gen::Action < LuckyCli::Task
   end
 
   private def success_message
-    "Done generating #{action_name.colorize(:green)} in #{app_directory_path.colorize(:green)}"
+    "Done generating #{action_name.colorize(:green)} in #{output_path.colorize(:green)}"
   end
 end

--- a/tasks/gen/action.cr
+++ b/tasks/gen/action.cr
@@ -1,41 +1,13 @@
 require "colorize"
 require "file_utils"
 
-class Lucky::ActionGenerator < Teeplate::FileTree
-  getter :name
+class Lucky::ActionTemplate < Teeplate::FileTree
+  @name : String
+  @action : String
 
-  directory "#{__DIR__}"
+  directory "#{__DIR__}/templates"
 
-  def initialize(@name : String)
-  end
-
-  def generate
-    make_folders_if_missing
-    File.write(filename, contents)
-  end
-
-  private def make_folders_if_missing
-    FileUtils.mkdir_p Dir.current + "/src/actions/#{path}"
-  end
-
-  private def path_args
-    name.split("::").map(&.downcase)
-  end
-
-  private def path
-    path_args[0..-2].join("/")
-  end
-
-  private def action
-    path_args.last
-  end
-
-  private def filename
-    Dir.current + "/src/actions/#{path}/#{action}.cr"
-  end
-
-  private def contents
-    to_s
+  def initialize(@name, @action)
   end
 end
 
@@ -44,7 +16,7 @@ class Gen::Action < LuckyCli::Task
 
   def call(io : IO = STDOUT)
     if valid?
-      Lucky::ActionGenerator.new(name: ARGV.first).generate
+      Lucky::ActionTemplate.new(action_name, action).render(output_path)
     else
       io.puts @error.colorize(:red)
     end
@@ -62,5 +34,25 @@ class Gen::Action < LuckyCli::Task
   private def name_matches_format
     @error = "That's not a valid Action.  Example: lucky gen.action Users::Index"
     ARGV.first.includes?("::")
+  end
+
+  private def action_name
+    ARGV.first
+  end
+
+  private def action
+    path_args.last
+  end
+
+  private def output_path
+    Dir.current + "/src/actions/#{path}"
+  end
+
+  private def path
+    path_args[0..-2].join("/")
+  end
+
+  private def path_args
+    action_name.split("::").map(&.downcase)
   end
 end

--- a/tasks/gen/action.cr
+++ b/tasks/gen/action.cr
@@ -17,6 +17,7 @@ class Gen::Action < LuckyCli::Task
   def call(io : IO = STDOUT)
     if valid?
       Lucky::ActionTemplate.new(action_name, action).render(output_path)
+      io.puts success_message
     else
       io.puts @error.colorize(:red)
     end
@@ -45,7 +46,11 @@ class Gen::Action < LuckyCli::Task
   end
 
   private def output_path
-    Dir.current + "/src/actions/#{path}"
+    Dir.current + app_directory_path
+  end
+
+  private def app_directory_path
+    "/src/actions/#{path}"
   end
 
   private def path
@@ -54,5 +59,9 @@ class Gen::Action < LuckyCli::Task
 
   private def path_args
     action_name.split("::").map(&.downcase)
+  end
+
+  private def success_message
+    "Done generating #{action_name.colorize(:green)} in #{output_path.colorize(:green)}"
   end
 end

--- a/tasks/gen/action.cr
+++ b/tasks/gen/action.cr
@@ -33,7 +33,7 @@ class Gen::Action < LuckyCli::Task
   end
 
   private def name_matches_format
-    @error = "That's not a valid Action.  Example: lucky gen.action Users::Index"
+    @error = "That's not a valid Action. Example: lucky gen.action Users::Index"
     ARGV.first.includes?("::")
   end
 

--- a/tasks/gen/action.cr
+++ b/tasks/gen/action.cr
@@ -62,6 +62,6 @@ class Gen::Action < LuckyCli::Task
   end
 
   private def success_message
-    "Done generating #{action_name.colorize(:green)} in #{output_path.colorize(:green)}"
+    "Done generating #{action_name.colorize(:green)} in #{app_directory_path.colorize(:green)}"
   end
 end

--- a/tasks/gen/action.ecr
+++ b/tasks/gen/action.ecr
@@ -1,4 +1,0 @@
-class <%= name %> < BrowserAction
-  action do
-  end
-end

--- a/tasks/gen/templates/{{action}}.cr.ecr
+++ b/tasks/gen/templates/{{action}}.cr.ecr
@@ -1,0 +1,4 @@
+class <%= @name %> < BrowserAction
+  action do
+  end
+end


### PR DESCRIPTION
The Action generator was halfway between using ECR and Teeplate to
render the contents of the Action file.   As such, when generating a new
Action, the file path and name were correct, but file itself just
contained the stringified ActionGenerator object (e.g.
<ActionGenerator:312>).

Switch to using the Teeplate `#render` method on ActionGenerator (now
ActionTemplate) to create a new Action.