### PR TITLE
Revamp logger

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.27.0
+FROM crystallang/crystal:0.27.2
 
 RUN apt-get update && \
   apt-get install -y libgconf-2-4 build-essential curl libreadline-dev libevent-dev libssl-dev libxml2-dev libyaml-dev libgmp-dev git  && \

--- a/shard.yml
+++ b/shard.yml
@@ -34,7 +34,7 @@ dependencies:
     branch: master
   habitat:
     github: luckyframework/habitat
-    version: ~> 0.4.0
+    version: ~> 0.4
   wordsmith:
     github: luckyframework/wordsmith
     version: ~> 0.2
@@ -57,6 +57,9 @@ dependencies:
 development_dependencies:
   ameba:
     github: veelenga/ameba
+  mocks:
+    github: waterlink/mocks.cr
+    version: ~> 0.9
 
 scripts:
   postinstall: shards build

--- a/spec/lucky/json_log_formatter_spec.cr
+++ b/spec/lucky/json_log_formatter_spec.cr
@@ -1,0 +1,26 @@
+require "../spec_helper"
+
+describe Lucky::JsonLogFormatter do
+  it "formats the data as JSON" do
+    data = {
+      my_data: "is great!",
+    }
+    io = IO::Memory.new
+
+    Lucky::JsonLogFormatter.new.format(
+      severity: Logger::Severity::INFO,
+      timestamp: timestamp,
+      progname: "",
+      data: data,
+      io: io
+    )
+
+    io.to_s.chomp.should eq(
+      {severity: "INFO", timestamp: timestamp, my_data: "is great!"}.to_json
+    )
+  end
+end
+
+private def timestamp
+  Time.utc(2016, 2, 15)
+end

--- a/spec/lucky/log_handler_spec.cr
+++ b/spec/lucky/log_handler_spec.cr
@@ -3,96 +3,36 @@ require "http/server"
 
 include ContextHelper
 
-private class EmojiLogFormatter < Lucky::LogFormatters::Base
-  def format(context, time, elapsed) : String
-    "🐵 #{context.request.method} - BOOM"
-  end
-end
-
 describe Lucky::LogHandler do
-  it "logs" do
-    io = IO::Memory.new
+  it "logs the start and end of the request" do
     called = false
     log_io = IO::Memory.new
-    context = build_context_with_io(io)
+    context = build_context_with_io(log_io)
 
     call_log_handler_with(log_io, context) { called = true }
 
     log_output = log_io.to_s
-    log_output.should contain("GET")
-    log_output.should contain("200")
-    log_output.should contain("/")
-    log_output.should_not match(/#{Time.now.to_s("%Y-%m-%d")}/)
+    log_output.should contain("GET #{"/".colorize.underline}")
+    log_output.should contain("Sent #{"200".colorize.green}")
     called.should be_true
   end
 
-  it "logs debug messages" do
-    io = IO::Memory.new
-    log_io = IO::Memory.new
-    context = build_context_with_io(io)
-    context.add_debug_message("debug this")
-
-    call_log_handler_with(log_io, context) { }
-
-    log_output = log_io.to_s
-    log_output.should contain("debug this")
-  end
-
   it "logs errors" do
-    io = IO::Memory.new
-    context = build_context_with_io(io)
     log_io = IO::Memory.new
+    context = build_context_with_io(log_io)
 
-    expect_raises(Exception, "Foo") do
-      call_log_handler_with(log_io, context) { raise "Foo" }
+    expect_raises(Exception, "an error") do
+      call_log_handler_with(log_io, context) { raise "an error" }
     end
     log_output = log_io.to_s
-    log_output.should contain("GET")
-    log_output.should_not match(/#{Time.now.to_s("%Y-%m-%d")}/)
-    log_output.should contain("Unhandled exception:")
-  end
-
-  context "when configured to log timestamps" do
-    it "logs timestamp" do
-      Lucky::LogHandler.temp_config(show_timestamps: true) do
-        io = IO::Memory.new
-        called = false
-        log_io = IO::Memory.new
-        context = build_context_with_io(io)
-
-        call_log_handler_with(log_io, context) { called = true }
-
-        log_output = log_io.to_s
-        log_output.should contain("GET")
-        log_output.should match(/#{Time.now.to_s("%Y-%m-%d")}/)
-        called.should be_true
-      end
-    end
-  end
-
-  context "when configured to be disabled" do
-    it "logs timestamp" do
-      Lucky::LogHandler.temp_config(enabled: false) do
-        io = IO::Memory.new
-        called = false
-        log_io = IO::Memory.new
-        context = build_context_with_io(io)
-
-        call_log_handler_with(log_io, context) { called = true }
-
-        log_output = log_io.to_s
-        log_output.should eq ""
-        called.should be_true
-      end
-    end
+    log_output.should contain("an error")
   end
 
   context "when context is configured to be hidden from logs" do
     it "does not log anything" do
-      io = IO::Memory.new
       called = false
       log_io = IO::Memory.new
-      context = build_context_with_io(io)
+      context = build_context_with_io(log_io)
       context.hide_from_logs = true
 
       call_log_handler_with(log_io, context) { called = true }
@@ -102,26 +42,12 @@ describe Lucky::LogHandler do
       called.should be_true
     end
   end
-
-  context "when configured with custom log formatter" do
-    it "logs emoji" do
-      Lucky::LogHandler.temp_config(log_formatter: EmojiLogFormatter.new) do
-        called = false
-        log_io = IO::Memory.new
-        context = build_context("PATCH")
-
-        call_log_handler_with(log_io, context) { called = true }
-
-        log_output = log_io.to_s.chomp
-        log_output.should eq "🐵 PATCH - BOOM"
-        called.should be_true
-      end
-    end
-  end
 end
 
 private def call_log_handler_with(io : IO, context : HTTP::Server::Context, &block)
-  handler = Lucky::LogHandler.new(io)
-  handler.next = ->(_ctx : HTTP::Server::Context) { block.call }
-  handler.call(context)
+  Lucky::LogHandler.temp_config(logger: Lucky::Logger.new(io)) do
+    handler = Lucky::LogHandler.new
+    handler.next = ->(_ctx : HTTP::Server::Context) { block.call }
+    handler.call(context)
+  end
 end

--- a/spec/lucky/logger_spec.cr
+++ b/spec/lucky/logger_spec.cr
@@ -1,0 +1,73 @@
+require "../spec_helper"
+
+private class RawFormatter < Lucky::BaseLogFormatter
+  def format(
+    severity,
+    timestamp,
+    progname,
+    data,
+    io
+  )
+    io << data
+  end
+end
+
+describe Lucky::Logger do
+  it "inherits from the Crytal Logger" do
+    build_logger.should be_a(::Logger)
+  end
+
+  it "converts string into NamedTuple" do
+    io = IO::Memory.new
+    logger = build_logger(io)
+
+    logger.info("Something")
+
+    io.to_s.chomp.should eq(%({message: "Something"}))
+  end
+
+  it "converts string into NamedTuple" do
+    io = IO::Memory.new
+    logger = build_logger(io)
+
+    logger.info("Something")
+
+    io.to_s.chomp.should eq(%({message: "Something"}))
+  end
+
+  it "allows logging key/value data" do
+    io = IO::Memory.new
+    logger = build_logger(io)
+
+    logger.log(Logger::Severity::INFO, foo: "bar")
+
+    io.to_s.chomp.should eq(%({foo: "bar"}))
+  end
+
+  {% for name in ::Logger::Severity.constants %}
+    it "logs key/value data for '{{ name.id.downcase }}'" do
+      io = IO::Memory.new
+      logger = build_logger(io)
+
+      logger.{{ name.id.downcase }}({foo: "bar"})
+
+      io.to_s.chomp.should eq(%({foo: "bar"}))
+    end
+
+    it "logs splatted key/value data for '{{ name.id.downcase }}'" do
+      io = IO::Memory.new
+      logger = build_logger(io)
+
+      # Surrounding {} not required:
+      logger.{{ name.id.downcase }}(foo: "bar")
+
+      io.to_s.chomp.should eq(%({foo: "bar"}))
+    end
+  {% end %}
+end
+
+private def build_logger(io = STDOUT)
+  Lucky::Logger.new(io, level: Logger::Severity::DEBUG).tap do |logger|
+    logger.log_formatter = RawFormatter.new
+  end
+end

--- a/spec/lucky/pretty_log_formatter_spec.cr
+++ b/spec/lucky/pretty_log_formatter_spec.cr
@@ -1,0 +1,66 @@
+require "../spec_helper"
+
+describe Lucky::PrettyLogFormatter do
+  context "special cases" do
+    it "pretty formats data for the start of an HTTP request" do
+      io = IO::Memory.new
+      format(io, {method: "GET", path: "/foo"})
+
+      io.to_s.chomp.should start_with("GET #{"/foo".colorize.underline}")
+    end
+
+    it "pretty formats data for the end of an HTTP request" do
+      io = IO::Memory.new
+      format(io, {status: 200, duration: "1.4ms"})
+
+      io.to_s.chomp.should start_with("Sent #{"200".colorize(:green)} (1.4ms)")
+    end
+  end
+
+  context "when given data that is not the start/end of an HTTP request " do
+    it "prints message text with an arrow" do
+      io = IO::Memory.new
+      format(io, {message: "some text"})
+
+      io.to_s.chomp.should eq " #{"▸".colorize.dim} some text"
+    end
+
+    it "humanizes keys in key value pairs and prints with an arrow" do
+      io = IO::Memory.new
+      format(io, {failed_to_save: "SignUpForm"})
+
+      io.to_s.chomp.should eq(" #{"▸".colorize.dim} Failed to save #{"SignUpForm".colorize.bold}")
+    end
+
+    it "formats multiple key value pairs" do
+      io = IO::Memory.new
+      format(io, {first_thing: "one", second_thing: "two"})
+
+      io.to_s.chomp.should eq(" #{"▸".colorize.dim} First thing #{"one".colorize.bold}. Second thing #{"two".colorize.bold}")
+    end
+  end
+
+  it "uses a red arrow for ERRORS and above" do
+    io = IO::Memory.new
+    format(io, severity: Logger::Severity::ERROR, data: {message: "message"})
+
+    io.to_s.chomp.should eq(" #{"▸".colorize.red} message")
+  end
+
+  it "uses a yellow arrow for warnings" do
+    io = IO::Memory.new
+    format(io, severity: Logger::Severity::WARN, data: {message: "message"})
+
+    io.to_s.chomp.should eq(" #{"▸".colorize.yellow} message")
+  end
+end
+
+private def format(io, data : NamedTuple, severity = Logger::Severity::INFO)
+  Lucky::PrettyLogFormatter.new.format(
+    severity: severity,
+    timestamp: Time.now,
+    progname: "",
+    data: data,
+    io: io
+  )
+end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,4 +1,5 @@
 require "spec"
+require "mocks/spec"
 require "../src/lucky"
 require "../tasks/**"
 require "./support/**"
@@ -7,6 +8,10 @@ Lucky::AssetHelpers.load_manifest
 
 Spec.before_each do
   ARGV.clear
+end
+
+Lucky.configure do |settings|
+  settings.logger = Lucky::Logger.new(nil)
 end
 
 Lucky::Session.configure do |settings|
@@ -32,7 +37,7 @@ Lucky::ErrorHandler.configure do |settings|
 end
 
 Lucky::LogHandler.configure do |settings|
-  settings.show_timestamps = false
+  settings.logger = Lucky.logger
 end
 
 Lucky::StaticFileHandler.configure do |settings|

--- a/src/lucky.cr
+++ b/src/lucky.cr
@@ -14,3 +14,13 @@ require "./lucky/exceptions"
 require "./lucky/response"
 require "./lucky/cookies/*"
 require "./lucky/*"
+
+module Lucky
+  Habitat.create do
+    setting logger : Lucky::Logger
+  end
+
+  def self.logger
+    settings.logger
+  end
+end

--- a/src/lucky/action_callbacks.cr
+++ b/src/lucky/action_callbacks.cr
@@ -165,8 +165,7 @@ module Lucky::ActionCallbacks
     context : HTTP::Server::Context,
     callback_method_name : String
   ) : Void
-    callback_method_with_color = callback_method_name.colorize(HTTP::Server::Context::DEBUG_COLOR)
-    context.add_debug_message("Stopped at #{callback_method_with_color}")
+    Lucky.logger.warn({stopped_by: callback_method_name})
   end
 
   # :nodoc:
@@ -174,8 +173,7 @@ module Lucky::ActionCallbacks
     context : HTTP::Server::Context,
     callback_method_name : String
   ) : Void
-    callback_method_with_color = callback_method_name.colorize(HTTP::Server::Context::DEBUG_COLOR)
-    context.add_debug_message("Ran #{callback_method_with_color}")
+    Lucky.logger.debug({ran: callback_method_name})
   end
 
   # :nodoc:

--- a/src/lucky/base_log_formatter.cr
+++ b/src/lucky/base_log_formatter.cr
@@ -1,0 +1,9 @@
+abstract class Lucky::BaseLogFormatter
+  abstract def format(
+    severity : ::Logger::Severity,
+    timestamp : Time,
+    progname : String,
+    data : NamedTuple,
+    io : IO
+  ) : Void
+end

--- a/src/lucky/context_extensions.cr
+++ b/src/lucky/context_extensions.cr
@@ -1,6 +1,4 @@
 class HTTP::Server::Context
-  DEBUG_COLOR = :green
-  getter debug_messages : Array(String) = [] of String
   property? hide_from_logs : Bool = false
 
   @_cookies : Lucky::CookieJar?
@@ -19,11 +17,5 @@ class HTTP::Server::Context
 
   def flash
     @_flash ||= Lucky::FlashStore.from_session(session)
-  end
-
-  def add_debug_message(message : String)
-    {% if !flag?(:release) %}
-      debug_messages << message
-    {% end %}
   end
 end

--- a/src/lucky/json_log_formatter.cr
+++ b/src/lucky/json_log_formatter.cr
@@ -1,0 +1,13 @@
+require "./base_log_formatter"
+
+class Lucky::JsonLogFormatter < Lucky::BaseLogFormatter
+  def format(
+    severity : ::Logger::Severity,
+    timestamp : Time,
+    progname : String,
+    data,
+    io : IO
+  ) : Void
+    {severity: severity.to_s, timestamp: timestamp}.merge(data).to_json(io)
+  end
+end

--- a/src/lucky/log_formatters/default_log_formatter.cr
+++ b/src/lucky/log_formatters/default_log_formatter.cr
@@ -1,5 +1,0 @@
-class DefaultLogFormatter < Lucky::LogFormatters::Base
-  def format(context, time, elapsed) : String
-    "#{context.request.method} #{colored_status_code(context.response.status_code)} #{context.request.resource}#{timestamp(time)} (#{elapsed_text(elapsed)})"
-  end
-end

--- a/src/lucky/logger.cr
+++ b/src/lucky/logger.cr
@@ -1,0 +1,80 @@
+require "logger"
+require "./base_log_formatter"
+require "./pretty_log_formatter"
+require "./json_log_formatter"
+
+class Lucky::Logger < Logger
+  property log_formatter : Lucky::BaseLogFormatter
+
+  # The built-in Crystal Logger requires a formatter, but we don't use it.
+  # We instead override the `write` method and use our own formatter that
+  # accepts a NamedTuple instead of a string
+  private UNUSED_FORMATTER = Formatter.new do |_, _, _, _, _|
+    # unused
+  end
+
+  def initialize(
+    @io : IO?,
+    @level = Severity::INFO,
+    @log_formatter = Lucky::PrettyLogFormatter.new,
+    @progname = ""
+  )
+    @formatter = UNUSED_FORMATTER
+    @closed = false
+    @mutex = Mutex.new
+  end
+
+  {% for name in ::Logger::Severity.constants %}
+    # Logs *message* if the logger's current severity is lower or equal to `{{name.id}}`.
+    def {{name.id.downcase}}(data : NamedTuple) : Void
+      log(Severity::{{name.id}}, data)
+    end
+
+    # Logs *message* if the logger's current severity is lower or equal to `{{name.id}}`.
+    #
+    # Same as `{{ name.id }} but does not require surrounding data with {}:
+    #
+    # Example: `Lucky::Logger.new(STDOUT).{{ name.id }}(data: "my_data")`
+    def {{name.id.downcase}}(**data) : Void
+      log(Severity::{{name.id}}, data)
+    end
+  {% end %}
+
+  def log(severity : ::Logger::Severity, **data) : Void
+    log(severity: severity, data: data)
+  end
+
+  def log(severity : ::Logger::Severity, data : NamedTuple) : Void
+    return if severity < level || !@io
+    write(severity, Time.now, @progname, data)
+  end
+
+  # :nodoc:
+  def formatter=(value) : Void
+    {% raise "Use log_formatter= instead" %}
+  end
+
+  private def write(severity : ::Logger::Severity, datetime : Time, progname, message : String | NamedTuple) : Void
+    io = @io
+    return unless io
+
+    data = if message.is_a?(String)
+             {message: message}
+           else
+             message
+           end
+
+    progname_to_s = progname.to_s
+    @mutex.synchronize do
+      log_formatter.format(
+        severity: severity,
+        timestamp: datetime,
+        progname: progname_to_s,
+        data: data,
+        io: io
+      )
+      io.puts
+      io.flush
+    end
+  end
+end

--- a/src/lucky/logger_helpers.cr
+++ b/src/lucky/logger_helpers.cr
@@ -1,7 +1,5 @@
-abstract class Lucky::LogFormatters::Base
-  abstract def format(context, time, elapsed) : String
-
-  private def colored_status_code(status_code)
+module Lucky::LoggerHelpers
+  def self.colored_status_code(status_code : Int32) : String
     case status_code
     when 200..399
       "#{status_code.colorize(:green)}"
@@ -14,11 +12,7 @@ abstract class Lucky::LogFormatters::Base
     end
   end
 
-  private def timestamp(time)
-    Lucky::LogHandler.timestamp(time)
-  end
-
-  private def elapsed_text(elapsed)
+  def self.elapsed_text(elapsed : Time::Span)
     minutes = elapsed.total_minutes
     return "#{minutes.round(2)}m" if minutes >= 1
 

--- a/src/lucky/pretty_log_formatter.cr
+++ b/src/lucky/pretty_log_formatter.cr
@@ -1,0 +1,91 @@
+require "./base_log_formatter"
+
+class Lucky::PrettyLogFormatter < Lucky::BaseLogFormatter
+  private abstract class MessageFormatter
+    class Continue; end
+
+    private getter io, severity
+
+    def initialize(@io : IO, @severity : ::Logger::Severity)
+    end
+
+    def format(_catch_all)
+      Continue.new
+    end
+
+    private def add_arrow : Void
+      io << " "
+      io << arrow
+      io << " "
+    end
+
+    private def arrow
+      arrow = "▸"
+
+      case severity.value
+      when Logger::Severity::WARN.value
+        arrow.colorize.yellow
+      when .>= Logger::Severity::ERROR.value
+        arrow.colorize.red
+      else
+        arrow.colorize.dim
+      end
+    end
+  end
+
+  private class RequestStartedFormatter < MessageFormatter
+    def format(data : NamedTuple(method: String, path: String))
+      io << data[:method]
+      io << " "
+      io << data[:path].colorize.underline
+    end
+  end
+
+  private class RequestEndedFormatter < MessageFormatter
+    def format(data : NamedTuple(status: Int32, duration: String))
+      io << "Sent "
+      io << Lucky::LoggerHelpers.colored_status_code(data[:status])
+      io << " ("
+      io << data[:duration]
+      io << ")"
+    end
+  end
+
+  private class PlainTextFormatter < MessageFormatter
+    def format(data : NamedTuple(message: String))
+      add_arrow
+
+      io << data[:message]
+    end
+  end
+
+  private class AnyOtherDataFormatter < MessageFormatter
+    def format(data : NamedTuple)
+      add_arrow
+
+      io << data.map do |key, value|
+        "#{Wordsmith::Inflector.humanize(key)} #{value.colorize.bold}"
+      end.join(". ")
+    end
+  end
+
+  MESSAGE_FORMATTERS = [
+    RequestStartedFormatter,
+    RequestEndedFormatter,
+    PlainTextFormatter,
+    AnyOtherDataFormatter,
+  ]
+
+  def format(
+    severity : ::Logger::Severity,
+    timestamp : Time,
+    progname : String,
+    data : NamedTuple,
+    io : IO
+  ) : Void
+    MESSAGE_FORMATTERS.each do |message_formatter|
+      result = message_formatter.new(io, severity).format(data)
+      break unless result.is_a?(MessageFormatter::Continue)
+    end
+  end
+end

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -89,7 +89,7 @@ module Lucky::Renderable
   end
 
   private def log_message(view)
-    "Rendered #{view.class.colorize(HTTP::Server::Context::DEBUG_COLOR)}"
+    "Rendered #{view.class.colorize.bold}"
   end
 
   # :nodoc:
@@ -105,7 +105,7 @@ module Lucky::Renderable
 
   private def log_response(response : Lucky::Response)
     response.debug_message.try do |message|
-      context.add_debug_message(message)
+      Lucky.logger.debug(message)
     end
   end
 

--- a/src/lucky/route_handler.cr
+++ b/src/lucky/route_handler.cr
@@ -6,7 +6,7 @@ class Lucky::RouteHandler
   def call(context)
     handler = Lucky::Router.find_action(context.request)
     if handler
-      context.add_debug_message("Handled by #{handler.payload.to_s.colorize(HTTP::Server::Context::DEBUG_COLOR)}")
+      Lucky.logger.debug("Handled by #{handler.payload.to_s.colorize.bold}")
       handler.payload.new(context, handler.params).perform_action
     else
       call_next(context)


### PR DESCRIPTION
- [x] Add JSON logger for production

Maybe now, maybe later:
- [ ] Add request ids
- [ ] Global context
- [ ] Configuration blocks to ignore or modify data
- [x] Use data for action halted warning
- [ ] Group before callbacks into one line

* Create `Lucky::Logger` that inherites from `::Logger`
* `Lucky::Logger` allows passing data as NamedTuple
* This data is passed to `LogFormatters` so that it can be formatted in
  any way a user wants.
* Add JSON and pretty log formatters by default.

Now that we have a solid and flexible logger we can also start logging
to a file during test. This new logger will also be used with Avram to
start logging when forms fail to save.

This also logs everything in real-time (as opposed to logging request details once the request was finished). This means that if you log other stuff with `puts` it will show up in the correct spot chronologically. 

<img width="491" alt="screen shot 2019-02-22 at 10 03 22 am" src="https://user-images.githubusercontent.com/22394/53287898-440b1880-3750-11e9-9b52-0b2058d3af4c.png">