### PR TITLE
Add with_defaults

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -12,4 +12,4 @@ fi
 
 docker-compose build
 
-docker-compose run app shards install
+docker-compose run app shards update

--- a/shard.yml
+++ b/shard.yml
@@ -60,6 +60,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: veelenga/ameba
+    version: ~> 0.9
 
 scripts:
   postinstall: script/precompile_tasks

--- a/spec/lucky/with_defaults_spec.cr
+++ b/spec/lucky/with_defaults_spec.cr
@@ -1,0 +1,55 @@
+require "../../spec_helper"
+
+private class TestWithDefaultsPage
+  include Lucky::HTMLPage
+
+  def render
+    with_defaults field: name_field, class: "form-control" do |html|
+      html.text_input
+    end
+
+    with_defaults field: name_field, class: "form-control" do |html|
+      html.text_input placeholder: "Name please"
+    end
+
+    with_defaults field: name_field, placeholder: "default" do |html|
+      html.text_input placeholder: "replace default"
+    end
+
+    with_defaults field: name_field, class: "default" do |html|
+      html.text_input append_class: "appended classes"
+    end
+
+    with_defaults field: name_field, class: "default" do |html|
+      html.text_input replace_class: "replaced"
+    end
+
+    @view
+  end
+end
+
+describe "with_defaults" do
+  it "renders the component" do
+    contents = TestWithDefaultsPage.new(build_context).render.to_s
+
+    contents
+      .should contain %(<input type="text" id="user_name" name="user:name" value="" class="form-control">)
+    contents
+      .should contain %(<input type="text" id="user_name" name="user:name" value="" class="form-control" placeholder="Name please">)
+    contents
+      .should contain %(<input type="text" id="user_name" name="user:name" value="" placeholder="replace default">)
+    contents
+      .should contain %(<input type="text" id="user_name" name="user:name" value="" class="default appended classes">)
+    contents
+      .should contain %(<input type="text" id="user_name" name="user:name" value="" class="replaced">)
+  end
+end
+
+private def name_field
+  Avram::FillableField(String).new(
+    name: :name,
+    param: "",
+    value: "",
+    form_name: "user"
+  )
+end

--- a/src/lucky/html_builder.cr
+++ b/src/lucky/html_builder.cr
@@ -20,6 +20,7 @@ module Lucky::HTMLBuilder
   include Lucky::MountComponent
   include Lucky::HelpfulParagraphError
   include Lucky::RenderIfDefined
+  include Lucky::WithDefaults
 
   macro setup_initializer_hook
     macro finished

--- a/src/lucky/tags/with_defaults.cr
+++ b/src/lucky/tags/with_defaults.cr
@@ -1,0 +1,88 @@
+# Set up defaults arguments for HTML tags.
+#
+# This is automatically included in Pages and Cells.
+module Lucky::WithDefaults
+  # This is typically used in Cells and helper methods to set up defaults for
+  # reusable components.
+  #
+  # Example in a page or cell:
+  #
+  #    with_defaults field: form.email, class: "input" do |html|
+  #      html.email_input placeholder: "Email"
+  #    end
+  #
+  # Is the same as:
+  #
+  #     email_input field: form.email, class: "input", placeholder: "Email"
+  def with_defaults(**named_args)
+    OptionMerger.new(page_context: self, named_args: named_args).run do |html|
+      yield html
+    end
+  end
+
+  class OptionMerger(T, V)
+    def initialize(@page_context : T, @named_args : V)
+    end
+
+    def run
+      yield self
+    end
+
+    macro method_missing(call)
+      overridden_html_class = nil
+
+      {% named_args = call.named_args %}
+      {% if named_args %}
+        {% if call.named_args.any? { |arg| arg.name == :class } %}
+          {% raise <<-ERROR
+
+
+          Use 'replace_class' or 'append_class' instead of 'class'.
+
+          Correct example:
+
+              with_defaults class: "default" do |html|
+                # Use 'replace_class' or 'append_class' here
+                html.div replace_class: "replaced"
+              end
+
+          Incorrect example:
+
+              with_defaults class: "default" do |html|
+                # Won't work with 'class'
+                html.div class: "replaced"
+              end
+
+          -----------------
+
+          ERROR
+          %}
+        {% end %}
+
+        {% appended_class_arg = call.named_args.find { |arg| arg.name == :append_class } %}
+        {% if appended_class_arg %}
+          overridden_html_class = "#{@named_args[:class]?} #{{{ appended_class_arg.value }}}"
+        {% end %}
+        {% named_args = named_args.reject { |arg| arg.name == :append_class } %}
+
+        {% replace_class_arg = call.named_args.find { |arg| arg.name == :replace_class } %}
+        {% if replace_class_arg %}
+          overridden_html_class = "#{{{ replace_class_arg.value }}}"
+        {% end %}
+        {% named_args = named_args.reject { |arg| arg.name == :replace_class } %}
+      {% end %}
+
+      args = @named_args{% if named_args %}.merge(
+        {% for arg in named_args %}
+          {{ arg.name }}: {{ arg.value }},
+        {% end %}
+      )
+      if overridden_html_class
+        args = args.merge(class: overridden_html_class)
+      end
+      {% end %}
+
+      @page_context.{{ call.name }} **args
+    end
+  end
+end


### PR DESCRIPTION
This will allow you to use a block to set some default values
and then override or modify them. This will allow some super cool stuff
with Class components and inputs. Stuff like this:

```crystal
mount Shared::Field.new(f.email), 
  &.email_input(placeholder: "Email here...", append_class: "compact-input")
```

Where `Shared::Field` sets up default classes, field, placeholder, and
whatever else you want.

```crystal
class Shared::Field(T) < BaseComponent
  needs field : Avram::FillableField(T)

  def render
    label_for @field
    with_defaults field: @field, class: "form-input" do |html|
      yield html
    end
  end
end
```