### PR TITLE
Raise friendly error with invalid action

### DIFF
--- a/src/lucky/action.cr
+++ b/src/lucky/action.cr
@@ -6,7 +6,7 @@ abstract class Lucky::Action
   def initialize(@context : HTTP::Server::Context, @route_params : Hash(String, String))
   end
 
-  abstract def call : Lucky::Response
+  abstract def call
 
   include Lucky::ActionDelegates
   include Lucky::ContentTypeHelpers

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -37,8 +37,14 @@ module Lucky::Renderable
     response.print
   end
 
-  private def handle_response(_response)
-    {% raise "You must return a Lucky::Response from #{@type}. You can do that by using methods such as `render`, `redirect`, `json`" %}
+  private def handle_response(_response : T) forall T
+    {% raise <<-ERROR
+
+     #{@type} returned #{T}, but it must return a Lucky::Response.
+
+     Try this...
+     ▸ Make sure to use a method like `render`, `redirect`, `json` at the end of your action.
+    ERROR %}
   end
 
   private def render_text(body)

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -43,7 +43,8 @@ module Lucky::Renderable
      #{@type} returned #{T}, but it must return a Lucky::Response.
 
      Try this...
-     ▸ Make sure to use a method like `render`, `redirect`, `json` at the end of your action.
+       ▸ Make sure to use a method like `render`, `redirect`, or `json` at the end of your action.
+       ▸ If you are using a conditional, make sure all branches return a Lucky::Response.
     ERROR %}
   end
 

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -37,6 +37,10 @@ module Lucky::Renderable
     response.print
   end
 
+  private def handle_response(_response)
+    {% raise "You must return a Lucky::Response from #{@type}. You can do that by using methods such as `render`, `redirect`, `json`" %}
+  end
+
   private def render_text(body)
     Lucky::Response.new(context, "text/plain", body)
   end

--- a/src/lucky/routeable.cr
+++ b/src/lucky/routeable.cr
@@ -8,7 +8,7 @@ module Lucky::Routeable
   {% end %}
 
   macro setup_call_method(body)
-    def call : Lucky::Response
+    def call
       callback_result = run_before_callbacks
 
       response = if callback_result.is_a?(Lucky::Response)


### PR DESCRIPTION
An action must return a response object to be valid. If a developer
fails to do so, the current error message isn't very clear on what needs
to be fixed.  Change the error message to explicitly state that one should
return a response from the action, and suggest methods to do so.

See issue #129 