### PR TITLE
Write to response only updated cookies

### DIFF
--- a/spec/lucky/session_handler_spec.cr
+++ b/spec/lucky/session_handler_spec.cr
@@ -28,6 +28,19 @@ describe Lucky::SessionHandler do
     context_2.cookies.get(:email).should eq "test@example.com"
   end
 
+  it "write to response only updated cookies" do
+    request = build_request
+    # set initial cookies via header
+    request.headers.add("Cookie", "cookie1=value1; cookie2=value2")
+    context = build_context("/", request: request)
+    context.cookies.set_raw(:cookie2, "updated2")
+
+    Lucky::SessionHandler.new.call(context)
+
+    context.response.headers["Set-Cookie"].should contain("cookie2=updated2")
+    context.response.headers["Set-Cookie"].should_not contain("cookie1")
+  end
+
   it "sets a session" do
     context = build_context
     context.session.set(:email, "test@example.com")

--- a/src/lucky/session_handler.cr
+++ b/src/lucky/session_handler.cr
@@ -18,7 +18,7 @@ class Lucky::SessionHandler
   private def write_cookies(context : HTTP::Server::Context) : Void
     response = context.response
 
-    context.cookies.raw.each do |cookie|
+    context.cookies.updated.each do |cookie|
       response.cookies[cookie.name] = cookie
     end
 


### PR DESCRIPTION
Write only cookies that was set in this request. Cookies that was only read from response not written back, since that cause to lost HttpOnly and Expire options.

closes #745