### PR TITLE
Add default render_text to action generator

### DIFF
--- a/tasks/gen/templates/action/{{action}}.cr.ecr
+++ b/tasks/gen/templates/action/{{action}}.cr.ecr
@@ -1,4 +1,5 @@
 class <%= @name %> < BrowserAction
   action do
+    render_text "Render something in <%= @name %>"
   end
 end


### PR DESCRIPTION
Generated actions did not compile by default, as the default action
didn't return a Lucky::Response. Add a default `render_text` urging
developers to render something in the generated action.

Closes #310