### PR TITLE
Remove incorrect error message

### DIFF
--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -90,19 +90,6 @@ module Lucky::Renderable
     response.print
   end
 
-  private def handle_response(_response : T) forall T
-    {%
-      raise <<-ERROR
-
-      #{@type} returned #{T}, but it must return a Lucky::Response.
-
-      Try this...
-        ▸ Make sure to use a method like `render`, `redirect`, or `json` at the end of your action.
-        ▸ If you are using a conditional, make sure all branches return a Lucky::Response.
-      ERROR
-    %}
-  end
-
   private def log_response(response : Lucky::Response)
     response.debug_message.try do |message|
       context.add_debug_message(message)


### PR DESCRIPTION
Closes #437

It seems this may be an issue in Crystal, but I need more time to track
it down. For now, I'm going to remove this special error-handling and
add it back later. That's better than giving people incorrect
instructions. Note that a compile-time error will still be raised, it
will just be a generic Crystal error.