### PR TITLE
adding in helper to catch plain text content types

### DIFF
--- a/spec/lucky/content_type_helper_spec.cr
+++ b/spec/lucky/content_type_helper_spec.cr
@@ -64,10 +64,6 @@ describe Lucky::ContentTypeHelpers do
     set_content_type "text/plain; charset=UTF8" do
       FakeAction.new.plain?.should be_true
     end
-
-    set_content_type "plain/text" do
-      FakeAction.new.plain?.should be_false
-    end
   end
 end
 

--- a/spec/lucky/content_type_helper_spec.cr
+++ b/spec/lucky/content_type_helper_spec.cr
@@ -61,6 +61,10 @@ describe Lucky::ContentTypeHelpers do
       FakeAction.new.plain?.should be_true
     end
 
+    set_content_type "text/plain; charset=UTF8" do
+      FakeAction.new.plain?.should be_true
+    end
+
     set_content_type "plain/text" do
       FakeAction.new.plain?.should be_false
     end

--- a/spec/lucky/content_type_helper_spec.cr
+++ b/spec/lucky/content_type_helper_spec.cr
@@ -55,6 +55,16 @@ describe Lucky::ContentTypeHelpers do
       FakeAction.new.xml?.should be_false
     end
   end
+
+  it "works for plain text" do
+    set_content_type "text/plain" do
+      FakeAction.new.plain?.should be_true
+    end
+
+    set_content_type "plain/text" do
+      FakeAction.new.plain?.should be_false
+    end
+  end
 end
 
 private def set_content_type(content_type)

--- a/src/lucky/content_type_helpers.cr
+++ b/src/lucky/content_type_helpers.cr
@@ -35,9 +35,10 @@ module Lucky::ContentTypeHelpers
 
   # Check if the request is plain text
   #
-  # This tests if the Content-Type header is `plain/text`
+  # This tests if the Content-Type header is `text/plain` or
+  # with the optional character set per W3 RFC1341 7.1
   def plain?
-    content_type == "text/plain"
+    content_type == "text/plain" || content_type.downcase.starts_with?("text/plain; charset=")
   end
 
   private def content_type : String

--- a/src/lucky/content_type_helpers.cr
+++ b/src/lucky/content_type_helpers.cr
@@ -33,6 +33,13 @@ module Lucky::ContentTypeHelpers
     ["application/xml", "application/xhtml+xml"].includes? content_type
   end
 
+  # Check if the request is plain text
+  #
+  # This tests if the Content-Type header is `plain/text`
+  def plain?
+    content_type == "text/plain"
+  end
+
   private def content_type : String
     headers["Content-Type"]? || ""
   end


### PR DESCRIPTION
For being able to do 

```crystal
if plain?
  render_some_text
else
  render(SomeHTMLPage)
end
```

EDIT: per [this](https://www.w3.org/Protocols/rfc1341/7_1_Text.html) adding in the charset as an optional parameter, I updated to allow `text/plain; charset=WHATEVER`