### PR TITLE
Remove StaticFileHandler#mime_type method

### DIFF
--- a/src/charms/static_file_handler.cr
+++ b/src/charms/static_file_handler.cr
@@ -9,20 +9,4 @@ class Lucky::StaticFileHandler < HTTP::StaticFileHandler
     context.hide_from_logs = settings.hide_from_logs
     super(context)
   end
-
-  private def mime_type(path)
-    case File.extname(path)
-    when ".txt"          then "text/plain"
-    when ".htm", ".html" then "text/html"
-    when ".css"          then "text/css"
-    when ".js"           then "application/javascript"
-    when ".svg"          then "image/svg+xml"
-    when ".svgz"         then "image/svg+xml"
-    when ".eot"          then "application/vnd.ms-fontobject"
-    when ".ttf"          then "font/ttf"
-    when ".woff"         then "font/woff"
-    when ".woff2"        then "font/woff2"
-    else                      "application/octet-stream"
-    end
-  end
 end


### PR DESCRIPTION
Since Crystal 0.27.1 there's built-in MIME registry which's used instead of this helper method making it obsolete.