### PR TITLE
allowing the AllowedInTags to be used as attribute values. fixes #483

### DIFF
--- a/spec/lucky/input_helpers_spec.cr
+++ b/spec/lucky/input_helpers_spec.cr
@@ -185,6 +185,10 @@ describe Lucky::InputHelpers do
     view.search_input(form.first_name, class: "cool").to_s.should contain <<-HTML
     <input type="search" id="user_first_name" name="user:first_name" value="My name" class="cool">
     HTML
+
+    view.search_input(form.first_name, autofocus: true).to_s.should contain <<-HTML
+    <input type="search" id="user_first_name" name="user:first_name" value="My name" autofocus="true">
+    HTML
   end
 
   it "renders password inputs" do
@@ -214,6 +218,10 @@ describe Lucky::InputHelpers do
 
     view.textarea(form.first_name, class: "cool").to_s.should contain <<-HTML
     <textarea id="user_first_name" name="user:first_name" class="cool">My name</textarea>
+    HTML
+
+    view.textarea(form.first_name, rows: 5, cols: 15).to_s.should contain <<-HTML
+    <textarea id="user_first_name" name="user:first_name" rows="5" cols="15">My name</textarea>
     HTML
   end
 end

--- a/spec/lucky/link_helpers_spec.cr
+++ b/spec/lucky/link_helpers_spec.cr
@@ -98,6 +98,16 @@ describe Lucky::LinkHelpers do
     <a href="/link_helpers"></a>
     HTML
   end
+
+  it "renders a link with a special data attribute" do
+    view.link(to: LinkHelpers::Index, "data-is-useless": true).to_s.should contain <<-HTML
+    <a href="/link_helpers" data-is-useless="true"></a>
+    HTML
+
+    view.link(to: LinkHelpers::Index, "data-num": 4).to_s.should contain <<-HTML
+    <a href="/link_helpers" data-num="4"></a>
+    HTML
+  end
 end
 
 private def view

--- a/src/charms/bool_extensions.cr
+++ b/src/charms/bool_extensions.cr
@@ -2,5 +2,4 @@ require "../lucky/allowed_in_tags"
 
 struct Bool
   include ::Lucky::AllowedInTags
-
 end

--- a/src/charms/bool_extensions.cr
+++ b/src/charms/bool_extensions.cr
@@ -1,0 +1,6 @@
+require "../lucky/allowed_in_tags"
+
+struct Bool
+  include ::Lucky::AllowedInTags
+
+end

--- a/src/lucky/tags/base_tags.cr
+++ b/src/lucky/tags/base_tags.cr
@@ -84,7 +84,7 @@ module Lucky::BaseTags
     tag_attrs = String.build do |attrs|
       options.each do |key, value|
         attrs << " " << LuckyInflector::Inflector.dasherize(key.to_s) << "=\""
-        attrs << HTML.escape(value)
+        attrs << HTML.escape(value.to_s)
         attrs << "\""
       end
     end
@@ -99,14 +99,14 @@ module Lucky::BaseTags
   end
 
   private def merge_options(html_options, tag_attrs)
-    options = {} of String => String
+    options = {} of String => String | Lucky::AllowedInTags
     tag_attrs.each do |key, value|
       options[key.to_s] = value
     end
 
     html_options.each do |key, value|
       next if key == :boolean_attrs
-      options[key.to_s] = value.as(String)
+      options[key.to_s] = value
     end
 
     options


### PR DESCRIPTION
This gives developers the ability to use more than just strings for values when using form helper methods.

Before this:
```crystal
textarea(form.first_name, rows: "5", cols: "15")
```

After this:
```crystal
textarea(form.first_name, rows: 5, cols: 15)
```

I've also added a new extension for `Bool` which also allows for things like

```crystal
password_input(form.password, required: true)
```

This is my initial shot at #483, but let me know if you see anything. 

On a side note, running specs now sort of looks weird.

```text
[18:44PM] lucky (features/allowed_in_tags)$ crystal spec/
555
........Created CreateContactInfos::V20181004184518 in ./db/migrations/20181004184518_create_contact_infos.cr
......Created CreateUsers::V20181004184518 in ./db/migrations/20181004184518_create_users.cr
..........  ▸ Building binary with 'crystal build --release src/server.cr
  ▸ Build succeeded - binary saved at './server'
.  ▸ Building binary with 'crystal build --release src/server.cr
Error in src/server.cr:1: this build will fail

{{ raise "this build will fail" }}
^

.....................................................................................................................................................................................................................................................................................

Finished in 1.92 seconds
302 examples, 0 failures, 0 errors, 0 pending
```

Even though they still pass, seeing all of that output sort of makes me nervous. 