### PR TITLE
Fix `BaseHTTPClient` params

### DIFF
--- a/spec/lucky/base_http_client_spec.cr
+++ b/spec/lucky/base_http_client_spec.cr
@@ -14,8 +14,8 @@ describe Lucky::BaseHTTPClient do
   describe "#get" do
     it "sends requests to correct uri (with the correct query params) and gives the right response" do
       TestServer.route("hello", "world")
-      Lucky::RouteHelper.temp_config(base_uri: "localhost") do
-        client = Lucky::BaseHTTPClient.new(port: 6226)
+      Lucky::Server.temp_config(host: "localhost", port: 6226) do
+        client = Lucky::BaseHTTPClient.new
         response = client.get("hello", params: HTTP::Params.new(raw_params: {"foo" => ["bar"]}))
 
         response.body.should eq "world"
@@ -30,8 +30,8 @@ describe Lucky::BaseHTTPClient do
   describe "#delete" do
     it "sends requests to correct uri (with the correct query params) and gives the right response" do
       TestServer.route("hello", "world")
-      Lucky::RouteHelper.temp_config(base_uri: "localhost") do
-        client = Lucky::BaseHTTPClient.new(port: 6226)
+      Lucky::Server.temp_config(host: "localhost", port: 6226) do
+        client = Lucky::BaseHTTPClient.new
         response = client.delete("hello")
 
         response.body.should eq "world"
@@ -44,8 +44,8 @@ describe Lucky::BaseHTTPClient do
     describe "\#{{method.id}}" do
       it "sends correct request to correct uri and gives the correct response" do
         TestServer.route("hello", "world")
-        Lucky::RouteHelper.temp_config(base_uri: "localhost") do
-          client = Lucky::BaseHTTPClient.new(port: 6226)
+        Lucky::Server.temp_config(host: "localhost", port: 6226) do
+          client = Lucky::BaseHTTPClient.new
           response = client.{{method.id}}(
             path: "hello",
             body: { "foo" => "bar" }

--- a/src/lucky/base_http_client.cr
+++ b/src/lucky/base_http_client.cr
@@ -3,8 +3,8 @@ require "http/client"
 class Lucky::BaseHTTPClient
   @client : HTTP::Client
 
-  def initialize(port = nil)
-    @client = HTTP::Client.new(Lucky::RouteHelper.settings.base_uri, port: port)
+  def initialize(host = Lucky::Server.settings.host, port = Lucky::Server.settings.port)
+    @client = HTTP::Client.new(host, port: port)
   end
 
   def get(path : String, headers : HTTP::Headers? = nil, params : HTTP::Params? = nil)


### PR DESCRIPTION
The underlying `HTTP::Client` was expecting a host, but we were
providing it a base URI (which is the combined host and port).

It was also deriving its default value from the `RouteHelper`, but the
requests are expected to be made to the `Server` *first*.

This also enables the host to be configured without overriding the
client.