### PR TITLE
Test against crystal nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: crystal
+crystal:
+  - latest
+  - nightly
 install:
   - shards install
+matrix:
+  allow_failures:
+    - crystal: nightly
 script:
   - crystal spec
   - crystal tool format spec src --check

--- a/spec/lucky/file_response_spec.cr
+++ b/spec/lucky/file_response_spec.cr
@@ -94,13 +94,12 @@ private def print_file_response(context : HTTP::Server::Context,
                                 disposition : String = "attachment",
                                 filename : String? = nil,
                                 status : Int32? = nil)
-
   response = Lucky::FileResponse.new(context,
-                                     fixture_file(file),
-                                     content_type,
-                                     disposition: disposition,
-                                     filename: filename,
-                                     status: status)
+    fixture_file(file),
+    content_type,
+    disposition: disposition,
+    filename: filename,
+    status: status)
   response.print
 end
 


### PR DESCRIPTION
This is a follow up and closes #591

Now lucky will be tested against nightly crystal build so we can try to catch bugs before crystal release. It's an allowed failure, so won't break the build, but will be a flag for us.

In this PR there's a (small) formatting of `spec/lucky/file_response_spec.cr` so format check pass in the build, and the travis will be green again.

Split in two commits because are 2 small modifications and overkill to open 2 PRs 😉 
