### PR TITLE
Add Lucky::Request class from lucky_cli's AppRequest

### DIFF
--- a/spec/lucky/request_spec.cr
+++ b/spec/lucky/request_spec.cr
@@ -16,7 +16,7 @@ describe Lucky::Request do
     it "authenticates users with authorization token" do
       test_user = TestUser.new
       request = Lucky::Request.new
-  
+
       request.get("/", as: test_user)
       request.headers["Authorization"].should eq test_user.generate_token
     end
@@ -25,7 +25,7 @@ describe Lucky::Request do
   describe "#post" do
     it "parses body into query params" do
       request = Lucky::Request.new
-      request.post("/", { "first" => "value", "second" => "value"})
+      request.post("/", {"first" => "value", "second" => "value"})
       request.query_params.should eq "first=value&second=value"
     end
   end
@@ -33,7 +33,7 @@ describe Lucky::Request do
   describe "#put" do
     it "parses body into query params" do
       request = Lucky::Request.new
-      request.put("/", { "first" => "value", "second" => "value"})
+      request.put("/", {"first" => "value", "second" => "value"})
       request.query_params.should eq "first=value&second=value"
     end
   end

--- a/spec/lucky/request_spec.cr
+++ b/spec/lucky/request_spec.cr
@@ -1,0 +1,46 @@
+require "../../spec_helper"
+
+describe Lucky::Request do
+  describe "#get" do
+    it "sends requests to correct uri" do
+      path = "/any_path"
+      uri = Lucky::RouteHelper.settings.base_uri + path
+      request = Lucky::Request.new
+
+      request.get(path)
+      request.url.should eq uri
+    end
+  end
+
+  describe "authenticates" do
+    it "authenticates users with authorization token" do
+      test_user = TestUser.new
+      request = Lucky::Request.new
+  
+      request.get("/", as: test_user)
+      request.headers["Authorization"].should eq test_user.generate_token
+    end
+  end
+
+  describe "#post" do
+    it "parses body into query params" do
+      request = Lucky::Request.new
+      request.post("/", { "first" => "value", "second" => "value"})
+      request.query_params.should eq "first=value&second=value"
+    end
+  end
+
+  describe "#put" do
+    it "parses body into query params" do
+      request = Lucky::Request.new
+      request.put("/", { "first" => "value", "second" => "value"})
+      request.query_params.should eq "first=value&second=value"
+    end
+  end
+end
+
+class TestUser
+  def generate_token
+    "test_token"
+  end
+end

--- a/src/lucky/request.cr
+++ b/src/lucky/request.cr
@@ -1,0 +1,79 @@
+require "http/client"
+
+class Lucky::Request
+  getter! response
+  @response : HTTP::Client::Response? = nil
+
+  def get(path : String, as user : Authentic::PasswordAuthenticatable? = nil, headers : HTTP::Headers? = nil)
+    if user
+      headers ||= HTTP::Headers.new
+      headers.add "Authorization", user.generate_token
+    end
+
+    request("GET", path, nil, headers)
+  end
+
+  def put(path : String, body : Hash(String, String), as user : Authentic::PasswordAuthenticatable? = nil, headers : HTTP::Headers? = nil)
+    if user
+      headers ||= HTTP::Headers.new
+      headers.add "Authorization", user.generate_token
+    end
+
+    request("PUT", path, body, headers)
+  end
+
+  def post(path : String, body : Hash(String, String), as user : Authentic::PasswordAuthenticatable? = nil, headers : HTTP::Headers? = nil)
+    if user
+      headers ||= HTTP::Headers.new
+      headers.add "Authorization", user.generate_token
+    end
+
+    request("POST", path, body, headers)
+  end
+
+  def delete(path : String, as user : Authentic::PasswordAuthenticatable? = nil, headers : HTTP::Headers? = nil)
+    if user
+      headers ||= HTTP::Headers.new
+      headers.add "Authorization", user.generate_token
+    end
+
+    request("DELETE", path, nil, headers)
+  end
+
+  def response
+    @response.not_nil!
+  end
+
+  def response_body
+    if response.success?
+      response.body
+    else
+      raise Exception.new(response.body)
+    end
+  end
+
+  def response_json
+    JSON.parse(response_body)
+  end
+
+  private def request(method : String, path : String, body : Hash(String, String)? = nil, headers : HTTP::Headers? = nil)
+    url = Lucky::RouteHelper.settings.base_uri + path
+    body = body ? hash_to_params(body) : nil
+
+    @response = HTTP::Client.exec(method, url: url, body: body, headers: headers)
+  end
+
+  private def hash_to_params(body : Hash(String, String))
+    body_strings = [] of String
+    body.each do |key, value|
+      body_strings << "#{URI.escape(key)}=#{URI.escape(value)}"
+    end
+    body_strings.join("&")
+  end
+
+  private def hash_to_headers(hash : Hash(String, String))
+    headers = HTTP::Headers.new
+    hash.keys.map { |key| headers.add key, hash[key] }
+    headers
+  end
+end

--- a/src/lucky/request.cr
+++ b/src/lucky/request.cr
@@ -12,39 +12,19 @@ class Lucky::Request
   @response : HTTP::Client::Response? = nil
 
   def get(path : String, as user = nil, headers : HTTP::Headers? = nil)
-    if user
-      headers ||= HTTP::Headers.new
-      headers.add "Authorization", user.generate_token
-    end
-
-    request("GET", path, nil, headers)
+    request("GET", path, nil, headers, as: user)
   end
 
   def put(path : String, body : Hash(String, String), as user = nil, headers : HTTP::Headers? = nil)
-    if user
-      headers ||= HTTP::Headers.new
-      headers.add "Authorization", user.generate_token
-    end
-
-    request("PUT", path, body, headers)
+    request("PUT", path, body, headers, as: user)
   end
 
   def post(path : String, body : Hash(String, String), as user = nil, headers : HTTP::Headers? = nil)
-    if user
-      headers ||= HTTP::Headers.new
-      headers.add "Authorization", user.generate_token
-    end
-
-    request("POST", path, body, headers)
+    request("POST", path, body, headers, as: user)
   end
 
   def delete(path : String, as user = nil, headers : HTTP::Headers? = nil)
-    if user
-      headers ||= HTTP::Headers.new
-      headers.add "Authorization", user.generate_token
-    end
-
-    request("DELETE", path, nil, headers)
+    request("DELETE", path, nil, headers, as: user)
   end
 
   def response
@@ -63,7 +43,12 @@ class Lucky::Request
     JSON.parse(response_body)
   end
 
-  private def request(method : String, path : String, body : Hash(String, String)? = nil, headers : HTTP::Headers? = nil)
+  private def request(method : String, path : String, body : Hash(String, String)? = nil, headers : HTTP::Headers? = nil, as user = nil)
+    if user
+      headers ||= HTTP::Headers.new
+      headers.add "Authorization", user.generate_token
+    end
+
     @url = Lucky::RouteHelper.settings.base_uri + path
     @headers = headers
     @query_params = body ? hash_to_params(body) : nil

--- a/src/lucky/request.cr
+++ b/src/lucky/request.cr
@@ -1,10 +1,17 @@
 require "http/client"
 
 class Lucky::Request
+  getter! url
+  getter! headers
+  getter! query_params
   getter! response
+
+  @url : String? = nil
+  @headers : HTTP::Headers? = nil
+  @query_params : String? = nil
   @response : HTTP::Client::Response? = nil
 
-  def get(path : String, as user : Authentic::PasswordAuthenticatable? = nil, headers : HTTP::Headers? = nil)
+  def get(path : String, as user = nil, headers : HTTP::Headers? = nil)
     if user
       headers ||= HTTP::Headers.new
       headers.add "Authorization", user.generate_token
@@ -13,7 +20,7 @@ class Lucky::Request
     request("GET", path, nil, headers)
   end
 
-  def put(path : String, body : Hash(String, String), as user : Authentic::PasswordAuthenticatable? = nil, headers : HTTP::Headers? = nil)
+  def put(path : String, body : Hash(String, String), as user = nil, headers : HTTP::Headers? = nil)
     if user
       headers ||= HTTP::Headers.new
       headers.add "Authorization", user.generate_token
@@ -22,7 +29,7 @@ class Lucky::Request
     request("PUT", path, body, headers)
   end
 
-  def post(path : String, body : Hash(String, String), as user : Authentic::PasswordAuthenticatable? = nil, headers : HTTP::Headers? = nil)
+  def post(path : String, body : Hash(String, String), as user = nil, headers : HTTP::Headers? = nil)
     if user
       headers ||= HTTP::Headers.new
       headers.add "Authorization", user.generate_token
@@ -31,7 +38,7 @@ class Lucky::Request
     request("POST", path, body, headers)
   end
 
-  def delete(path : String, as user : Authentic::PasswordAuthenticatable? = nil, headers : HTTP::Headers? = nil)
+  def delete(path : String, as user = nil, headers : HTTP::Headers? = nil)
     if user
       headers ||= HTTP::Headers.new
       headers.add "Authorization", user.generate_token
@@ -57,10 +64,11 @@ class Lucky::Request
   end
 
   private def request(method : String, path : String, body : Hash(String, String)? = nil, headers : HTTP::Headers? = nil)
-    url = Lucky::RouteHelper.settings.base_uri + path
-    body = body ? hash_to_params(body) : nil
+    @url = Lucky::RouteHelper.settings.base_uri + path
+    @headers = headers
+    @query_params = body ? hash_to_params(body) : nil
 
-    @response = HTTP::Client.exec(method, url: url, body: body, headers: headers)
+    @response = HTTP::Client.exec(method, url: url, body: @query_params, headers: headers)
   end
 
   private def hash_to_params(body : Hash(String, String))


### PR DESCRIPTION
Closes #557 

This PR moves the AppRequest class over to Lucky as Lucky::Request and adds specs. A couple notable differences:

- Added url, headers and query_params getters to keep track of request state for specs.
```crystal
  @url : String? = nil
  @headers : HTTP::Headers? = nil
  @query_params : String? = nil
```
- Removed user type on `as user` param. (used to be `Authentic::PasswordAuthenticatable` but it is still expected that the user has a `generate_token` method.