### PR TITLE
Fix Missing hash key error when accessing nested_key on json params

### DIFF
--- a/spec/lucky/params_spec.cr
+++ b/spec/lucky/params_spec.cr
@@ -142,6 +142,16 @@ describe Lucky::Params do
       params.nested?(:user).should eq({"name" => "Paul", "age" => "28"})
     end
 
+    it "gets empty JSON params when nested key is missing" do
+      request = build_request body: "{}",
+        content_type: "application/json"
+      request.query = "from=query"
+
+      params = Lucky::Params.new(request)
+
+      params.nested?(:user).should eq({} of String => JSON::Any)
+    end
+
     it "gets nested JSON params mixed with query params" do
       request = build_request body: {user: {name: "Bunyan", age: 102}}.to_json,
         content_type: "application/json"

--- a/src/lucky/params.cr
+++ b/src/lucky/params.cr
@@ -145,8 +145,9 @@ class Lucky::Params
 
   private def nested_json_params(nested_key : String) : Hash(String, String)
     nested_params = {} of String => String
+    nested_key_json = parsed_json.as_h[nested_key]? || JSON.parse("{}")
 
-    parsed_json.as_h[nested_key].as_h.each do |key, value|
+    nested_key_json.as_h.each do |key, value|
       nested_params[key.to_s] = value.to_s
     end
 


### PR DESCRIPTION
Hello just encountered a bug when getting a hash value by key, when accessing the hash from the parsed json:

`Missing hash key`
