### PR TITLE
add HSTS header to ForceSSLHandler.

### DIFF
--- a/spec/lucky/force_ssl_handler_spec.cr
+++ b/spec/lucky/force_ssl_handler_spec.cr
@@ -53,6 +53,24 @@ describe Lucky::ForceSSLHandler do
       context.response.status_code.should eq 200
       context.response.headers["Location"]?.should be_nil
     end
+
+    it "enables HSTS with 1 year max age and subdomains by default" do
+      context = build_context(path: "/path")
+
+      run_force_ssl_handler context
+
+      context.response.headers["Strict-Transport-Security"].should eq "max-age=31536000; includeSubDomains"
+    end
+
+    it "allows setting hsts max-age to 180 days with no subdomains" do
+      context = build_context(path: "/path")
+
+      Lucky::ForceSSLHandler.temp_config(hsts: {max_age: 180.days, include_subdomains: false}) do
+        run_force_ssl_handler context
+      end
+
+      context.response.headers["Strict-Transport-Security"].should eq "max-age=15552000"
+    end
   end
 end
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -39,4 +39,9 @@ Lucky::StaticFileHandler.configure do |settings|
   settings.hide_from_logs = true
 end
 
+Lucky::ForceSSLHandler.configure do |settings|
+  settings.enabled = true
+  settings.hsts = {max_age: 365.days, include_subdomains: true}
+end
+
 Habitat.raise_if_missing_settings!

--- a/src/lucky/force_ssl_handler.cr
+++ b/src/lucky/force_ssl_handler.cr
@@ -26,8 +26,8 @@ class Lucky::ForceSSLHandler
 
   Habitat.create do
     setting redirect_status : Int32 = Lucky::Action::Status::PermanentRedirect.value
-    setting enabled : Bool = true
-    setting hsts : Hsts? = {max_age: 365.days, include_subdomains: true}
+    setting enabled : Bool
+    setting hsts : Hsts
   end
 
   def call(context)
@@ -55,12 +55,12 @@ class Lucky::ForceSSLHandler
 
   # Read more about [HSTS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)
   private def add_hsts_if_enabled(context : HTTP::Server::Context)
-    sts_value = settings.hsts.try do |hsts|
-      String.build do |s|
+    settings.hsts.try do |hsts|
+      sts_value = String.build do |s|
         s << "max-age=#{hsts[:max_age].total_seconds.to_i}"
         s << "; includeSubDomains" if hsts[:include_subdomains]
       end
+      context.response.headers["Strict-Transport-Security"] = sts_value
     end
-    context.response.headers["Strict-Transport-Security"] = sts_value if sts_value
   end
 end

--- a/src/lucky/force_ssl_handler.cr
+++ b/src/lucky/force_ssl_handler.cr
@@ -12,12 +12,15 @@
 
 # *Enabled* - The handler can be enabled/disabled. This is helpful for working
 # in a local development environment.
+
+# *HSTS* - Settings to configure HSTS header with max-age and includeSubDomains
 #
 # ```
 # # Usually in config/force_ssl_handler.cr
 # Lucky::ForceSSLHandler.configure do |settings|
 #   settings.redirect_status = 303
 #   settings.enabled = false
+#   settings.hsts = {max_age: 18.weeks, include_subdomains: false}
 # end
 # ```
 class Lucky::ForceSSLHandler


### PR DESCRIPTION
Fixes #523 

This allows you to configure setting [HSTS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security#Preloading_Strict_Transport_Security) when you have SSL enabled. By default this is on as well as including the subdomains option and a default age of 365 days. If the option is set to nil, then it's just disabled and no extra header is set.

