### PR TITLE
Make missing asset message more robust

### DIFF
--- a/spec/lucky/asset_helpers_spec.cr
+++ b/spec/lucky/asset_helpers_spec.cr
@@ -62,7 +62,7 @@ describe Lucky::AssetHelpers do
     end
 
     it "raises a helpful error" do
-      expect_raises Exception, "Missing asset: /woops!.png" do
+      expect_raises Exception, "Missing asset: woops!.png" do
         TestPage.new.missing_dynamic_asset_path
       end
     end

--- a/src/lucky/asset_helpers.cr
+++ b/src/lucky/asset_helpers.cr
@@ -5,12 +5,11 @@ module Lucky::AssetHelpers
 
   macro asset(path)
     {% if path.is_a?(StringLiteral) %}
-      {% path = "/" + path %}
       {% if Lucky::AssetHelpers::ASSET_MANIFEST[path] %}
         {{ Lucky::AssetHelpers::ASSET_MANIFEST[path] }}
       {% else %}
-        {% p Lucky::AssetHelpers::ASSET_MANIFEST %}
-        {{ run "../run_macros/missing_asset", path }}
+        {% asset_paths = Lucky::AssetHelpers::ASSET_MANIFEST.keys.join(",") %}
+        {{ run "../run_macros/missing_asset", path, asset_paths }}
       {% end %}
     {% elsif path.is_a?(StringInterpolation) %}
       {% raise <<-ERROR
@@ -37,7 +36,6 @@ module Lucky::AssetHelpers
   end
 
   def dynamic_asset(path)
-    path = "/#{path}"
     fingerprinted_path = Lucky::AssetHelpers::ASSET_MANIFEST[path]?
     if fingerprinted_path
       fingerprinted_path

--- a/src/run_macros/generate_asset_helpers.cr
+++ b/src/run_macros/generate_asset_helpers.cr
@@ -36,7 +36,7 @@ class AssetManifestBuilder
     manifest = JSON.parse(manifest_file)
 
     manifest.each do |key, value|
-      key = key.as_s.gsub(/^\/assets/, "")
+      key = key.as_s.gsub(/^\//, "").gsub(/^assets\//, "")
       puts %({% ASSET_MANIFEST["#{key}"] = "#{value.as_s}" %})
     end
   end

--- a/src/run_macros/missing_asset.cr
+++ b/src/run_macros/missing_asset.cr
@@ -3,16 +3,14 @@ require "json"
 require "levenshtein"
 
 missing_asset = ARGV.first
-manifest_path = File.expand_path("./public/mix-manifest.json")
-manifest_file = File.read(manifest_path)
-manifest = JSON.parse(manifest_file)
+asset_paths = ARGV[1].split(",")
 
-best_match = Levenshtein::Finder.find missing_asset, manifest.map(&.to_s), tolerance: 4
+best_match = Levenshtein::Finder.find missing_asset, asset_paths, tolerance: 4
 
 puts %("#{missing_asset}" does not exist in the manifest.).colorize(:red)
 
 if best_match
-  puts %(Did you mean "#{best_match}"?).colorize(:yellow)
+  puts %(Did you mean "#{best_match}"?).colorize(:yellow).bold
 else
   puts "Make sure the asset exists and you have compiled your assets.".colorize(:red)
   puts "If you recently added a static asset or font try stopping the server (ctrl-c) and starting it again (lucky dev).".colorize(:red)


### PR DESCRIPTION
Use the paths generated by the asset path helper so that error messages
are always correct.