### PR TITLE
Add HTTP Methods PATCH and TRACE

### DIFF
--- a/spec/lucky/action_spec.cr
+++ b/spec/lucky/action_spec.cr
@@ -20,6 +20,18 @@ class CustomRoutes::Post < Lucky::Action
   end
 end
 
+class CustomRoutes::Patch < Lucky::Action
+  patch "/so_custom" do
+    text "test"
+  end
+end
+
+class CustomRoutes::Trace < Lucky::Action
+  trace "/so_custom" do
+    text "test"
+  end
+end
+
 class CustomRoutes::Delete < Lucky::Action
   delete "/so_custom" do
     text "test"
@@ -170,6 +182,8 @@ describe Lucky::Action do
       assert_route_added? Lucky::Route.new :get, "/so_custom", CustomRoutes::Index
       assert_route_added? Lucky::Route.new :put, "/so_custom", CustomRoutes::Put
       assert_route_added? Lucky::Route.new :post, "/so_custom", CustomRoutes::Post
+      assert_route_added? Lucky::Route.new :patch, "/so_custom", CustomRoutes::Patch
+      assert_route_added? Lucky::Route.new :trace, "/so_custom", CustomRoutes::Trace
       assert_route_added? Lucky::Route.new :delete, "/so_custom", CustomRoutes::Delete
     end
   end

--- a/src/lucky/routeable.cr
+++ b/src/lucky/routeable.cr
@@ -1,6 +1,6 @@
 # Methods for routing HTTP requests and their parameters to actions.
 module Lucky::Routeable
-  {% for http_method in [:get, :put, :post, :delete] %}
+  {% for http_method in [:get, :put, :post, :patch, :trace, :delete] %}
     # Define a route that responds to a {{ http_method.id.upcase }} request
     #
     # Use these methods if you need a custom path or are using a non-restful


### PR DESCRIPTION
In `Routable` actions, you can now use the `patch` and `trace` methods to create routes that match those HTTP verbs.