### PR TITLE
Adds some extra specs. fixes #601

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -43,7 +43,7 @@ dependencies:
     branch: master
   lucky_router:
     github: luckyframework/lucky_router
-    version: ~> 0.2.0
+    branch: master
   shell-table:
     github: luckyframework/shell-table.cr
     branch: refactor/setter

--- a/spec/lucky/router_spec.cr
+++ b/spec/lucky/router_spec.cr
@@ -8,4 +8,11 @@ describe Lucky::Router do
     Lucky::Router.find_action("get", "/test").should_not be_nil
     Lucky::Router.find_action(:post, "/test").should be_nil
   end
+
+  it "finds the associated get route by a head method" do
+    Lucky::Router.add :get, "/test", Lucky::Action
+
+    Lucky::Router.find_action(:head, "/test").should_not be_nil
+    Lucky::Router.find_action("head", "/test").should_not be_nil
+  end
 end

--- a/spec/lucky/text_response_spec.cr
+++ b/spec/lucky/text_response_spec.cr
@@ -22,9 +22,22 @@ describe Lucky::TextResponse do
       print_response(context, status: nil)
       context.response.status_code.should eq 300
     end
+
+    it "prints no body with a head call" do
+      context = build_context("HEAD")
+      print_response_with_body(context, "Body", "text/plain", nil)
+      context.request.method.should eq "HEAD"
+      context.request.body.to_s.should eq ""
+      context.response.status_code.should eq 200
+      context.response.headers["Content-Type"].should eq "text/plain"
+    end
   end
 end
 
 private def print_response(context : HTTP::Server::Context, status : Int32?)
-  Lucky::TextResponse.new(context, "", "", status: status).print
+  print_response_with_body(context, "", "", status)
+end
+
+private def print_response_with_body(context : HTTP::Server::Context, body : String = "", content_type : String = "", status : Int32? = nil)
+  Lucky::TextResponse.new(context, content_type, body, status: status).print
 end

--- a/spec/lucky/text_response_spec.cr
+++ b/spec/lucky/text_response_spec.cr
@@ -25,19 +25,18 @@ describe Lucky::TextResponse do
 
     it "prints no body with a head call" do
       context = build_context("HEAD")
-      print_response_with_body(context, "Body", "text/plain", nil)
+      print_response_with_body(context, "Body", status: nil)
       context.request.method.should eq "HEAD"
       context.request.body.to_s.should eq ""
       context.response.status_code.should eq 200
-      context.response.headers["Content-Type"].should eq "text/plain"
     end
   end
 end
 
 private def print_response(context : HTTP::Server::Context, status : Int32?)
-  print_response_with_body(context, "", "", status)
+  print_response_with_body(context, "", status)
 end
 
-private def print_response_with_body(context : HTTP::Server::Context, body : String = "", content_type : String = "", status : Int32? = nil)
-  Lucky::TextResponse.new(context, content_type, body, status: status).print
+private def print_response_with_body(context : HTTP::Server::Context, body : String, status : Int32?)
+  Lucky::TextResponse.new(context, "", body, status: status).print
 end


### PR DESCRIPTION
Adds specs to confirm that using a HEAD request on a GET route works with latest LuckyRouter update. 

These specs will fail until [LuckyRouter](https://github.com/luckyframework/lucky_router/commit/9a8b31872a44429a921280da91acf2604a33dc3a) is updated to a new version, and this repo pulls in that new update.