### PR TITLE
Small refactor to allow/support >1 response types

### DIFF
--- a/spec/lucky/text_response_spec.cr
+++ b/spec/lucky/text_response_spec.cr
@@ -2,12 +2,12 @@ require "../spec_helper"
 
 include ContextHelper
 
-describe Lucky::Response do
+describe Lucky::TextResponse do
   describe "#print" do
     it "uses the default status if none is set" do
       context = build_context
       print_response(context, status: nil)
-      context.response.status_code.should eq Lucky::Response::DEFAULT_STATUS
+      context.response.status_code.should eq Lucky::TextResponse::DEFAULT_STATUS
     end
 
     it "uses the passed in status" do
@@ -16,7 +16,7 @@ describe Lucky::Response do
       context.response.status_code.should eq 300
     end
 
-    it "uses the response status if it's set, and Lucky::Response status is nil" do
+    it "uses the response status if it's set, and Lucky::TextResponse status is nil" do
       context = build_context
       context.response.status_code = 300
       print_response(context, status: nil)
@@ -26,5 +26,5 @@ describe Lucky::Response do
 end
 
 private def print_response(context : HTTP::Server::Context, status : Int32?)
-  Lucky::Response.new(context, "", "", status: status).print
+  Lucky::TextResponse.new(context, "", "", status: status).print
 end

--- a/src/lucky/redirectable.cr
+++ b/src/lucky/redirectable.cr
@@ -52,7 +52,7 @@ module Lucky::Redirectable
     context.response.headers.add "Location", path
     context.response.headers.add "Turbolinks-Location", path
     context.response.status_code = status
-    Lucky::Response.new(context, "", "")
+    Lucky::TextResponse.new(context, "", "")
   end
 
   # Redirect using a `String` and a `Status` value

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -67,7 +67,7 @@ module Lucky::Renderable
       {% end %}
     )
     body = view.perform_render.to_s
-    Lucky::Response.new(
+    Lucky::TextResponse.new(
       context,
       "text/html",
       body,
@@ -97,11 +97,11 @@ module Lucky::Renderable
   end
 
   private def text(body, status : Int32? = nil)
-    Lucky::Response.new(context, "text/plain", body, status: status)
+    Lucky::TextResponse.new(context, "text/plain", body, status: status)
   end
 
   private def text(body, status : Lucky::Action::Status)
-    Lucky::Response.new(context, "text/plain", body, status: status.value)
+    Lucky::TextResponse.new(context, "text/plain", body, status: status.value)
   end
 
   private def render_text(*args, **named_args)
@@ -109,7 +109,7 @@ module Lucky::Renderable
   end
 
   private def head(status : Int32)
-    Lucky::Response.new(context, content_type: "", body: "", status: status)
+    Lucky::TextResponse.new(context, content_type: "", body: "", status: status)
   end
 
   private def head(status : Lucky::Action::Status)
@@ -117,7 +117,7 @@ module Lucky::Renderable
   end
 
   private def json(body, status : Int32? = nil)
-    Lucky::Response.new(context, "application/json", body.to_json, status)
+    Lucky::TextResponse.new(context, "application/json", body.to_json, status)
   end
 
   private def json(body, status : Lucky::Action::Status = nil)

--- a/src/lucky/response.cr
+++ b/src/lucky/response.cr
@@ -1,22 +1,3 @@
-class Lucky::Response
-  DEFAULT_STATUS = 200
-
-  getter context, content_type, body, debug_message
-
-  def initialize(@context : HTTP::Server::Context,
-                 @content_type : String,
-                 @body : String,
-                 @status : Int32? = nil,
-                 @debug_message : String? = nil)
-  end
-
-  def print
-    context.response.content_type = content_type
-    context.response.status_code = status
-    context.response.print body
-  end
-
-  def status
-    @status || context.response.status_code || DEFAULT_STATUS
-  end
+abstract class Lucky::Response
+  abstract def print
 end

--- a/src/lucky/text_response.cr
+++ b/src/lucky/text_response.cr
@@ -1,0 +1,22 @@
+class Lucky::TextResponse < Lucky::Response
+  DEFAULT_STATUS = 200
+
+  getter context, content_type, body, debug_message
+
+  def initialize(@context : HTTP::Server::Context,
+                 @content_type : String,
+                 @body : String,
+                 @status : Int32? = nil,
+                 @debug_message : String? = nil)
+  end
+
+  def print
+    context.response.content_type = content_type
+    context.response.status_code = status
+    context.response.print body
+  end
+
+  def status
+    @status || context.response.status_code || DEFAULT_STATUS
+  end
+end


### PR DESCRIPTION
Currently there is only one `response` type in the framework -
`Lucky::Response`. This is all well and fine if we're only ever
returning text-based responses.

BUT - when someone wants to do something like return binary data, or
websockets, or ... some other fancy response? I guess? ... we'd have to
do a lot of jumping through hoops to get that ONE response class to fit
into those use cases.

After some discussion, the framework might be best served by having a
single interface type (or abstract class) - like the existing
`Lucky::Response` - that defines the interface that will need to be
implemented by other response classes.

This way we can still expect that abstract class in our type signatures,
but extend and expand on our response objects.

This paves the way for something like `Lucky::CustomResponse` or
`Lucky::FileResponse` types.