### PR TITLE
Add more helpful error for non-response in Action

### DIFF
--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -103,6 +103,23 @@ module Lucky::Renderable
     response.print
   end
 
+  private def handle_response(_response : T) forall T
+    {%
+      raise <<-ERROR
+
+
+      Your action returned #{T}
+
+      But it should return a Lucky::Response
+
+      Try this...
+
+        ▸ Use a method like render/redirect/json at the end of your action.
+        ▸ Ensure all conditionals (like if/else) return a response with render/redirect/json/etc.
+      ERROR
+    %}
+  end
+
   private def log_response(response : Lucky::Response) : Nil
     response.debug_message.try do |message|
       Lucky.logger.debug(message)


### PR DESCRIPTION
Part of #460

There is still a bug that makes it so we can't show the type, but I
think we should show this error without the type. It is still better
than what is there.

Currently:

```
in src/lucky/renderable.cr:98: no overload matches 'Rendering::Index#handle_response' with type (Lucky::Response | Nil)
Overloads are:
 - Lucky::Renderable#handle_response(response : Lucky::Response)

    handle_response(response)
    ^~~~~~~~~~~~~~~

Rerun with --error-trace to show a complete error trace.
```

With this change:

```
in src/lucky/renderable.cr:98:
Your action returned (Lucky::Response | Nil)

But it should return a Lucky::Response.

Try this...

  ▸ Use a method like render/redirect/json at the end of your action.
  ▸ Ensure conditionals (if/else/case) at the end of your action return a response (render/redirect/json/etc.)

    handle_response(response)
```

Still not a helpful trace as the file is not the user's file, but at least it explains what to do a bit better