### PR TITLE
Add /docs to the gitignore instead of /doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/doc/
+/docs/
 /libs/
 /lib/
 /bin/


### PR DESCRIPTION
My guess is this was added in error or perhaps crystal changed the
generated directory at some point. Either way, /docs is the directory
that is generated, not /doc.