### PR TITLE
Added some logging when the fallback route picks up a request.

### DIFF
--- a/src/lucky/route_not_found_handler.cr
+++ b/src/lucky/route_not_found_handler.cr
@@ -1,6 +1,6 @@
 # This HTTP::Handler takes in the current `context`,
 # then checks to see if a `fallback_action` has been defined to render that action first.
-# If no fallback has been defined, then raise a `Lucky::RouteNotFoundError` exception.
+# If no fallback has been defined, then it will raise a `Lucky::RouteNotFoundError` exception.
 #
 # This handler should be used after the `Lucky::RouteHandler`.
 #
@@ -11,7 +11,7 @@ class Lucky::RouteNotFoundHandler
 
   def call(context)
     if has_fallback?(context)
-      Lucky.logger.debug("Handled by fallback in #{fallback_action.name.to_s.colorize.bold}")
+      Lucky.logger.debug(handled_by_fallback: fallback_action.name.to_s)
       fallback_action.new(context, {} of String => String).perform_action
     else
       raise Lucky::RouteNotFoundError.new(context)

--- a/src/lucky/route_not_found_handler.cr
+++ b/src/lucky/route_not_found_handler.cr
@@ -4,6 +4,7 @@ class Lucky::RouteNotFoundHandler
 
   def call(context)
     if has_fallback?(context)
+      Lucky.logger.debug("Handled by fallback in #{fallback_action.name.to_s.colorize.bold}")
       fallback_action.new(context, {} of String => String).perform_action
     else
       raise Lucky::RouteNotFoundError.new(context)

--- a/src/lucky/route_not_found_handler.cr
+++ b/src/lucky/route_not_found_handler.cr
@@ -1,3 +1,10 @@
+# This HTTP::Handler takes in the current `context`,
+# then checks to see if a `fallback_action` has been defined to render that action first.
+# If no fallback has been defined, then raise a `Lucky::RouteNotFoundError` exception.
+#
+# This handler should be used after the `Lucky::RouteHandler`.
+#
+# See `Lucky::Routeable.fallback` for implementing the `fallback_action`.
 class Lucky::RouteNotFoundHandler
   include HTTP::Handler
   class_property fallback_action : Lucky::Action.class | Nil


### PR DESCRIPTION
## Purpose
fixes #758 

This PR adds in a single line of logging to the fallback action. This lines up with the already existing log for normal actions.

## Description
If you use the `fallback` action, when reading your log output, there's not currently a way to tell if an action was caught by the fallback. In my case, the `/favicon.ico` call was caught by the fallback, but I had no way to tell. This will output

```
web | GET /favicon.ico
web | Handled by fallback in SPA::Index
```

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`

I can add some docs to this handler, but since it's mostly private methods, not sure if that matters in this case..