### PR TITLE
Adding in secure header modules.

### DIFF
--- a/spec/lucky/secure_headers_spec.cr
+++ b/spec/lucky/secure_headers_spec.cr
@@ -2,27 +2,27 @@ require "../../spec_helper"
 
 include ContextHelper
 
-class FrameGuardRoutes::WithSame < Lucky::Action
+class FrameGuardRoutes::WithSameorigin < Lucky::Action
   include Lucky::SecureHeaders::SetFrameGuard
 
   get "/so_custom" do
     text "test"
   end
 
-  def frame_guard_options
-    {allow_from: "same"}
+  def frame_guard_value
+    "sameorigin"
   end
 end
 
-class FrameGuardRoutes::WithNowhere < Lucky::Action
+class FrameGuardRoutes::WithDeny < Lucky::Action
   include Lucky::SecureHeaders::SetFrameGuard
 
   get "/so_custom" do
     text "test"
   end
 
-  def frame_guard_options
-    {allow_from: "nowhere"}
+  def frame_guard_value
+    "deny"
   end
 end
 
@@ -33,26 +33,44 @@ class FrameGuardRoutes::WithURL < Lucky::Action
     text "test"
   end
 
-  def frame_guard_options
-    {allow_from: "https://tacotrucks.food"}
+  def frame_guard_value
+    "https://tacotrucks.food"
+  end
+end
+
+class FrameGuardRoutes::WithBadValue < Lucky::Action
+  include Lucky::SecureHeaders::SetFrameGuard
+
+  get "/so_custom" do
+    text "test"
+  end
+
+  def frame_guard_value
+    "hax0rz"
   end
 end
 
 describe Lucky::SecureHeaders do
   describe "SetFrameGuard" do
     it "sets the X-Frame-Options header with sameorigin" do
-      route = FrameGuardRoutes::WithSame.new(build_context, params).call
+      route = FrameGuardRoutes::WithSameorigin.new(build_context, params).call
       route.context.response.headers["X-Frame-Options"].should eq "sameorigin"
     end
 
     it "sets the X-Frame-Options header with deny" do
-      route = FrameGuardRoutes::WithNowhere.new(build_context, params).call
+      route = FrameGuardRoutes::WithDeny.new(build_context, params).call
       route.context.response.headers["X-Frame-Options"].should eq "deny"
     end
 
     it "sets the X-Frame-Options header to allow from tacotrucks" do
       route = FrameGuardRoutes::WithURL.new(build_context, params).call
       route.context.response.headers["X-Frame-Options"].should eq "allow-from https://tacotrucks.food"
+    end
+
+    it "throws an error when given a bad value" do
+      expect_raises(Exception) do
+        route = FrameGuardRoutes::WithBadValue.new(build_context, params).call
+      end
     end
   end
 end

--- a/spec/lucky/secure_headers_spec.cr
+++ b/spec/lucky/secure_headers_spec.cr
@@ -50,6 +50,14 @@ class FrameGuardRoutes::WithBadValue < Lucky::Action
   end
 end
 
+class XSSGuardRoutes::Index < Lucky::Action
+  include Lucky::SecureHeaders::SetXSSGuard
+
+  get "/so_custom" do
+    text "test"
+  end
+end
+
 describe Lucky::SecureHeaders do
   describe "SetFrameGuard" do
     it "sets the X-Frame-Options header with sameorigin" do
@@ -71,6 +79,20 @@ describe Lucky::SecureHeaders do
       expect_raises(Exception, "You set frame_guard_value to hax0rz") do
         route = FrameGuardRoutes::WithBadValue.new(build_context, params).call
       end
+    end
+  end
+
+  describe "SetXSSGuard" do
+    it "sets the X-XSS-Protection for a modern browser" do
+      route = XSSGuardRoutes::Index.new(build_context, params).call
+      route.context.response.headers["X-XSS-Protection"].should eq "1; mode=block"
+    end
+
+    it "disables the X-XSS-Protection header on older IE browsers" do
+      request = HTTP::Request.new("GET", "/so_custom")
+      request.headers["User-Agent"] = "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0)"
+      route = XSSGuardRoutes::Index.new(build_context("/so_custom", request), params).call
+      route.context.response.headers["X-XSS-Protection"].should eq "0"
     end
   end
 end

--- a/spec/lucky/secure_headers_spec.cr
+++ b/spec/lucky/secure_headers_spec.cr
@@ -58,6 +58,14 @@ class XSSGuardRoutes::Index < Lucky::Action
   end
 end
 
+class SniffGuardRoutes::Index < Lucky::Action
+  include Lucky::SecureHeaders::SetSniffGuard
+
+  get "/so_custom" do
+    text "test"
+  end
+end
+
 describe Lucky::SecureHeaders do
   describe "SetFrameGuard" do
     it "sets the X-Frame-Options header with sameorigin" do
@@ -93,6 +101,13 @@ describe Lucky::SecureHeaders do
       request.headers["User-Agent"] = "Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0)"
       route = XSSGuardRoutes::Index.new(build_context("/so_custom", request), params).call
       route.context.response.headers["X-XSS-Protection"].should eq "0"
+    end
+  end
+
+  describe "SetSniffGuard" do
+    it "sets the X-Content-Type-Options to nosniff" do
+      route = SniffGuardRoutes::Index.new(build_context, params).call
+      route.context.response.headers["X-Content-Type-Options"].should eq "nosniff"
     end
   end
 end

--- a/spec/lucky/secure_headers_spec.cr
+++ b/spec/lucky/secure_headers_spec.cr
@@ -1,0 +1,58 @@
+require "../../spec_helper"
+
+include ContextHelper
+
+class FrameGuardRoutes::WithSame < Lucky::Action
+  include Lucky::SecureHeaders::SetFrameGuard
+
+  get "/so_custom" do
+    text "test"
+  end
+
+  def frame_guard_options
+    {allow_from: "same"}
+  end
+end
+
+class FrameGuardRoutes::WithNowhere < Lucky::Action
+  include Lucky::SecureHeaders::SetFrameGuard
+
+  get "/so_custom" do
+    text "test"
+  end
+
+  def frame_guard_options
+    {allow_from: "nowhere"}
+  end
+end
+
+class FrameGuardRoutes::WithURL < Lucky::Action
+  include Lucky::SecureHeaders::SetFrameGuard
+
+  get "/so_custom" do
+    text "test"
+  end
+
+  def frame_guard_options
+    {allow_from: "https://tacotrucks.food"}
+  end
+end
+
+describe Lucky::SecureHeaders do
+  describe "SetFrameGuard" do
+    it "sets the X-Frame-Options header with sameorigin" do
+      route = FrameGuardRoutes::WithSame.new(build_context, params).call
+      route.context.response.headers["X-Frame-Options"].should eq "sameorigin"
+    end
+
+    it "sets the X-Frame-Options header with deny" do
+      route = FrameGuardRoutes::WithNowhere.new(build_context, params).call
+      route.context.response.headers["X-Frame-Options"].should eq "deny"
+    end
+
+    it "sets the X-Frame-Options header to allow from tacotrucks" do
+      route = FrameGuardRoutes::WithURL.new(build_context, params).call
+      route.context.response.headers["X-Frame-Options"].should eq "allow-from https://tacotrucks.food"
+    end
+  end
+end

--- a/spec/lucky/secure_headers_spec.cr
+++ b/spec/lucky/secure_headers_spec.cr
@@ -68,7 +68,7 @@ describe Lucky::SecureHeaders do
     end
 
     it "throws an error when given a bad value" do
-      expect_raises(Exception) do
+      expect_raises(Exception, "You set frame_guard_value to hax0rz") do
         route = FrameGuardRoutes::WithBadValue.new(build_context, params).call
       end
     end

--- a/src/lucky.cr
+++ b/src/lucky.cr
@@ -14,6 +14,7 @@ require "./lucky/http_respondable"
 require "./lucky/exceptions"
 require "./lucky/response"
 require "./lucky/cookies/*"
+require "./lucky/secure_headers/*"
 require "./lucky/*"
 
 module Lucky

--- a/src/lucky/secure_headers/set_frame_guard.cr
+++ b/src/lucky/secure_headers/set_frame_guard.cr
@@ -1,0 +1,49 @@
+module Lucky
+  module SecureHeaders
+    # This module sets the HTTP header [X-Frame-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options).
+    # It's job is responsible for deciding which site can call your site from within a frame.
+    # For more information, read up on [Clickjacking](https://en.wikipedia.org/wiki/Clickjacking).
+    #
+    # Include this module in the actions you want to add this to.
+    # A required method `frame_guard_options` must be defined`
+    # ```
+    # class BrowserAction < Lucky::Action
+    #   include Lucky::SecureHeaders::SetFrameGuard
+    #
+    #   def frame_guard_options
+    #     {allow_from: "deny"}
+    #   end
+    # end
+    # ```
+    #
+    # ### Options
+    # The `frame_guard_options` method must be defined and return `NamedTuple(allow_from: String)`
+    # The `allow_from` key can have one of 3 String values:
+    # - `"same"` or `"sameorigin"`
+    # - `"nowhere" or `"deny"`
+    # - a valid URL e.g. `"https://mysite.com"`
+    module SetFrameGuard
+      macro included
+        before set_frame_guard_header
+      end
+
+      abstract def frame_guard_options : NamedTuple(allow_from: String)
+
+      private def set_frame_guard_header
+        context.response.headers["X-Frame-Options"] = frame_guard_value(frame_guard_options)
+        continue
+      end
+
+      private def frame_guard_value(options)
+        case options[:allow_from].downcase
+        when "same", "sameorigin"
+          "sameorigin"
+        when "nowhere", "deny"
+          "deny"
+        else
+          "allow-from #{options[:allow_from]}"
+        end
+      end
+    end
+  end
+end

--- a/src/lucky/secure_headers/set_frame_guard.cr
+++ b/src/lucky/secure_headers/set_frame_guard.cr
@@ -5,22 +5,22 @@ module Lucky
     # For more information, read up on [Clickjacking](https://en.wikipedia.org/wiki/Clickjacking).
     #
     # Include this module in the actions you want to add this to.
-    # A required method `frame_guard_options` must be defined`
+    # A required method `frame_guard_value` must be defined`
     # ```
     # class BrowserAction < Lucky::Action
     #   include Lucky::SecureHeaders::SetFrameGuard
     #
-    #   def frame_guard_options
-    #     {allow_from: "deny"}
+    #   def frame_guard_value
+    #     "deny"
     #   end
     # end
     # ```
     #
     # ### Options
-    # The `frame_guard_options` method must be defined and return `NamedTuple(allow_from: String)`
-    # The `allow_from` key can have one of 3 String values:
-    # - `"same"` or `"sameorigin"`
-    # - `"nowhere" or `"deny"`
+    # The `frame_guard_value` method must be defined and return a `String`
+    # It can have one of 3 String values:
+    # - `"sameorigin"`
+    # - `"deny"`
     # - a valid URL e.g. `"https://mysite.com"`
     module SetFrameGuard
       macro included
@@ -39,12 +39,13 @@ module Lucky
         case v
         when "sameorigin", "deny"
           v
-        when /^https?:\/\/[0-9a-zA-Z_-]+\.?[0-9a-zA-Z_-].+$/
+        when /^https?:\/\/\w+./
           "allow-from #{v}"
         else
           raise <<-MESSAGE
 
           You set frame_guard_value to #{value}, but it must be one of these options:
+
             - "sameorigin"
             - "deny"
             - A valid URL

--- a/src/lucky/secure_headers/set_sniff_guard.cr
+++ b/src/lucky/secure_headers/set_sniff_guard.cr
@@ -1,0 +1,24 @@
+module Lucky
+  module SecureHeaders
+    # This module sets the HTTP header [X-Content-Type-Options](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options).
+    # It's job is responsible for disabling mime type sniffing.
+    # For more information, read up on [MIME type security](https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/gg622941(v=vs.85)).
+    #
+    # Include this module in the actions you want to add this to.
+    # ```
+    # class BrowserAction < Lucky::Action
+    #   include Lucky::SecureHeaders::SetSniffGuard
+    # end
+    # ```
+    module SetSniffGuard
+      macro included
+        before set_sniff_guard_header
+      end
+
+      private def set_sniff_guard_header
+        context.response.headers["X-Content-Type-Options"] = "nosniff"
+        continue
+      end
+    end
+  end
+end

--- a/src/lucky/secure_headers/set_xss_guard.cr
+++ b/src/lucky/secure_headers/set_xss_guard.cr
@@ -2,7 +2,7 @@ module Lucky
   module SecureHeaders
     # This module sets the HTTP header [X-XSS-Protection](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection).
     # It's job is responsible for telling the browser to not render a page if it detects cross-site scripting.
-    # For Internet Explorer browsers less than 9, it's recommended to disabled it. Read more on [Microsoft](https://blogs.msdn.microsoft.com/ieinternals/2011/01/31/controlling-the-xss-filter/).
+    # Lucky disables this header for Internet Explorer version < 9 for you as per recommendations. Read more on [Microsoft](https://blogs.msdn.microsoft.com/ieinternals/2011/01/31/controlling-the-xss-filter/).
     #
     # Include this module in the actions you want to add this to.
     # ```

--- a/src/lucky/secure_headers/set_xss_guard.cr
+++ b/src/lucky/secure_headers/set_xss_guard.cr
@@ -1,0 +1,33 @@
+module Lucky
+  module SecureHeaders
+    # This module sets the HTTP header [X-XSS-Protection](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection).
+    # It's job is responsible for telling the browser to not render a page if it detects cross-site scripting.
+    # For Internet Explorer browsers less than 9, it's recommended to disabled it. Read more on [Microsoft](https://blogs.msdn.microsoft.com/ieinternals/2011/01/31/controlling-the-xss-filter/).
+    #
+    # Include this module in the actions you want to add this to.
+    # ```
+    # class BrowserAction < Lucky::Action
+    #   include Lucky::SecureHeaders::SetXSSGuard
+    # end
+    # ```
+    module SetXSSGuard
+      macro included
+        before set_xss_guard_header
+      end
+
+      private def set_xss_guard_header
+        context.response.headers["X-XSS-Protection"] = xss_guard_value
+        continue
+      end
+
+      private def xss_guard_value
+        useragent = context.request.headers.fetch("User-Agent", "").downcase
+        value = "1; mode=block"
+        useragent.match(/msie\s+(\d+)/).try { |match|
+          value = "0" if match[1].to_i < 9
+        }
+        value
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #565

This adds in the concept of SecureHeaders modules. I'm starting with the FrameGuard, but if this all looks good, I'll add in a couple more to this PR. 

For these you will include the modules you want to use, and they will each require a specific method to be defined which returns their config options.

```crystal
class SomeAction < BrowserAction
  include Lucky::SecureHeaders::SetFrameGuard
  get "/some-action" do
    #...
  end

  def frame_guard_options
    {allow_from: "http://lucky.lvh.me:5000"}
  end
end
```

- [x] X-Frame-Options header
- [x] XSS Protection
- [x] Anti MIME sniffing