### PR TITLE
Split action generators into `action.api` and `action.browser`

### DIFF
--- a/spec/tasks/gen/action_spec.cr
+++ b/spec/tasks/gen/action_spec.cr
@@ -5,11 +5,8 @@ include CleanupHelper
 describe Gen::Action do
   it "generates a basic browser action" do
     with_cleanup do
-      io = IO::Memory.new
       valid_action_name = "Users::Index"
-      ARGV.push(valid_action_name)
-
-      Gen::Action::Browser.new.call(io)
+      io = generate valid_action_name, Gen::Action::Browser
 
       index_action = File.read("./src/actions/users/index.cr")
       index_action.should contain(valid_action_name)
@@ -22,11 +19,8 @@ describe Gen::Action do
 
   it "generates a basic api action" do
     with_cleanup do
-      io = IO::Memory.new
       valid_action_name = "Users::Index"
-      ARGV.push(valid_action_name)
-
-      Gen::Action::Api.new.call(io)
+      io = generate valid_action_name, Gen::Action::Api
 
       index_action = File.read("./src/actions/users/index.cr")
       index_action.should contain(valid_action_name)
@@ -39,11 +33,8 @@ describe Gen::Action do
 
   it "generates nested browser and api actions" do
     with_cleanup do
-      io = IO::Memory.new
       valid_nested_action_name = "Users::Announcements::Index"
-      ARGV.push(valid_nested_action_name)
-
-      Gen::Action::Browser.new.call(io)
+      io = generate valid_nested_action_name, Gen::Action::Browser
 
       index_action = File.read("src/actions/users/announcements/index.cr")
       index_action.should contain(valid_nested_action_name)
@@ -54,11 +45,8 @@ describe Gen::Action do
     end
 
     with_cleanup do
-      io = IO::Memory.new
       valid_nested_action_name = "Users::Announcements::Index"
-      ARGV.push(valid_nested_action_name)
-
-      Gen::Action::Api.new.call(io)
+      io = generate valid_nested_action_name, Gen::Action::Api
 
       index_action = File.read("src/actions/users/announcements/index.cr")
       index_action.should contain(valid_nested_action_name)
@@ -70,11 +58,8 @@ describe Gen::Action do
 
     it "snake cases filenames of a camel case action" do
       with_cleanup do
-        io = IO::Memory.new
         valid_camel_case_action_name = "Users::HostedEvents"
-        ARGV.push(valid_camel_case_action_name)
-
-        Gen::Action::Browser.new.call(io)
+        io = generate valid_camel_case_action_name, Gen::Action::Browser
 
         File.read("src/actions/users/hosted_events.cr")
             .should contain(valid_camel_case_action_name)
@@ -85,22 +70,23 @@ describe Gen::Action do
   end
 
   it "displays an error if given no arguments" do
-    io = IO::Memory.new
-
-    Gen::Action::Browser.new.call(io)
+    io = generate nil, Gen::Action::Browser
 
     io.to_s.should contain("Action name is required.")
   end
 
   it "displays an error if given only one class" do
     with_cleanup do
-      io = IO::Memory.new
-      invalid_action_name = "Users"
-      ARGV.push(invalid_action_name)
-
-      Gen::Action::Browser.new.call(io)
+      io = generate "Users", Gen::Action::Browser
 
       io.to_s.should contain("That's not a valid Action.")
     end
   end
+end
+
+private def generate(name, generator : Class)
+  ARGV.push(name) if name
+  io = IO::Memory.new
+  generator.new.call(io)
+  io
 end

--- a/spec/tasks/gen/action_spec.cr
+++ b/spec/tasks/gen/action_spec.cr
@@ -8,9 +8,8 @@ describe Gen::Action do
       valid_action_name = "Users::Index"
       io = generate valid_action_name, Gen::Action::Browser
 
-      index_action = File.read("./src/actions/users/index.cr")
-      index_action.should contain(valid_action_name)
-      index_action.should contain("< BrowserAction")
+      filename = "./src/actions/users/index.cr"
+      should_have_generated "#{valid_action_name} < BrowserAction", inside: filename
 
       io.to_s.should contain(valid_action_name)
       io.to_s.should contain("/src/actions/users")
@@ -22,9 +21,8 @@ describe Gen::Action do
       valid_action_name = "Users::Index"
       io = generate valid_action_name, Gen::Action::Api
 
-      index_action = File.read("./src/actions/users/index.cr")
-      index_action.should contain(valid_action_name)
-      index_action.should contain("< ApiAction")
+      filename = "./src/actions/users/index.cr"
+      should_have_generated "#{valid_action_name} < ApiAction", inside: filename
 
       io.to_s.should contain(valid_action_name)
       io.to_s.should contain("/src/actions/users")
@@ -36,9 +34,8 @@ describe Gen::Action do
       valid_nested_action_name = "Users::Announcements::Index"
       io = generate valid_nested_action_name, Gen::Action::Browser
 
-      index_action = File.read("src/actions/users/announcements/index.cr")
-      index_action.should contain(valid_nested_action_name)
-      index_action.should contain("< BrowserAction")
+      filename = "src/actions/users/announcements/index.cr"
+      should_have_generated "#{valid_nested_action_name} < BrowserAction", inside: filename
 
       io.to_s.should contain(valid_nested_action_name)
       io.to_s.should contain("/src/actions/users/announcements")
@@ -48,9 +45,8 @@ describe Gen::Action do
       valid_nested_action_name = "Users::Announcements::Index"
       io = generate valid_nested_action_name, Gen::Action::Api
 
-      index_action = File.read("src/actions/users/announcements/index.cr")
-      index_action.should contain(valid_nested_action_name)
-      index_action.should contain("< ApiAction")
+      filename = "src/actions/users/announcements/index.cr"
+      should_have_generated "#{valid_nested_action_name} < ApiAction", inside: filename
 
       io.to_s.should contain(valid_nested_action_name)
       io.to_s.should contain("/src/actions/users/announcements")
@@ -61,8 +57,7 @@ describe Gen::Action do
         valid_camel_case_action_name = "Users::HostedEvents"
         io = generate valid_camel_case_action_name, Gen::Action::Browser
 
-        File.read("src/actions/users/hosted_events.cr")
-            .should contain(valid_camel_case_action_name)
+        should_have_generated valid_camel_case_action_name, inside: "src/actions/users/hosted_events.cr"
         io.to_s.should contain(valid_camel_case_action_name)
         io.to_s.should contain("/src/actions/users")
       end
@@ -89,4 +84,8 @@ private def generate(name, generator : Class)
   io = IO::Memory.new
   generator.new.call(io)
   io
+end
+
+private def should_have_generated(text, inside)
+  File.read(inside).should contain(text)
 end

--- a/spec/tasks/gen/action_spec.cr
+++ b/spec/tasks/gen/action_spec.cr
@@ -3,31 +3,35 @@ require "../../spec_helper"
 include CleanupHelper
 
 describe Gen::Action do
-  it "generates a basic action" do
+  it "generates a basic browser action" do
     with_cleanup do
       io = IO::Memory.new
       valid_action_name = "Users::Index"
       ARGV.push(valid_action_name)
 
-      Gen::Action.new.call(io)
+      Gen::Action::Browser.new.call(io)
 
-      File.read("./src/actions/users/index.cr")
-          .should contain(valid_action_name)
+      index_action = File.read("./src/actions/users/index.cr")
+      index_action.should contain(valid_action_name)
+      index_action.should contain("< BrowserAction")
+
       io.to_s.should contain(valid_action_name)
       io.to_s.should contain("/src/actions/users")
     end
   end
 
-  it "generates a nested action" do
+  it "generates a nested api action" do
     with_cleanup do
       io = IO::Memory.new
       valid_nested_action_name = "Users::Announcements::Index"
       ARGV.push(valid_nested_action_name)
 
-      Gen::Action.new.call(io)
+      Gen::Action::Api.new.call(io)
 
-      File.read("src/actions/users/announcements/index.cr")
-          .should contain(valid_nested_action_name)
+      index_action = File.read("src/actions/users/announcements/index.cr")
+      index_action.should contain(valid_nested_action_name)
+      index_action.should contain("< ApiAction")
+
       io.to_s.should contain(valid_nested_action_name)
       io.to_s.should contain("/src/actions/users/announcements")
     end
@@ -38,7 +42,7 @@ describe Gen::Action do
         valid_camel_case_action_name = "Users::HostedEvents"
         ARGV.push(valid_camel_case_action_name)
 
-        Gen::Action.new.call(io)
+        Gen::Action::Browser.new.call(io)
 
         File.read("src/actions/users/hosted_events.cr")
             .should contain(valid_camel_case_action_name)
@@ -51,7 +55,7 @@ describe Gen::Action do
   it "displays an error if given no arguments" do
     io = IO::Memory.new
 
-    Gen::Action.new.call(io)
+    Gen::Action::Browser.new.call(io)
 
     io.to_s.should contain("Action name is required.")
   end
@@ -62,7 +66,7 @@ describe Gen::Action do
       invalid_action_name = "Users"
       ARGV.push(invalid_action_name)
 
-      Gen::Action.new.call(io)
+      Gen::Action::Browser.new.call(io)
 
       io.to_s.should contain("That's not a valid Action.")
     end

--- a/spec/tasks/gen/action_spec.cr
+++ b/spec/tasks/gen/action_spec.cr
@@ -37,7 +37,22 @@ describe Gen::Action do
     end
   end
 
-  it "generates a nested api action" do
+  it "generates nested browser and api actions" do
+    with_cleanup do
+      io = IO::Memory.new
+      valid_nested_action_name = "Users::Announcements::Index"
+      ARGV.push(valid_nested_action_name)
+
+      Gen::Action::Browser.new.call(io)
+
+      index_action = File.read("src/actions/users/announcements/index.cr")
+      index_action.should contain(valid_nested_action_name)
+      index_action.should contain("< BrowserAction")
+
+      io.to_s.should contain(valid_nested_action_name)
+      io.to_s.should contain("/src/actions/users/announcements")
+    end
+
     with_cleanup do
       io = IO::Memory.new
       valid_nested_action_name = "Users::Announcements::Index"

--- a/spec/tasks/gen/action_spec.cr
+++ b/spec/tasks/gen/action_spec.cr
@@ -20,6 +20,23 @@ describe Gen::Action do
     end
   end
 
+  it "generates a basic api action" do
+    with_cleanup do
+      io = IO::Memory.new
+      valid_action_name = "Users::Index"
+      ARGV.push(valid_action_name)
+
+      Gen::Action::Api.new.call(io)
+
+      index_action = File.read("./src/actions/users/index.cr")
+      index_action.should contain(valid_action_name)
+      index_action.should contain("< ApiAction")
+
+      io.to_s.should contain(valid_action_name)
+      io.to_s.should contain("/src/actions/users")
+    end
+  end
+
   it "generates a nested api action" do
     with_cleanup do
       io = IO::Memory.new

--- a/tasks/gen/action/api.cr
+++ b/tasks/gen/action/api.cr
@@ -1,4 +1,8 @@
-class Gen::Action::Api < Gen::ActionGenerator
+class Gen::Action::Api < LuckyCli::Task
+  include Gen::ActionGenerator
+
+  banner "Generate a new api action"
+
   def call(io : IO = STDOUT)
     render_action_template(io, inherit_from: "ApiAction")
   end

--- a/tasks/gen/action/api.cr
+++ b/tasks/gen/action/api.cr
@@ -1,0 +1,5 @@
+class Gen::Action::Api < Gen::ActionGenerator
+  def call(io : IO = STDOUT)
+    render_action_template(io, inherit_from: "ApiAction")
+  end
+end

--- a/tasks/gen/action/browser.cr
+++ b/tasks/gen/action/browser.cr
@@ -1,4 +1,8 @@
-class Gen::Action::Browser < Gen::ActionGenerator
+class Gen::Action::Browser < LuckyCli::Task
+  include Gen::ActionGenerator
+
+  banner "Generate a new browser action"
+
   def call(io : IO = STDOUT)
     render_action_template(io, inherit_from: "BrowserAction")
   end

--- a/tasks/gen/action/browser.cr
+++ b/tasks/gen/action/browser.cr
@@ -1,0 +1,5 @@
+class Gen::Action::Browser < Gen::ActionGenerator
+  def call(io : IO = STDOUT)
+    render_action_template(io, inherit_from: "BrowserAction")
+  end
+end

--- a/tasks/gen/action_generator.cr
+++ b/tasks/gen/action_generator.cr
@@ -1,24 +1,27 @@
-require "lucky_cli"
-require "teeplate"
 require "colorize"
 require "file_utils"
 
 class Lucky::ActionTemplate < Teeplate::FileTree
   @name : String
   @action : String
+  @inherit_from : String
 
   directory "#{__DIR__}/templates/action"
 
-  def initialize(@name, @action)
+  def initialize(@name, @action, @inherit_from)
   end
 end
 
-class Gen::Action < LuckyCli::Task
+class Gen::ActionGenerator < LuckyCli::Task
   banner "Generate a new action"
 
-  def call(io : IO = STDOUT)
+  def call
+
+  end
+
+  private def render_action_template(io, inherit_from : String)
     if valid?
-      Lucky::ActionTemplate.new(action_name, action).render(output_path)
+      Lucky::ActionTemplate.new(action_name, action, inherit_from).render(output_path)
       io.puts success_message
     else
       io.puts @error.colorize(:red)

--- a/tasks/gen/action_generator.cr
+++ b/tasks/gen/action_generator.cr
@@ -12,12 +12,7 @@ class Lucky::ActionTemplate < Teeplate::FileTree
   end
 end
 
-class Gen::ActionGenerator < LuckyCli::Task
-  banner "Generate a new action"
-
-  def call
-  end
-
+module Gen::ActionGenerator
   private def render_action_template(io, inherit_from : String)
     if valid?
       Lucky::ActionTemplate.new(action_name, action, inherit_from).render(output_path)

--- a/tasks/gen/action_generator.cr
+++ b/tasks/gen/action_generator.cr
@@ -16,7 +16,6 @@ class Gen::ActionGenerator < LuckyCli::Task
   banner "Generate a new action"
 
   def call
-
   end
 
   private def render_action_template(io, inherit_from : String)

--- a/tasks/gen/templates/action/{{action}}.cr.ecr
+++ b/tasks/gen/templates/action/{{action}}.cr.ecr
@@ -1,4 +1,4 @@
-class <%= @name %> < BrowserAction
+class <%= @name %> < <%= @inherit_from %>
   action do
     text "Render something in <%= @name %>"
   end

--- a/tasks/watch.cr
+++ b/tasks/watch.cr
@@ -16,13 +16,12 @@ module Sentry
     getter app_processes = [] of Process
     property successful_compilations
     property app_built
-    property? reload_browser
+    property? reload_browser : Bool = false
 
     @app_built : Bool = false
     @successful_compilations : Int32 = 0
 
     def initialize(build_commands : Array(String), run_commands : Array(String), files : Array(String))
-      parse_options
       @build_commands = build_commands
       @run_commands = run_commands
       @files = files
@@ -142,6 +141,8 @@ class Watch < LuckyCli::Task
   banner "Start and recompile project when files change"
 
   def call
+    parse_options
+
     build_commands = ["crystal build ./src/server.cr"]
     run_commands = ["./server"]
     files = ["./src/**/*.cr", "./src/**/*.ecr", "./config/**/*.cr", "./shard.lock"]


### PR DESCRIPTION
Closes #410.

With the new behavior you need to run `lucky gen.action.api` or `lucky gen.action.browser`.