### PR TITLE
Make options_for_select generic

### DIFF
--- a/spec/lucky/select_helpers_spec.cr
+++ b/spec/lucky/select_helpers_spec.cr
@@ -24,10 +24,10 @@ end
 
 class SomeFormWithCompany
   def company_id
-    Avram::PermittedAttribute(String).new(
+    Avram::PermittedAttribute(Int32?).new(
       name: :company_id,
       param: "1",
-      value: "",
+      value: nil,
       param_key: "company"
     )
   end

--- a/src/lucky/tags/select_helpers.cr
+++ b/src/lucky/tags/select_helpers.cr
@@ -1,13 +1,11 @@
 module Lucky::SelectHelpers
-  alias SelectOption = (String | Int32 | Int64)
-
   def select_input(field : Avram::PermittedAttribute, **html_options)
     select_tag merge_options(html_options, {"name" => input_name(field)}) do
       yield
     end
   end
 
-  def options_for_select(field : Avram::PermittedAttribute, select_options : Array(Tuple(String, SelectOption)), **html_options)
+  def options_for_select(field : Avram::PermittedAttribute(T), select_options : Array(Tuple(String, T)), **html_options) forall T
     select_options.each do |option_name, option_value|
       attributes = {"value" => option_value.to_s}
 


### PR DESCRIPTION
Closes #292

This works, the problem is some Fields are nilable, which would mean the
second item in the tuple would be nilable. That's probably not what the
user wants. On the other hand, it seems unlikely that a `nil` option
would end up there.