### PR TITLE
adding a flash clear method to match the current session and cookie api

### DIFF
--- a/spec/lucky/cookies/flash_store_spec.cr
+++ b/spec/lucky/cookies/flash_store_spec.cr
@@ -112,6 +112,18 @@ describe Lucky::FlashStore do
       flash_store.to_json.should eq(next_hash.to_json)
     end
   end
+
+  describe "#clear" do
+    it "clears out all flash messages" do
+      now_hash = {not: :present}
+      next_hash = {name: "Paul"}
+      flash_store = build_flash_store(now: now_hash, next: next_hash)
+
+      flash_store.get(:name).should eq "Paul"
+      flash_store.clear
+      flash_store.get?(:name).should eq nil
+    end
+  end
 end
 
 private def build_flash_store(

--- a/src/lucky/cookies/flash_store.cr
+++ b/src/lucky/cookies/flash_store.cr
@@ -44,6 +44,11 @@ class Lucky::FlashStore
     @next.to_json
   end
 
+  def clear : Void
+    @now.clear
+    @next.clear
+  end
+
   def set(key : Key, value : String) : String
     @next[key.to_s] = value
   end


### PR DESCRIPTION
This just adds a `clear` method to flash to keep a consistent API between session, cookie, and flash. All 3 have a `get`, `set`, and now `clear` method. This could be used to clear your flash out in the case of using a front-end like Varnish and your flash messages becoming stuck. 