### PR TITLE
Extract #with_cleanup into helper

### DIFF
--- a/spec/support/cleanup_helper.cr
+++ b/spec/support/cleanup_helper.cr
@@ -1,0 +1,18 @@
+module CleanupHelper
+  private def cleanup
+    ARGV.clear
+    FileUtils.rm_rf("./tmp")
+  end
+
+  private def with_cleanup
+    begin
+      Dir.mkdir("./tmp")
+      Dir.cd("./tmp")
+      yield
+    ensure
+      Dir.cd("..")
+      cleanup
+    end
+  end
+end
+

--- a/spec/tasks/gen/action_spec.cr
+++ b/spec/tasks/gen/action_spec.cr
@@ -1,5 +1,7 @@
 require "../../spec_helper"
 
+include CleanupHelper
+
 describe Gen::Action do
   it "generates a basic action" do
     with_cleanup do
@@ -52,15 +54,3 @@ describe Gen::Action do
   end
 end
 
-private def cleanup
-  ARGV.clear
-  FileUtils.rm_rf("./src/actions")
-end
-
-private def with_cleanup
-  begin
-    yield
-  ensure
-    cleanup
-  end
-end


### PR DESCRIPTION
Each of the generator tasks output files to a different directory.
Extract the #with_cleanup method into a spec support helper and
generalize it to handle outputting to different directories.