### PR TITLE
fixing css_link method. Fixes: #614

### DIFF
--- a/spec/lucky/custom_tags_spec.cr
+++ b/spec/lucky/custom_tags_spec.cr
@@ -36,6 +36,10 @@ describe Lucky::CustomTags do
       end.to_s.should contain %(<foo-tag class="my-class">content</foo-tag>)
     end
   end
+
+  it "has a method for empty tags" do
+    view.empty_tag("br").to_s.should eq "<br>"
+  end
 end
 
 private def view

--- a/spec/lucky/specialty_tags_spec.cr
+++ b/spec/lucky/specialty_tags_spec.cr
@@ -15,11 +15,11 @@ describe Lucky::SpecialtyTags do
   end
 
   it "renders css link tag" do
-    view.css_link("app.css").to_s.should contain <<-HTML
+    view.css_link("app.css").to_s.should eq <<-HTML
     <link href="app.css" rel="stylesheet" media="screen">
     HTML
 
-    view.css_link("app.css", rel: "preload", media: "print").to_s.should contain <<-HTML
+    view.css_link("app.css", rel: "preload", media: "print").to_s.should eq <<-HTML
     <link href="app.css" rel="preload" media="print">
     HTML
   end

--- a/src/lucky/tags/custom_tags.cr
+++ b/src/lucky/tags/custom_tags.cr
@@ -32,4 +32,10 @@ module Lucky::CustomTags
     yield
     @view << "</#{name}>"
   end
+
+  def inline_tag(name : String, options = EMPTY_HTML_ATTRS, **other_options)
+    merged_options = merge_options(other_options, options)
+    tag_attrs = build_tag_attrs(merged_options)
+    @view << "<#{name}" << tag_attrs << ">"
+  end
 end

--- a/src/lucky/tags/custom_tags.cr
+++ b/src/lucky/tags/custom_tags.cr
@@ -33,7 +33,9 @@ module Lucky::CustomTags
     @view << "</#{name}>"
   end
 
-  def inline_tag(name : String, options = EMPTY_HTML_ATTRS, **other_options)
+  # Outputs a custom tag with no tag closing.
+  # `empty_tag("br")` => `<br>`
+  def empty_tag(name : String, options = EMPTY_HTML_ATTRS, **other_options)
     merged_options = merge_options(other_options, options)
     tag_attrs = build_tag_attrs(merged_options)
     @view << "<#{name}" << tag_attrs << ">"

--- a/src/lucky/tags/specialty_tags.cr
+++ b/src/lucky/tags/specialty_tags.cr
@@ -5,7 +5,7 @@ module Lucky::SpecialtyTags
 
   def css_link(href, **options)
     options = {href: href, rel: "stylesheet", media: "screen"}.merge(options)
-    inline_tag "link", **options
+    empty_tag "link", **options
   end
 
   def js_link(src, **options)

--- a/src/lucky/tags/specialty_tags.cr
+++ b/src/lucky/tags/specialty_tags.cr
@@ -5,7 +5,7 @@ module Lucky::SpecialtyTags
 
   def css_link(href, **options)
     options = {href: href, rel: "stylesheet", media: "screen"}.merge(options)
-    tag "link", **options
+    inline_tag "link", **options
   end
 
   def js_link(src, **options)


### PR DESCRIPTION
The current implementation causes the `link` tag to output a closing `</link>` tag. I've added a new tag helper method called `inline_tag` which doesn't need to take a block or call yield. Just pass in options like you normally would.