### PR TITLE
Adds a new special space tag to generate &nbsp; entity.

### DIFF
--- a/spec/lucky/specialty_tags_spec.cr
+++ b/spec/lucky/specialty_tags_spec.cr
@@ -48,12 +48,12 @@ describe Lucky::SpecialtyTags do
     HTML
   end
 
-  it "renders proper space entity" do
-    view.space.to_s.should contain <<-HTML
+  it "renders proper non-breaking space entity" do
+    view.nbsp.to_s.should contain <<-HTML
     &nbsp;
     HTML
 
-    view.space(3).to_s.should contain <<-HTML
+    view.nbsp(3).to_s.should contain <<-HTML
     &nbsp;&nbsp;&nbsp;
     HTML
   end

--- a/spec/lucky/specialty_tags_spec.cr
+++ b/spec/lucky/specialty_tags_spec.cr
@@ -1,5 +1,7 @@
 require "../../spec_helper"
 
+include ContextHelper
+
 private class TestPage
   include Lucky::HTMLPage
 
@@ -43,6 +45,16 @@ describe Lucky::SpecialtyTags do
   it "renders responsive meta tag" do
     view.responsive_meta_tag.to_s.should contain <<-HTML
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    HTML
+  end
+
+  it "renders proper space entity" do
+    view.space.to_s.should contain <<-HTML
+    &nbsp;
+    HTML
+
+    view.space(3).to_s.should contain <<-HTML
+    &nbsp;&nbsp;&nbsp;
     HTML
   end
 end

--- a/src/lucky/tags/specialty_tags.cr
+++ b/src/lucky/tags/specialty_tags.cr
@@ -58,19 +58,19 @@ module Lucky::SpecialtyTags
   end
 
   # Generates an escaped HTML `&nbsp;` entity for the number of times specified
-  # by `how_many`. By default it generates 1 space character.
+  # by `how_many`. By default it generates 1 non-breaking space character.
   #
   # ```
   # link "Home", to: Home::Index
   # span do
-  #   space
+  #   nbsp
   #   text "|"
-  #   space
+  #   nbsp
   # end
   # link "About", to: About::Index
   # ```
   # Would generate `<a href="/">Home</a><span>&nbsp;|&nbsp;</span><a href="/about">About</a>`
-  def space(how_many : Int32 = 1)
+  def nbsp(how_many : Int32 = 1)
     how_many.times { raw("&nbsp;") }
     view
   end

--- a/src/lucky/tags/specialty_tags.cr
+++ b/src/lucky/tags/specialty_tags.cr
@@ -56,4 +56,22 @@ module Lucky::SpecialtyTags
   def raw(string : String)
     view << string
   end
+
+  # Generates an escaped HTML `&nbsp;` entity for the number of times specified
+  # by `how_many`. By default it generates 1 space character.
+  #
+  # ```
+  # link "Home", to: Home::Index
+  # span do
+  #   space
+  #   text "|"
+  #   space
+  # end
+  # link "About", to: About::Index
+  # ```
+  # Would generate `<a href="/">Home</a><span>&nbsp;|&nbsp;</span><a href="/about">About</a>`
+  def space(how_many : Int32 = 1)
+    how_many.times { raw("&nbsp;") }
+    view
+  end
 end


### PR DESCRIPTION
Fixes #669 

This adds a new method `space` that generates a `&nbsp;` HTML entity character. This method takes an optional argument for the number of spaces you'd like to render. 

It can be used like:

```crystal
link "Home", to: ""
span do
  space
  text "|"
  space
end
link "About", to: ""
# <a href="">Home</a><span>&nbsp;|&nbsp;</span><a href="">About</a>
```

```crystal
text "HALP!"
space(4)
text "I'm out of tacos"
# HALP!&nbsp;&nbsp;&nbsp;&nbsp;I'm out of tacos"
```