### PR TITLE
Set up asset helpers to work with Laravel Mix/Webpack

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,3 +1,0 @@
-{
-  "images/logo.png": "images/logo-with-hash.png"
-}

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,0 +1,3 @@
+{
+  "/images/logo.png": "/images/logo-with-hash.png"
+}

--- a/spec/lucky/asset_helpers_spec.cr
+++ b/spec/lucky/asset_helpers_spec.cr
@@ -54,7 +54,7 @@ describe Lucky::AssetHelpers do
     end
 
     it "raises a helpful error" do
-      expect_raises Exception, "Missing asset: woops!.png" do
+      expect_raises Exception, "Missing asset: /woops!.png" do
         TestPage.new.missing_dynamic_asset_path
       end
     end

--- a/src/lucky/asset_helpers.cr
+++ b/src/lucky/asset_helpers.cr
@@ -5,8 +5,9 @@ module Lucky::AssetHelpers
 
   macro asset(path)
     {% if path.is_a?(StringLiteral) %}
+      {% path = "/" + path %}
       {% if Lucky::AssetHelpers::ASSET_MANIFEST[path] %}
-        {{ "/" + Lucky::AssetHelpers::ASSET_MANIFEST[path] }}
+        {{ Lucky::AssetHelpers::ASSET_MANIFEST[path] }}
       {% else %}
         {{ run "../run_macros/missing_asset", path }}
       {% end %}
@@ -35,9 +36,10 @@ module Lucky::AssetHelpers
   end
 
   def dynamic_asset(path)
+    path = "/#{path}"
     fingerprinted_path = Lucky::AssetHelpers::ASSET_MANIFEST[path]?
     if fingerprinted_path
-      "/" + fingerprinted_path
+      fingerprinted_path
     else
       raise "Missing asset: #{path}"
     end

--- a/src/run_macros/generate_asset_helpers.cr
+++ b/src/run_macros/generate_asset_helpers.cr
@@ -2,7 +2,7 @@ require "json"
 require "colorize"
 
 class AssetManifestBuilder
-  MANIFEST_PATH = File.expand_path("./public/manifest.json")
+  MANIFEST_PATH = File.expand_path("./public/mix-manifest.json")
   MAX_RETRIES   =   20
   RETRY_AFTER   = 0.25
 


### PR DESCRIPTION
* Remove extra slash since Laravel Mix manifest already has it
* Change manifest.json to match the Laravel Mix location

Note that this will break brunch compatibility, but that is fine. Either
stay on an older version of Lucky or upgrade to Mix. It should be really
straightforward. I'll make the conversion and document it in an upgrade
guide.
