### PR TITLE
Allow empty text for `link`

### DIFF
--- a/spec/lucky/link_helpers_spec.cr
+++ b/spec/lucky/link_helpers_spec.cr
@@ -45,6 +45,14 @@ private class TestPage
       text "Hello"
     end
   end
+
+  def get_route_without_text
+    link to: LinkHelpers::Index
+  end
+
+  def string_path_without_text
+    link to: "/foo"
+  end
 end
 
 describe Lucky::LinkHelpers do
@@ -78,6 +86,16 @@ describe Lucky::LinkHelpers do
 
     view.get_route_with_block.to_s.should contain <<-HTML
     <a href="/link_helpers">Hello</a>
+    HTML
+  end
+
+  it "renders a link tag without text" do
+    view.string_path_without_text.to_s.should contain <<-HTML
+    <a href="/foo"></a>
+    HTML
+
+    view.get_route_without_text.to_s.should contain <<-HTML
+    <a href="/link_helpers"></a>
     HTML
   end
 end

--- a/src/lucky/tags/link_helpers.cr
+++ b/src/lucky/tags/link_helpers.cr
@@ -19,6 +19,14 @@ module Lucky::LinkHelpers
     end
   end
 
+  def link(to : Lucky::RouteHelper, **html_options)
+    a(merge_options(html_options, link_to_href(to))) {}
+  end
+
+  def link(to : Lucky::Action.class, **html_options)
+    a(merge_options(html_options, link_to_href(to.route))) {}
+  end
+
   private def link_to_href(route)
     if route.method == :get
       {"href" => route.path}
@@ -35,5 +43,9 @@ module Lucky::LinkHelpers
     a merge_options(html_options, {"href" => to}) do
       yield
     end
+  end
+
+  def link(to : String, **html_options)
+    a(merge_options(html_options, {"href" => to})) {}
   end
 end


### PR DESCRIPTION
Some links do not need text (e.g. links using a background image ).  Add
link helpers that accept empty text without a block.

Closes #104