### PR TITLE
Only generate one session CSRF token

### DIFF
--- a/spec/lucky/protect_from_forgery_spec.cr
+++ b/spec/lucky/protect_from_forgery_spec.cr
@@ -9,14 +9,12 @@ class ProtectedAction::Index < Lucky::Action
 end
 
 describe Lucky::ProtectFromForgery do
-  it "sets a new CSRF token after a successful request" do
+  it "sets a CSRF token if none was set" do
     original_token = "my_token"
     context = build_context(method: "GET")
-    context.session["X-CSRF-TOKEN"] = original_token
 
     response = ProtectedAction::Index.new(context, params).call
 
-    context.session["X-CSRF-TOKEN"].should_not eq(original_token)
     (context.session["X-CSRF-TOKEN"].not_nil!.size > 30).should be_true
   end
 

--- a/src/lucky/protect_from_forgery.cr
+++ b/src/lucky/protect_from_forgery.cr
@@ -5,7 +5,6 @@ module Lucky::ProtectFromForgery
 
   macro included
     before protect_from_forgery
-    after set_new_csrf_token
   end
 
   # :nodoc:
@@ -14,6 +13,7 @@ module Lucky::ProtectFromForgery
   end
 
   private def protect_from_forgery
+    set_session_csrf_token
     if request_does_not_require_protection? || valid_csrf_token?
       continue
     else
@@ -21,9 +21,8 @@ module Lucky::ProtectFromForgery
     end
   end
 
-  private def set_new_csrf_token
-    session[SESSION_KEY] = Random::Secure.urlsafe_base64(32)
-    continue
+  private def set_session_csrf_token
+    session[SESSION_KEY] ||= Random::Secure.urlsafe_base64(32)
   end
 
   private def request_does_not_require_protection?


### PR DESCRIPTION
The problem with generating a new CSRF token after every request is that
you can open two tabs and one of the tabs will have the old CSRF token
and fail when submitting the form.

After doing some research it seems that it is fine to have just one CSRF
token:

* https://github.com/elixir-plug/plug/issues/504
* http://security.stackexchange.com/questions/22903/why-refresh-csrf-token-per-form-request
* http://stackoverflow.com/questions/8655817/csrf-protection-do-we-have-to-generate-a-token-for-every-form

An additional improvement for the future would be to mask the CSRF
token: https://medium.com/rubyinside/a-deep-dive-into-csrf-protection-in-rails-19fa0a42c0ef

Also closes: #328