### PR TITLE
Add documentation for Lucky::ContentTypeHelpers

### DIFF
--- a/src/lucky/content_type_helpers.cr
+++ b/src/lucky/content_type_helpers.cr
@@ -1,19 +1,35 @@
+# These helpers check HTTP headers to determine "content type". Most check the
+# Content-Type header, check other information, such as the `X-Requested-With`
+# header.
 module Lucky::ContentTypeHelpers
   abstract def content_type : String
   abstract def headers : HTTP::Headers
 
+  # Check if the request is JSON
+  #
+  # This tests if the Content-Type header is `application/json`
   def json?
     content_type == "application/json"
   end
 
+  # Check if the request is AJAX
+  #
+  # This tests if the X-Requested-With header is `XMLHttpRequest`
   def ajax?
     headers["X-Requested-With"]? == "XMLHttpRequest"
   end
 
+  # Check if the request is HTML
+  #
+  # This tests if the Content-Type header is `text/html`
   def html?
     content_type == "text/html"
   end
 
+  # Check if the request is XML
+  #
+  # This tests if the Content-Type header is `application/xml` or
+  # `application/xhtml+xml`
   def xml?
     ["application/xml", "application/xhtml+xml"].includes? content_type
   end


### PR DESCRIPTION
Getting my feet wet with some documentation (#275). These are pretty simple methods but I think the expanded context of what these helpers are looking for could help.

I put two blank lines above each method's description so that the documentation would only show up on in the details method docs, not in the summary, which looked really cluttered. Happy to change it though if someone thinks it should be in both.