### PR TITLE
Output render log message only once

### DIFF
--- a/spec/lucky/action_rendering_spec.cr
+++ b/spec/lucky/action_rendering_spec.cr
@@ -53,9 +53,8 @@ describe Lucky::Action do
   describe "rendering HTML pages" do
     it "render assigns" do
       response = Rendering::Index.new(build_context, params).call
-      body = response.body
 
-      body.should contain "Anything"
+      response.body.should contain "Anything"
       response.debug_message.to_s.should contain "Rendering::Index"
     end
   end

--- a/spec/lucky/action_rendering_spec.cr
+++ b/spec/lucky/action_rendering_spec.cr
@@ -55,7 +55,7 @@ describe Lucky::Action do
       response = Rendering::Index.new(build_context, params).call
 
       response.body.should contain "Anything"
-      response.debug_message.to_s.should contain "Rendering::Index"
+      response.debug_message.to_s.should contain "Rendering::IndexPage"
     end
   end
 

--- a/spec/lucky/action_rendering_spec.cr
+++ b/spec/lucky/action_rendering_spec.cr
@@ -52,9 +52,11 @@ end
 describe Lucky::Action do
   describe "rendering HTML pages" do
     it "render assigns" do
-      body = Rendering::Index.new(build_context, params).call.body
+      response = Rendering::Index.new(build_context, params).call
+      body = response.body
 
       body.should contain "Anything"
+      response.debug_message.to_s.should contain "Rendering::Index"
     end
   end
 

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -55,7 +55,7 @@ module Lucky::Renderable
     %}
   end
 
-  private def log_response(response)
+  private def log_response(response : Lucky::Response)
     debug_message = response.debug_message
     if !debug_message.nil?
       context.add_debug_message(debug_message)

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -19,10 +19,13 @@ module Lucky::Renderable
         {{ key }}: {{ key }},
       {% end %}
     )
-    debug_message = log_message(view)
     body = view.perform_render.to_s
-    Lucky::Response.new(context, "text/html", body,
-                        debug_message: debug_message)
+    Lucky::Response.new(
+      context,
+      "text/html",
+      body,
+      debug_message: log_message(view),
+    )
   end
 
   private def log_message(view)

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -56,9 +56,8 @@ module Lucky::Renderable
   end
 
   private def log_response(response : Lucky::Response)
-    debug_message = response.debug_message
-    if !debug_message.nil?
-      context.add_debug_message(debug_message)
+    response.debug_message.try do |message|
+      context.add_debug_message(message)
     end
   end
 

--- a/src/lucky/response.cr
+++ b/src/lucky/response.cr
@@ -1,9 +1,9 @@
 class Lucky::Response
   DEFAULT_STATUS = 200
 
-  getter context, content_type, body
+  getter context, content_type, body, debug_message
 
-  def initialize(@context : HTTP::Server::Context, @content_type : String, @body : String, @status : Int32? = nil)
+  def initialize(@context : HTTP::Server::Context, @content_type : String, @body : String, @status : Int32? = nil, @debug_message : String? = nil)
   end
 
   def print

--- a/src/lucky/response.cr
+++ b/src/lucky/response.cr
@@ -3,7 +3,11 @@ class Lucky::Response
 
   getter context, content_type, body, debug_message
 
-  def initialize(@context : HTTP::Server::Context, @content_type : String, @body : String, @status : Int32? = nil, @debug_message : String? = nil)
+  def initialize(@context : HTTP::Server::Context,
+                 @content_type : String,
+                 @body : String,
+                 @status : Int32? = nil,
+                 @debug_message : String? = nil)
   end
 
   def print


### PR DESCRIPTION
If multiple pages were rendered in an action, there would be a log
message for each render.  Attach the log message to the Lucky::Response
and move the logging mechanism to #handle_response, to remove the
possibility of redundant messages.

Closes #270