### PR TITLE
Fixes boolean attrs with block elements. fixes #634

### DIFF
--- a/spec/lucky/base_tags_spec.cr
+++ b/spec/lucky/base_tags_spec.cr
@@ -30,10 +30,12 @@ describe Lucky::BaseTags do
 
   it "renders nested video with source tags and proper attributes" do
     view do
-      video(autoplay: "autoplay", loop: "loop", poster: "https://luckyframework.org/nothing.png") do
+      video(attrs: [:autoplay, :controls, :loop], poster: "https://luckyframework.org/nothing.png") do
         source(src: "https://luckyframework.org/nothing.mp4", type: "video/mp4")
       end
-    end.to_s.should contain %{<video autoplay="autoplay" loop="loop" poster="https://luckyframework.org/nothing.png"><source src="https://luckyframework.org/nothing.mp4" type="video/mp4"></video>}
+    end.to_s.should contain %{<video poster="https://luckyframework.org/nothing.png" autoplay controls loop><source src="https://luckyframework.org/nothing.mp4" type="video/mp4"></video>}
+
+    view.video(id: "player", "data-stream": "https://luckyframework.org/demo.mp4").to_s.should eq %{<video id="player" data-stream="https://luckyframework.org/demo.mp4"></video>}
   end
 
   it "renders a button with a disabled boolean attribute" do

--- a/src/lucky/tags/base_tags.cr
+++ b/src/lucky/tags/base_tags.cr
@@ -11,9 +11,8 @@ module Lucky::BaseTags
         attrs : Array(Symbol) = [] of Symbol,
         **other_options
       )
-      bool_attrs = build_boolean_attrs(attrs)
       merged_options = merge_options(other_options, options)
-      {{method_name.id}}(bool_attrs, merged_options) do
+      {{method_name.id}}(attrs, merged_options) do
         text content
       end
     end
@@ -38,7 +37,8 @@ module Lucky::BaseTags
       @view << "</{{tag.id}}>"
     end
 
-    def {{method_name.id}}(boolean_attrs : String, options = EMPTY_HTML_ATTRS, **other_options, &block)
+    def {{method_name.id}}(attrs : Array(Symbol), options = EMPTY_HTML_ATTRS, **other_options, &block)
+      boolean_attrs = build_boolean_attrs(attrs)
       merged_options = merge_options(other_options, options)
       tag_attrs = build_tag_attrs(merged_options)
       @view << "<{{tag.id}}" << tag_attrs << boolean_attrs << ">"


### PR DESCRIPTION
fixing call to boolean attrs when the element uses a block format like video

Fixes: #634 