### PR TITLE
Fixes allowing a symbol for status in a redirect.

### DIFF
--- a/spec/lucky/action_redirect_spec.cr
+++ b/spec/lucky/action_redirect_spec.cr
@@ -31,6 +31,10 @@ describe Lucky::Action do
     action = RedirectAction.new(build_context, params)
     action.redirect to: "/somewhere", status: Lucky::Action::Status::MovedPermanently
     should_redirect(action, to: "/somewhere", status: 301)
+
+    action = RedirectAction.new(build_context, params)
+    action.redirect to: "/somewhere", status: :moved_permanently
+    should_redirect(action, to: "/somewhere", status: 301)
   end
 end
 

--- a/spec/lucky/action_rendering_spec.cr
+++ b/spec/lucky/action_rendering_spec.cr
@@ -43,6 +43,12 @@ class Rendering::JSON::WithTypedStatus < Lucky::Action
   end
 end
 
+class Rendering::JSON::WithSymbolStatus < Lucky::Action
+  get "/foo" do
+    json({name: "Paul"}, status: :created)
+  end
+end
+
 class Rendering::HeadOnly < Lucky::Action
   get "/foo" do
     head status: 204
@@ -52,6 +58,12 @@ end
 class Rendering::HeadOnly::WithTypedStatus < Lucky::Action
   get "/foo" do
     head status: Status::NoContent
+  end
+end
+
+class Rendering::HeadOnly::WithSymbolStatus < Lucky::Action
+  get "/foo" do
+    head status: :no_content
   end
 end
 
@@ -70,6 +82,12 @@ end
 class Rendering::Text::WithTypedStatus < Lucky::Action
   get "/foo" do
     text "Anything", status: Status::Created
+  end
+end
+
+class Rendering::Text::WithSymbolStatus < Lucky::Action
+  get "/foo" do
+    text "Anything", status: :created
   end
 end
 
@@ -134,6 +152,9 @@ describe Lucky::Action do
 
     status = Rendering::JSON::WithTypedStatus.new(build_context, params).call.status
     status.should eq 201
+
+    status = Rendering::JSON::WithSymbolStatus.new(build_context, params).call.status
+    status.should eq 201
   end
 
   it "renders head response with no body" do
@@ -142,6 +163,9 @@ describe Lucky::Action do
     response.status.should eq 204
 
     response = Rendering::HeadOnly::WithTypedStatus.new(build_context, params).call
+    response.status.should eq 204
+
+    response = Rendering::HeadOnly::WithSymbolStatus.new(build_context, params).call
     response.status.should eq 204
   end
 
@@ -155,6 +179,10 @@ describe Lucky::Action do
     response.status.should eq 201
 
     response = Rendering::Text::WithTypedStatus.new(build_context, params).call
+    response.body.should eq "Anything"
+    response.status.should eq 201
+
+    response = Rendering::Text::WithSymbolStatus.new(build_context, params).call
     response.body.should eq "Anything"
     response.status.should eq 201
   end

--- a/src/lucky/redirectable.cr
+++ b/src/lucky/redirectable.cr
@@ -42,19 +42,6 @@ module Lucky::Redirectable
     redirect to: action.route, status: status
   end
 
-  # Redirect using a `String`
-  #
-  # ```crystal
-  # redirect to: "/users"
-  # redirect to: "/users/1", status: 301
-  # ```
-  def redirect(to path : String, status = 302) : Lucky::TextResponse
-    context.response.headers.add "Location", path
-    context.response.headers.add "Turbolinks-Location", path
-    context.response.status_code = status
-    Lucky::TextResponse.new(context, "", "")
-  end
-
   # Redirect using a `String` and a `Status` value
   #
   # ```crystal
@@ -63,6 +50,19 @@ module Lucky::Redirectable
   # You can find a list of all of the possible statuses [here](https://github.com/luckyframework/lucky/blob/master/src/lucky/action.cr).
   def redirect(to path : String, status : Lucky::Action::Status = Lucky::Action::Status::Found) : Lucky::TextResponse
     redirect(path, status.value)
+  end
+
+  # Redirect using a `String`
+  #
+  # ```crystal
+  # redirect to: "/users"
+  # redirect to: "/users/1", status: 301
+  # ```
+  def redirect(to path : String, status : Int32 = 302) : Lucky::TextResponse
+    context.response.headers.add "Location", path
+    context.response.headers.add "Turbolinks-Location", path
+    context.response.status_code = status
+    Lucky::TextResponse.new(context, "", "")
   end
 
   # :nodoc:

--- a/src/lucky/redirectable.cr
+++ b/src/lucky/redirectable.cr
@@ -46,6 +46,8 @@ module Lucky::Redirectable
   #
   # ```crystal
   # redirect to: "/users", status: Status::MovedPermanently
+  # # Symbols can be used in place of the enum. Crystal will convert these at compile time
+  # redirect to: "/users", status: :moved_permanently
   # ```
   # You can find a list of all of the possible statuses [here](https://github.com/luckyframework/lucky/blob/master/src/lucky/action.cr).
   def redirect(to path : String, status : Lucky::Action::Status) : Lucky::TextResponse

--- a/src/lucky/redirectable.cr
+++ b/src/lucky/redirectable.cr
@@ -42,22 +42,23 @@ module Lucky::Redirectable
     redirect to: action.route, status: status
   end
 
-  # Redirect using a `String` and a `Status` value
+  # Redirect to the given path, with a human friendly status
   #
   # ```crystal
   # redirect to: "/users", status: Status::MovedPermanently
   # ```
   # You can find a list of all of the possible statuses [here](https://github.com/luckyframework/lucky/blob/master/src/lucky/action.cr).
-  def redirect(to path : String, status : Lucky::Action::Status = Lucky::Action::Status::Found) : Lucky::TextResponse
+  def redirect(to path : String, status : Lucky::Action::Status) : Lucky::TextResponse
     redirect(path, status.value)
   end
 
-  # Redirect using a `String`
+  # Redirect to the given path, with an optional `Int32` status
   #
   # ```crystal
   # redirect to: "/users"
   # redirect to: "/users/1", status: 301
   # ```
+  # Note: It's recommended to use the method above that accepts a human friendly version of the status
   def redirect(to path : String, status : Int32 = 302) : Lucky::TextResponse
     context.response.headers.add "Location", path
     context.response.headers.add "Turbolinks-Location", path


### PR DESCRIPTION
Fixes #729 

The only relevant change here is adding a type to status. That forces the compiler to use the enum one. I moved that method override up thinking it was an order thing at first. I left it since it made sense. It calls the method below it. 