### PR TITLE
Adds "Paths must start with a slash" error to route methods

### DIFF
--- a/src/lucky/routeable.cr
+++ b/src/lucky/routeable.cr
@@ -20,7 +20,7 @@ module Lucky::Routeable
     # * [Routing](https://luckyframework.org/guides/actions-and-routing/#routing)
     macro {{ http_method.id }}(path)
       \{% unless path.starts_with?("/") %}
-        \{% path.raise "Paths must start with a slash. For example, '" + path + "' is not a valid path, but '/" + path + "' is." %}
+        \{% path.raise "Path must start with a slash. For example: '/" + path + "'." %}
       \{% end %}
 
       add_route :{{ http_method.id }}, \{{ path }}, \{{ @type.name.id }}

--- a/src/lucky/routeable.cr
+++ b/src/lucky/routeable.cr
@@ -19,6 +19,10 @@ module Lucky::Routeable
     # **See also** our guides for more information and examples:
     # * [Routing](https://luckyframework.org/guides/actions-and-routing/#routing)
     macro {{ http_method.id }}(path)
+      \{% unless path.starts_with?("/") %}
+        \{% path.raise "Paths must start with a slash. For example, '" + path + "' is not a valid path, but '/" + path + "' is." %}
+      \{% end %}
+
       add_route :{{ http_method.id }}, \{{ path }}, \{{ @type.name.id }}
 
       setup_call_method(\{{ yield }})

--- a/src/lucky/routeable.cr
+++ b/src/lucky/routeable.cr
@@ -20,7 +20,7 @@ module Lucky::Routeable
     # * [Routing](https://luckyframework.org/guides/actions-and-routing/#routing)
     macro {{ http_method.id }}(path)
       \{% unless path.starts_with?("/") %}
-        \{% path.raise "Path must start with a slash. For example: '/" + path + "'." %}
+        \{% path.raise "Path must start with a slash. Example: '/" + path + "'" %}
       \{% end %}
 
       add_route :{{ http_method.id }}, \{{ path }}, \{{ @type.name.id }}


### PR DESCRIPTION
Resolves https://github.com/luckyframework/lucky/issues/444

This seems to work. I added a "For example" part to the message. Using string interpolation to put `path` in the error message kept putting escaped double-quotes `\"` into the resulting message, but for some reason concatenation with `+` did not, so I used that. I'm new to Crystal, so this may be some standard type of behavior I'm not aware of.

Thanks for your help!