### PR TITLE
Routable docs

### DIFF
--- a/src/lucky/routeable.cr
+++ b/src/lucky/routeable.cr
@@ -1,3 +1,4 @@
+# Methods for routing HTTP requests and their parameters to actions.
 module Lucky::Routeable
   {% for http_method in [:get, :put, :post, :delete] %}
     # Define a route that responds to a {{ http_method.id.upcase }} request

--- a/src/lucky/routeable.cr
+++ b/src/lucky/routeable.cr
@@ -1,5 +1,17 @@
 module Lucky::Routeable
   {% for http_method in [:get, :put, :post, :delete] %}
+    # Define a route that responds to a {{ http_method.id.upcase }} request
+    #
+    # Use these methods if you are not using a restful route or a custom path.
+    # For example:
+    # ```
+    # class Profile::ImageUpload
+    #   {{ http_method.id }} "/profile/image/:id" do
+    #     # action code here
+    #   end
+    # end
+    # ```
+    # will respond to an `HTTP {{ http_method.id.upcase }}` request.
     macro {{ http_method.id }}(path)
       add_route :{{ http_method.id }}, \{{ path }}, \{{ @type.name.id }}
 

--- a/src/lucky/routeable.cr
+++ b/src/lucky/routeable.cr
@@ -39,6 +39,21 @@ module Lucky::Routeable
     end
   end
 
+  # Define a nested route that responds to the appropriate HTTP request
+  # automatically
+  #
+  # This works similarly to `action` but it will provide multiple parameters.
+  # For example:
+  # ```
+  # class Posts::Comments::Show
+  #   nested_action do
+  #     render_text "Post: #{post_id}, Comment: #{id}"
+  #   end
+  # end
+  # ```
+  #
+  # **Note:** The `singular` option will likely be removed soon. Try `get`,
+  # `post`, `put`, and `delete` with a custom path instead.
   macro nested_action(singular = false)
     infer_nested_route(singular: {{ singular }})
 

--- a/src/lucky/routeable.cr
+++ b/src/lucky/routeable.cr
@@ -72,7 +72,17 @@ module Lucky::Routeable
 
   # Define a route that responds to the appropriate HTTP request automatically
   #
-  # A route needs a few pieces of information to be created:
+  # ```
+  # class Posts::Show
+  #   action do
+  #     render_text "Post: #{id}"
+  #   end
+  # end
+  # ```
+  #
+  # This action responds to the `/posts/:id` path.
+  #
+  # Each route needs a few pieces of information to be created:
   #
   # * The HTTP method, like `GET`, `POST`, `DELETE`, etc.
   # * The path, such as `/users/:id`
@@ -97,6 +107,10 @@ module Lucky::Routeable
   # ```text
   # Could not infer route for User::ImageUploads
   # ```
+  #
+  # **See also** our guides for more information and examples:
+  # * [Automatically Generate RESTful Routes](https://luckyframework.org/guides/actions-and-routing/#automatically-generate-restful-routes)
+  # * [Examples of automatically generated routes](https://luckyframework.org/guides/actions-and-routing/#examples-of-automatically-generated-routes)
   macro action(singular = false)
     infer_route(singular: {{ singular }})
 

--- a/src/lucky/routeable.cr
+++ b/src/lucky/routeable.cr
@@ -2,8 +2,9 @@ module Lucky::Routeable
   {% for http_method in [:get, :put, :post, :delete] %}
     # Define a route that responds to a {{ http_method.id.upcase }} request
     #
-    # Use these methods if you are not using a restful route or a custom path.
-    # For example:
+    # Use these methods if you need a custom path or are using a non-restful
+    # route. For example:
+    #
     # ```
     # class Profile::ImageUpload
     #   {{ http_method.id }} "/profile/image/:id" do

--- a/src/lucky/routeable.cr
+++ b/src/lucky/routeable.cr
@@ -192,6 +192,30 @@ module Lucky::Routeable
     \{% end %}
   end
 
+  # Access a query parameter
+  #
+  # This will allow any action to accept and access query parameters. By
+  # default query parameters are ignored, but adding a `param` will make them
+  # available:
+  # ```
+  # class Posts::Index < BrowserAction
+  #   param page : Int32 = 1
+  #
+  #   action do
+  #     render_text "Posts - Page #{page}"
+  #   end
+  # end
+  # ```
+  #
+  # Visiting `/posts?page=10` would render the following:
+  #
+  # ```text
+  # Posts - Page 10
+  # ```
+  #
+  # Additionally, these parameters are typed. The path `/posts?page=ten` will
+  # raise a `Lucky::Exceptions::InvalidParam` error because `ten` is a string
+  # not an Int32.
   macro param(type_declaration)
     {% PARAM_DECLARATIONS << type_declaration %}
 

--- a/src/lucky/routeable.cr
+++ b/src/lucky/routeable.cr
@@ -220,11 +220,10 @@ module Lucky::Routeable
     \{% end %}
   end
 
-  # Access a query parameter
+  # Access additional parameter
   #
-  # This will allow any action to accept and access query parameters. By
-  # default query parameters are ignored, but adding a `param` will make them
-  # available:
+  # When a query parameter or POST data is passed to an action, it is stored in the params object. But accessing it from the params object isn't type safe. Enter `param`. It checks the given param's type and makes it easily available inside the action.
+  #
   # ```
   # class Posts::Index < BrowserAction
   #   param page : Int32 = 1
@@ -235,15 +234,31 @@ module Lucky::Routeable
   # end
   # ```
   #
-  # Visiting `/posts?page=10` would render the following:
+  # Visiting `/posts?page=10` would render the above action like this:
   #
   # ```text
   # Posts - Page 10
   # ```
   #
-  # Additionally, these parameters are typed. The path `/posts?page=ten` will
-  # raise a `Lucky::Exceptions::InvalidParam` error because `ten` is a string
-  # not an Int32.
+  # This works behind the scenes by creating a `page` method in the action to access the parameter.
+  #
+  # These parameters are also typed. The path `/posts?page=ten` will raise a `Lucky::Exceptions::InvalidParam` error because `ten` is a String not an Int32.
+  #
+  # Additionally, if the param is non-optional it will raise the
+  # `Lucky::Exceptions::MissingParam` error.
+  #
+  # ```
+  # class UserConfirmations::New
+  #   param token : String # this param is required!
+  #
+  #   action do
+  #     # confirm the user with their `token`
+  #   end
+  # end
+  # ```
+  #
+  # When visiting this page, the path _must_ contain the token parameter:
+  # `/user_confirmations?token=abc123`
   macro param(type_declaration)
     {% PARAM_DECLARATIONS << type_declaration %}
 

--- a/src/lucky/routeable.cr
+++ b/src/lucky/routeable.cr
@@ -60,6 +60,8 @@ module Lucky::Routeable
   # end
   # ```
   #
+  # This action responds to the `/posts/:post_id/comments/:id` path.
+  #
   # **Note:** The `singular` option will likely be removed soon. Try `get`,
   # `post`, `put`, and `delete` with a custom path instead.
   macro nested_action(singular = false)

--- a/src/lucky/routeable.cr
+++ b/src/lucky/routeable.cr
@@ -33,6 +33,33 @@ module Lucky::Routeable
     setup_call_method({{ yield }})
   end
 
+  # Define a route that responds to the appropriate HTTP request automatically
+  #
+  # A route needs a few pieces of information to be created:
+  #
+  # * The HTTP method, like `GET`, `POST`, `DELETE`, etc.
+  # * The path, such as `/users/:id`
+  # * The class to route to, like `Users::Show`
+  #
+  # The `action` method will try to determine these pieces of information based
+  # the class name. After it knows the class, Lucky will transform the full
+  # class name to figure out the path, i.e. removing the `::` separators and
+  # adding underscores. The method is found via the last part of the class name:
+  #
+  # * `Index` -> `GET`
+  # * `Show` -> `GET`
+  # * `New` -> `GET`
+  # * `Create` -> `POST`
+  # * `Edit` -> `GET`
+  # * `Update` -> `PUT`
+  # * `Delete` -> `DELETE`
+  #
+  # If you are using a non-restful action name you should use the `get`, `put`,
+  # `post`, or `delete` methods. Otherwise you will see an error like this:
+  #
+  # ```text
+  # Could not infer route for User::ImageUploads
+  # ```
   macro action(singular = false)
     infer_route(singular: {{ singular }})
 

--- a/src/lucky/routeable.cr
+++ b/src/lucky/routeable.cr
@@ -14,6 +14,9 @@ module Lucky::Routeable
     # end
     # ```
     # will respond to an `HTTP {{ http_method.id.upcase }}` request.
+    #
+    # **See also** our guides for more information and examples:
+    # * [Routing](https://luckyframework.org/guides/actions-and-routing/#routing)
     macro {{ http_method.id }}(path)
       add_route :{{ http_method.id }}, \{{ path }}, \{{ @type.name.id }}
 

--- a/src/lucky/routeable.cr
+++ b/src/lucky/routeable.cr
@@ -220,32 +220,45 @@ module Lucky::Routeable
     \{% end %}
   end
 
-  # Access additional parameter
+  # Access query and POST parameters
   #
-  # When a query parameter or POST data is passed to an action, it is stored in the params object. But accessing it from the params object isn't type safe. Enter `param`. It checks the given param's type and makes it easily available inside the action.
+  # When a query parameter or POST data is passed to an action, it is stored in
+  # the params object. But accessing the param directly from the params object
+  # isn't type safe. Enter `param`. It checks the given param's type and makes
+  # it easily available inside the action.
   #
   # ```
   # class Posts::Index < BrowserAction
-  #   param page : Int32 = 1
+  #   param page : Int32?
   #
   #   action do
-  #     render_text "Posts - Page #{page}"
+  #     render_text "Posts - Page #{page || 1}"
   #   end
   # end
   # ```
   #
-  # Visiting `/posts?page=10` would render the above action like this:
+  # To generate a link with a param, use the `with` method:
+  # `Posts::Index.with(10).path` which will generate `/posts?page=10`. Visiting
+  # that path would render the above action like this:
   #
   # ```text
   # Posts - Page 10
   # ```
   #
-  # This works behind the scenes by creating a `page` method in the action to access the parameter.
+  # This works behind the scenes by creating a `page` method in the action to
+  # access the parameter.
   #
-  # These parameters are also typed. The path `/posts?page=ten` will raise a `Lucky::Exceptions::InvalidParam` error because `ten` is a String not an Int32.
+  # **Note:** Params can also have a default, but then their routes will not
+  # include the parameter in the query string. Using the `with(10)` method for a
+  # param like this:
+  # `param page : Int32 = 1` will only generate `/posts`.
+  #
+  # These parameters are also typed. The path `/posts?page=ten` will raise a
+  # `Lucky::Exceptions::InvalidParam` error because `ten` is a String not an
+  # Int32.
   #
   # Additionally, if the param is non-optional it will raise the
-  # `Lucky::Exceptions::MissingParam` error.
+  # `Lucky::Exceptions::MissingParam` error if the required param is absent:
   #
   # ```
   # class UserConfirmations::New

--- a/src/lucky/routeable.cr
+++ b/src/lucky/routeable.cr
@@ -13,6 +13,7 @@ module Lucky::Routeable
     #   end
     # end
     # ```
+    #
     # will respond to an `HTTP {{ http_method.id.upcase }}` request.
     #
     # **See also** our guides for more information and examples:
@@ -50,6 +51,7 @@ module Lucky::Routeable
   #
   # This works similarly to `action` but it will provide multiple parameters.
   # For example:
+  #
   # ```
   # class Posts::Comments::Show
   #   nested_action do

--- a/src/lucky/routeable.cr
+++ b/src/lucky/routeable.cr
@@ -19,6 +19,7 @@ module Lucky::Routeable
     end
   {% end %}
 
+  # :nodoc:
   macro setup_call_method(body)
     def call
       callback_result = run_before_callbacks
@@ -93,14 +94,17 @@ module Lucky::Routeable
     setup_call_method({{ yield }})
   end
 
+  # :nodoc:
   macro infer_nested_route(singular = false)
     infer_route(has_parent: true, singular: singular)
   end
 
+  # :nodoc:
   macro infer_route(has_parent = false, singular = false)
     {{ run "../run_macros/infer_route", @type.name, has_parent, singular }}
   end
 
+  # :nodoc:
   macro add_route(method, path, action)
     Lucky::Router.add({{ method }}, {{ path }}, {{ @type.name.id }})
 
@@ -184,6 +188,7 @@ module Lucky::Routeable
     end
   end
 
+  # :nodoc:
   macro inherit_param_declarations
     PARAM_DECLARATIONS = [] of Crystal::Macros::TypeDeclaration
 


### PR DESCRIPTION
I [added](https://github.com/luckyframework/lucky/commit/e8340019fa907abdeef9cdac88f097e835e55853) `:nodoc:` to a few methods that I think aren't intended to be accessed, but let me know if that's not true.

One of the methods was `add_route`. While I don't _think_ we expect people to use `add_route`, it does contain used methods like `with`, `path`, and `url`. I tried adding documentation directly to those methods but they wouldn't show up since they are generated. Maybe it doesn't matter? Maybe there's another spot for them? Maybe there's a way to add documentation without a method to attach to?

Suggestions on that and my copy welcome 😄 