### PR TITLE
Add custom config to log handler output. fixes #480

### DIFF
--- a/spec/lucky/log_handler_spec.cr
+++ b/spec/lucky/log_handler_spec.cr
@@ -54,11 +54,7 @@ describe Lucky::LogHandler do
 
   context "when configured to log timestamps" do
     it "logs timestamp" do
-      begin
-        Lucky::LogHandler.configure do
-          settings.show_timestamps = true
-        end
-
+      Lucky::LogHandler.temp_config(show_timestamps: true) do
         io = IO::Memory.new
         called = false
         log_io = IO::Memory.new
@@ -70,21 +66,13 @@ describe Lucky::LogHandler do
         log_output.should contain("GET")
         log_output.should match(/#{Time.now.to_s("%Y-%m-%d")}/)
         called.should be_true
-      ensure
-        Lucky::LogHandler.configure do
-          settings.show_timestamps = false
-        end
       end
     end
   end
 
   context "when configured to be disabled" do
     it "logs timestamp" do
-      begin
-        Lucky::LogHandler.configure do
-          settings.enabled = false
-        end
-
+      Lucky::LogHandler.temp_config(enabled: false) do
         io = IO::Memory.new
         called = false
         log_io = IO::Memory.new
@@ -95,10 +83,6 @@ describe Lucky::LogHandler do
         log_output = log_io.to_s
         log_output.should eq ""
         called.should be_true
-      ensure
-        Lucky::LogHandler.configure do
-          settings.enabled = true
-        end
       end
     end
   end
@@ -121,11 +105,7 @@ describe Lucky::LogHandler do
 
   context "when configured with custom log formatter" do
     it "logs emoji" do
-      begin
-        Lucky::LogHandler.configure do
-          settings.log_formatter = EmojiLogFormatter.new
-        end
-
+      Lucky::LogHandler.temp_config(log_formatter: EmojiLogFormatter.new) do
         called = false
         log_io = IO::Memory.new
         context = build_context("PATCH")
@@ -135,10 +115,6 @@ describe Lucky::LogHandler do
         log_output = log_io.to_s.chomp
         log_output.should eq "🐵 PATCH - BOOM"
         called.should be_true
-      ensure
-        Lucky::LogHandler.configure do
-          settings.log_formatter = DefaultLogFormatter.new
-        end
       end
     end
   end

--- a/spec/lucky/log_handler_spec.cr
+++ b/spec/lucky/log_handler_spec.cr
@@ -3,6 +3,12 @@ require "http/server"
 
 include ContextHelper
 
+class EmojiLogFormatter < Lucky::LogFormatters::Base
+  def format(context, time, elapsed) : String
+    "🐵 #{context.request.method} - BOOM"
+  end 
+end
+
 describe Lucky::LogHandler do
   it "logs" do
     io = IO::Memory.new
@@ -91,7 +97,7 @@ describe Lucky::LogHandler do
         called.should be_true
       ensure
         Lucky::LogHandler.configure do
-          settings.show_timestamps = false
+          settings.enabled = true
         end
       end
     end
@@ -110,6 +116,30 @@ describe Lucky::LogHandler do
       log_output = log_io.to_s
       log_output.should eq("")
       called.should be_true
+    end
+  end
+
+  context "when configured with custom log formatter" do
+    it "logs emoji" do
+      begin
+        Lucky::LogHandler.configure do
+          settings.log_formatter = EmojiLogFormatter.new
+        end
+
+        called = false
+        log_io = IO::Memory.new
+        context = build_context("PATCH")
+
+        call_log_handler_with(log_io, context) { called = true }
+
+        log_output = log_io.to_s.chomp
+        log_output.should eq "🐵 PATCH - BOOM"
+        called.should be_true
+      ensure
+        Lucky::LogHandler.configure do
+          settings.log_formatter = DefaultLogFormatter.new
+        end
+      end
     end
   end
 end

--- a/spec/lucky/log_handler_spec.cr
+++ b/spec/lucky/log_handler_spec.cr
@@ -3,10 +3,10 @@ require "http/server"
 
 include ContextHelper
 
-class EmojiLogFormatter < Lucky::LogFormatters::Base
+private class EmojiLogFormatter < Lucky::LogFormatters::Base
   def format(context, time, elapsed) : String
     "🐵 #{context.request.method} - BOOM"
-  end 
+  end
 end
 
 describe Lucky::LogHandler do

--- a/src/lucky/log_formatters/base.cr
+++ b/src/lucky/log_formatters/base.cr
@@ -1,0 +1,37 @@
+abstract class Lucky::LogFormatters::Base
+  abstract def format(context, time, elapsed) : String
+  
+  private def colored_status_code(status_code)
+    case status_code
+    when 200..399
+      "#{status_code.colorize(:green)}"
+    when 400..499
+      "#{status_code.colorize(:yellow)}"
+    when 500..599
+      "#{status_code.colorize(:red)}"
+    else
+      "#{status_code}"
+    end
+  end
+  
+  private def timestamp(time)
+    if Lucky::LogHandler.settings.show_timestamps
+      " #{Time::Format::ISO_8601_DATE_TIME.format(time || Time.now)}"
+    else
+      ""
+    end
+  end
+  
+  private def elapsed_text(elapsed)
+    minutes = elapsed.total_minutes
+    return "#{minutes.round(2)}m" if minutes >= 1
+
+    seconds = elapsed.total_seconds
+    return "#{seconds.round(2)}s" if seconds >= 1
+
+    millis = elapsed.total_milliseconds
+    return "#{millis.round(2)}ms" if millis >= 1
+
+    "#{(millis * 1000).round(2)}µs"
+  end
+end

--- a/src/lucky/log_formatters/base.cr
+++ b/src/lucky/log_formatters/base.cr
@@ -1,6 +1,6 @@
 abstract class Lucky::LogFormatters::Base
   abstract def format(context, time, elapsed) : String
-  
+
   private def colored_status_code(status_code)
     case status_code
     when 200..399
@@ -13,7 +13,7 @@ abstract class Lucky::LogFormatters::Base
       "#{status_code}"
     end
   end
-  
+
   private def timestamp(time)
     if Lucky::LogHandler.settings.show_timestamps
       " #{Time::Format::ISO_8601_DATE_TIME.format(time || Time.now)}"
@@ -21,7 +21,7 @@ abstract class Lucky::LogFormatters::Base
       ""
     end
   end
-  
+
   private def elapsed_text(elapsed)
     minutes = elapsed.total_minutes
     return "#{minutes.round(2)}m" if minutes >= 1

--- a/src/lucky/log_formatters/base.cr
+++ b/src/lucky/log_formatters/base.cr
@@ -15,11 +15,7 @@ abstract class Lucky::LogFormatters::Base
   end
 
   private def timestamp(time)
-    if Lucky::LogHandler.settings.show_timestamps
-      " #{Time::Format::ISO_8601_DATE_TIME.format(time || Time.now)}"
-    else
-      ""
-    end
+    Lucky::LogHandler.timestamp(time)
   end
 
   private def elapsed_text(elapsed)

--- a/src/lucky/log_formatters/default_log_formatter.cr
+++ b/src/lucky/log_formatters/default_log_formatter.cr
@@ -1,0 +1,6 @@
+class DefaultLogFormatter < Lucky::LogFormatters::Base
+  
+  def format(context, time, elapsed) : String
+    "#{context.request.method} #{colored_status_code(context.response.status_code)} #{context.request.resource}#{timestamp(time)} (#{elapsed_text(elapsed)})"
+  end
+end

--- a/src/lucky/log_formatters/default_log_formatter.cr
+++ b/src/lucky/log_formatters/default_log_formatter.cr
@@ -1,5 +1,4 @@
 class DefaultLogFormatter < Lucky::LogFormatters::Base
-  
   def format(context, time, elapsed) : String
     "#{context.request.method} #{colored_status_code(context.response.status_code)} #{context.request.resource}#{timestamp(time)} (#{elapsed_text(elapsed)})"
   end

--- a/src/lucky/log_handler.cr
+++ b/src/lucky/log_handler.cr
@@ -6,7 +6,7 @@ class Lucky::LogHandler
 
   Habitat.create do
     setting show_timestamps : Bool
-    setting log_formatter : LogFormatters::Base = DefaultLogFormatter.new 
+    setting log_formatter : LogFormatters::Base = DefaultLogFormatter.new
     setting enabled : Bool = true
   end
 

--- a/src/lucky/log_handler.cr
+++ b/src/lucky/log_handler.cr
@@ -1,14 +1,12 @@
 require "colorize"
+require "./log_formatters/**"
 
 class Lucky::LogHandler
   include HTTP::Handler
-  alias LogProc = ::Proc(Lucky::LogHandler, HTTP::Server::Context, Time, Time::Span, String)
 
   Habitat.create do
     setting show_timestamps : Bool
-    setting request_formatter : LogProc = ->(handler : Lucky::LogHandler, context : HTTP::Server::Context, time : Time, elapsed : Time::Span) {
-      "#{context.request.method} #{handler.colored_status_code(context.response.status_code)} #{context.request.resource}#{handler.timestamp(time)} (#{handler.elapsed_text(elapsed)})"
-    }
+    setting log_formatter : LogFormatters::Base = DefaultLogFormatter.new 
     setting enabled : Bool = true
   end
 
@@ -36,25 +34,12 @@ class Lucky::LogHandler
   end
 
   private def log_request(context, time, elapsed)
-    @io.puts settings.request_formatter.call(self, context, time, elapsed)
+    @io.puts settings.log_formatter.format(context, time, elapsed)
   end
 
   private def log_exception(context, time, e)
     @io.puts "#{context.request.method} #{context.request.resource}#{timestamp(time)} - Unhandled exception:"
     e.inspect_with_backtrace(@io)
-  end
-
-  def colored_status_code(status_code)
-    case status_code
-    when 200..399
-      "#{status_code.colorize(:green)}"
-    when 400..499
-      "#{status_code.colorize(:yellow)}"
-    when 500..599
-      "#{status_code.colorize(:red)}"
-    else
-      "#{status_code}"
-    end
   end
 
   private def log_debug_messages(context)
@@ -63,20 +48,7 @@ class Lucky::LogHandler
     end
   end
 
-  def elapsed_text(elapsed)
-    minutes = elapsed.total_minutes
-    return "#{minutes.round(2)}m" if minutes >= 1
-
-    seconds = elapsed.total_seconds
-    return "#{seconds.round(2)}s" if seconds >= 1
-
-    millis = elapsed.total_milliseconds
-    return "#{millis.round(2)}ms" if millis >= 1
-
-    "#{(millis * 1000).round(2)}µs"
-  end
-
-  def timestamp(time)
+  private def timestamp(time)
     if settings.show_timestamps
       " #{Time::Format::ISO_8601_DATE_TIME.format(time || Time.now)}"
     else

--- a/src/lucky/log_handler.cr
+++ b/src/lucky/log_handler.cr
@@ -38,7 +38,7 @@ class Lucky::LogHandler
   end
 
   private def log_exception(context, time, e)
-    @io.puts "#{context.request.method} #{context.request.resource}#{timestamp(time)} - Unhandled exception:"
+    @io.puts "#{context.request.method} #{context.request.resource}#{LogHandler.timestamp(time)} - Unhandled exception:"
     e.inspect_with_backtrace(@io)
   end
 
@@ -48,7 +48,7 @@ class Lucky::LogHandler
     end
   end
 
-  private def timestamp(time)
+  def self.timestamp(time)
     if settings.show_timestamps
       " #{Time::Format::ISO_8601_DATE_TIME.format(time || Time.now)}"
     else


### PR DESCRIPTION
This first commit actually tanks crystal:

```
[15:04PM] lucky (features/custom_log_message)$ crystal spec/lucky/log_handler_spec.cr
Module validation failed: !dbg attachment points at wrong subprogram for function
!12 = distinct !DISubprogram(name: "request_formatter?", linkageName: "request_formatter?", scope: !5, file: !5, line: 7, type: !6, isLocal: true, isDefinition: true, scopeLine: 7, isOptimized: false, unit: !0, variables: !2)
%"->" ()* @"*Lucky::LogHandler::Settings::request_formatter?:(Proc(Lucky::LogHandler, HTTP::Server::Context, Time, Time::Span, String) | Nil)"
  %0 = call %"->"* @"~Lucky::LogHandler::Settings::request_formatter:read"(), !dbg !13
!13 = !DILocation(line: 7, column: 3, scope: !14)
!14 = distinct !DISubprogram(name: "show_timestamps", linkageName: "show_timestamps", scope: !5, file: !5, line: 7, type: !6, isLocal: true, isDefinition: true, scopeLine: 7, isOptimized: false, unit: !0, variables: !2)
!14 = distinct !DISubprogram(name: "show_timestamps", linkageName: "show_timestamps", scope: !5, file: !5, line: 7, type: !6, isLocal: true, isDefinition: true, scopeLine: 7, isOptimized: false, unit: !0, variables: !2)
 (Exception)
  from Crystal::CodeGenVisitor#finish:Nil
  from Crystal::Compiler#codegen<Crystal::Program, Crystal::ASTNode+, Array(Crystal::Compiler::Source), String>:(Tuple(Array(Crystal::Compiler::CompilationUnit), Array(String)) | Nil)
  from Crystal::Compiler#compile<Array(Crystal::Compiler::Source), String>:Crystal::Compiler::Result
  from Crystal::Command#run_command<Bool>:Nil
  from Crystal::Command#run:(Bool | Crystal::Compiler::Result | Nil)
  from main
Error: you've found a bug in the Crystal compiler. Please open an issue, including source code that will allow us to reproduce the bug: https://github.com/crystal-lang/crystal/issues
```

Until that is solved, let me know your thoughts on implementation. To keep the current format the same, we would need to pass the log handler instance in, and make those helper methods public. Maybe those methods need to be moved out to a module? 

EDIT: running `crystal spec/ --no-debug` all specs pass.  