### PR TITLE
Call error action regardless of `show_debug_output`

### DIFF
--- a/spec/lucky/error_handling_spec.cr
+++ b/spec/lucky/error_handling_spec.cr
@@ -68,21 +68,4 @@ describe Lucky::ErrorHandler do
     context.response.headers["Content-Type"].should eq("text/plain")
     context.response.status_code.should eq(418)
   end
-
-  context "when configured to show debug output" do
-    it "prints debug output instead of calling the error action" do
-      Lucky::ErrorHandler.temp_config(show_debug_output: true) do
-        fake_io = IO::Memory.new
-        error_handler = Lucky::ErrorHandler.new(action: FakeErrorAction, error_io: fake_io)
-        error_handler.next = ->(_ctx : HTTP::Server::Context) { raise UnhandledError.new }
-
-        context = error_handler.call(build_context).as(HTTP::Server::Context)
-
-        context.response.headers["Content-Type"].should eq("text/html")
-        context.response.status_code.should eq(500)
-        fake_io.to_s.should contain("UnhandledError")
-        fake_io.to_s.should contain("from spec/lucky/error_handling_spec.cr")
-      end
-    end
-  end
 end

--- a/spec/lucky/error_handling_spec.cr
+++ b/spec/lucky/error_handling_spec.cr
@@ -68,4 +68,14 @@ describe Lucky::ErrorHandler do
     context.response.headers["Content-Type"].should eq("text/plain")
     context.response.status_code.should eq(418)
   end
+
+  describe ".render_exception_page" do
+    it "returns a exception page as a response with a 500 status" do
+      context = build_context
+      error = Exception.new
+      response = Lucky::ErrorHandler.render_exception_page(context, error)
+      response.should be_a(Lucky::Response)
+      response.status.should eq(500)
+    end
+  end
 end

--- a/src/lucky/error_handler.cr
+++ b/src/lucky/error_handler.cr
@@ -13,20 +13,10 @@ class Lucky::ErrorHandler
   def call(context : HTTP::Server::Context)
     call_next(context)
   rescue error : Exception
-    if settings.show_debug_output
-      print_debug_output(context, error)
-    else
-      call_error_action(context, error)
-    end
+    call_error_action(context, error)
   end
 
-  private def print_debug_output(context : HTTP::Server::Context, error : Exception) : HTTP::Server::Context
-    error.inspect_with_backtrace(error_io)
-    render_exception_page(context, error)
-    context
-  end
-
-  private def render_exception_page(context, error)
+  def self.render_exception_page(context, error)
     context.response.reset
     context.response.status_code = 500
     context.response.content_type = "text/html"

--- a/src/lucky/error_handler.cr
+++ b/src/lucky/error_handler.cr
@@ -18,9 +18,12 @@ class Lucky::ErrorHandler
 
   def self.render_exception_page(context, error)
     context.response.reset
-    context.response.status_code = 500
-    context.response.content_type = "text/html"
-    context.response.print Lucky::ExceptionPage.for_runtime_exception(context, error)
+    Lucky::TextResponse.new(
+      context: context,
+      status: 500,
+      content_type: "text/html",
+      body: Lucky::ExceptionPage.for_runtime_exception(context, error).to_s
+    )
   end
 
   private def call_error_action(context : HTTP::Server::Context, error : Exception) : HTTP::Server::Context


### PR DESCRIPTION
Before, the response code and body could vary with `show_debug_output`.

Also make `render_exception_page` class-level and public so it can be
used by error actions.

Works toward resolving #719. 