### PR TITLE
Change the generated time's time zone to utc

### DIFF
--- a/spec/lucky/session_handler_spec.cr
+++ b/spec/lucky/session_handler_spec.cr
@@ -93,7 +93,7 @@ describe Lucky::SessionHandler do
       .cookies
       .set(:yo, "lo")
       .path("/awesome")
-      .expires(Time.new(2000, 1, 1))
+      .expires(Time.utc(2000, 1, 1))
       .domain("luckyframework.org")
       .secure(true)
       .http_only(true)


### PR DESCRIPTION
If I run the test for the proper headers when a cookie is set in the
time zone `UTC +0200`, the expected `expires` value is different for me:
```
Expected:   "path=/awesome; expires=Fri, 31 Dec 1999 23:00:00 GMT;"
       to include: "expires=Sat, 01 Jan 2000"
```
(I removed output from the test failure to keep the line length below
80).

If we change it to use a specific time zone (utc) it should work
regardless of where the tests are run.
`Time.utc(2000, 1, 1)`