### PR TITLE
Remove namespace requirement for components

### DIFF
--- a/spec/tasks/gen/component_spec.cr
+++ b/spec/tasks/gen/component_spec.cr
@@ -25,15 +25,15 @@ describe Gen::Component do
     io.to_s.should contain("Component name is required.")
   end
 
-  it "displays an error if given only one class" do
+  it "displays an error if not given a class" do
     with_cleanup do
       io = IO::Memory.new
-      invalid_name = "Users"
-      ARGV.push(invalid_name)
+      invalid_component = "mycomponent"
+      ARGV.push(invalid_component)
 
       Gen::Component.new.call(io)
 
-      io.to_s.should contain("Components must be namespaced")
+      io.to_s.should contain("Component name should be camel case")
     end
   end
 end

--- a/tasks/gen/component.cr
+++ b/tasks/gen/component.cr
@@ -36,8 +36,8 @@ class Gen::Component < LuckyCli::Task
   end
 
   private def invalid_format_error
-    if !component_class.includes?("::")
-      "Components must be namespaced. Example: lucky gen.component Users::Row"
+    if component_class.camelcase != component_class
+      "Component name should be camel case. Example: lucky gen.component #{component_class.camelcase}"
     end
   end
 


### PR DESCRIPTION
I wanted to use a few components w/o namespaces. It really isn't necessary so let's allow it