### PR TITLE
Add Redirectable docs

### DIFF
--- a/src/lucky/redirectable.cr
+++ b/src/lucky/redirectable.cr
@@ -1,9 +1,10 @@
-# Redirect the browser
+# Redirect the request
 #
 # There are multiple ways to redirect inside of an action. The most common ways are to redirect to a `Lucky::Action` class, or a URL/path `String`. Both use the `redirect` method:
 #
 # ```crystal
 # redirect to: Users::Index
+# redirect to: Users::Show.with(user.id)
 # redirect to: "https://luckyframework.org/"
 # redirect to: "/users"
 # ```
@@ -11,26 +12,44 @@
 # By default, the method will set the status code to `302` A.K.A. "Found". If you want to customize the status code, you can pass it directly:
 #
 # ```crystal
-# # create a user
-# redirect to: Users::Index, status: 201
+# redirect to: Users::Index, status: 301
 #
 # # or use the built in enum value
-# redirect to: Users::Index, status: Status::Created
+# redirect to: Users::Index, status: Status::MovedPermanently
 # ```
 #
-# Internally, all the different methods in this module eventually use the method that takes a `String`. However, it's recommended you pass a `Lucky::Action` class if possible because it guarentees runtime safety.
+# You can find a list of all of the possible statuses [here](https://github.com/luckyframework/lucky/blob/master/src/lucky/action.cr).
+#
+# Internally, all the different methods in this module eventually use the
+# method that takes a `String`. However, it's recommended you pass a
+# `Lucky::Action` class if possible because it guarantees runtime safety.
 module Lucky::Redirectable
   # Redirect using a `Lucky::RouteHelper`
+  #
+  # ```crystal
+  # route = Lucky::RouteHelper.new(method: :get, path: "/users/1")
+  # redirect to: route, status: 301
+  # ```
   def redirect(to route : Lucky::RouteHelper, status = 302)
     redirect to: route.path, status: status
   end
 
-  # Redirect using a `Lucky::Action`
+  # Redirect to a `Lucky::Action`
+  #
+  # ```crystal
+  # redirect to: Users::Index
+  # redirect to: Users::Show.with(user.id), status: 301
+  # ```
   def redirect(to action : Lucky::Action.class, status = 302)
     redirect to: action.route, status: status
   end
 
   # Redirect using a `String`
+  #
+  # ```crystal
+  # redirect to: "/users"
+  # redirect to: "/users/1", status: 301
+  # ```
   def redirect(to path : String, status = 302)
     context.response.headers.add "Location", path
     context.response.headers.add "Turbolinks-Location", path
@@ -39,6 +58,10 @@ module Lucky::Redirectable
   end
 
   # Redirect using a `String` and a `Status` value
+  #
+  # ```crystal
+  # redirect to: "/users", status: Status::MovedPermanently
+  # ```
   def redirect(to path : String, status : Lucky::Action::Status = Lucky::Action::Status::Found)
     redirect(path, status.value)
   end

--- a/src/lucky/redirectable.cr
+++ b/src/lucky/redirectable.cr
@@ -27,8 +27,7 @@ module Lucky::Redirectable
   # Redirect using a `Lucky::RouteHelper`
   #
   # ```crystal
-  # route = Lucky::RouteHelper.new(method: :get, path: "/users/1")
-  # redirect to: route, status: 301
+  # redirect to: Users::Show.with(user.id), status: 301
   # ```
   def redirect(to route : Lucky::RouteHelper, status = 302)
     redirect to: route.path, status: status
@@ -38,7 +37,6 @@ module Lucky::Redirectable
   #
   # ```crystal
   # redirect to: Users::Index
-  # redirect to: Users::Show.with(user.id), status: 301
   # ```
   def redirect(to action : Lucky::Action.class, status = 302)
     redirect to: action.route, status: status

--- a/src/lucky/redirectable.cr
+++ b/src/lucky/redirectable.cr
@@ -62,6 +62,7 @@ module Lucky::Redirectable
   # ```crystal
   # redirect to: "/users", status: Status::MovedPermanently
   # ```
+  # You can find a list of all of the possible statuses [here](https://github.com/luckyframework/lucky/blob/master/src/lucky/action.cr).
   def redirect(to path : String, status : Lucky::Action::Status = Lucky::Action::Status::Found)
     redirect(path, status.value)
   end

--- a/src/lucky/redirectable.cr
+++ b/src/lucky/redirectable.cr
@@ -1,12 +1,36 @@
+# Redirect the browser
+#
+# There are multiple ways to redirect inside of an action. The most common ways are to redirect to a `Lucky::Action` class, or a URL/path `String`. Both use the `redirect` method:
+#
+# ```crystal
+# redirect to: Users::Index
+# redirect to: "https://luckyframework.org/"
+# redirect to: "/users"
+# ```
+#
+# By default, the method will set the status code to `302` A.K.A. "Found". If you want to customize the status code, you can pass it directly:
+#
+# ```crystal
+# # create a user
+# redirect to: Users::Index, status: 201
+#
+# # or use the built in enum value
+# redirect to: Users::Index, status: Status::Created
+# ```
+#
+# Internally, all the different methods in this module eventually use the method that takes a `String`. However, it's recommended you pass a `Lucky::Action` class if possible because it guarentees runtime safety.
 module Lucky::Redirectable
+  # Redirect using a `Lucky::RouteHelper`
   def redirect(to route : Lucky::RouteHelper, status = 302)
     redirect to: route.path, status: status
   end
 
+  # Redirect using a `Lucky::Action`
   def redirect(to action : Lucky::Action.class, status = 302)
     redirect to: action.route, status: status
   end
 
+  # Redirect using a `String`
   def redirect(to path : String, status = 302)
     context.response.headers.add "Location", path
     context.response.headers.add "Turbolinks-Location", path
@@ -14,6 +38,7 @@ module Lucky::Redirectable
     Lucky::Response.new(context, "", "")
   end
 
+  # Redirect using a `String` and a `Status` value
   def redirect(to path : String, status : Lucky::Action::Status = Lucky::Action::Status::Found)
     redirect(path, status.value)
   end


### PR DESCRIPTION
To the user, this will likely feel like the same method, so that's the way I documented it. Instead of documenting each method, I just put some module docs up top to explain how all the different type
signatures work.

Let me know if you'd like me to document the individual methods more. I thought about marking them as `:nodoc:` but there seemed to be _some_ value in showing the type signatures.