### PR TITLE
Make the 500 page return a 500 in production. fixes #457

### DIFF
--- a/spec/lucky/error_handling_spec.cr
+++ b/spec/lucky/error_handling_spec.cr
@@ -14,7 +14,7 @@ private class FakeErrorAction < Lucky::ErrorAction
   end
 
   def handle_error(error : Exception)
-    head status: 500
+    text "Oops"
   end
 end
 
@@ -42,7 +42,7 @@ describe Lucky::ErrorHandler do
 
     context = error_handler.call(build_context).as(HTTP::Server::Context)
 
-    context.response.headers["Content-Type"].should eq("")
+    context.response.headers["Content-Type"].should eq("text/plain")
     context.response.status_code.should eq(500)
   end
 

--- a/src/lucky/error_handler.cr
+++ b/src/lucky/error_handler.cr
@@ -30,6 +30,7 @@ class Lucky::ErrorHandler
   end
 
   private def call_error_action(context : HTTP::Server::Context, error : Exception) : HTTP::Server::Context
+    context.response.status_code = 500
     action.new(context).perform_action(error)
     context
   end


### PR DESCRIPTION
Ensure the 500 page rendered in production also returns a 500 status code. It already returns a 500 status in development with specs around it. I wasn't sure how to add a spec for this. I don't think it's a huge deal, but if you want a spec, I can try and figure that out.