### PR TITLE
refactor CookieOverflow

### DIFF
--- a/spec/lucky/cookies/cookie_jar_spec.cr
+++ b/spec/lucky/cookies/cookie_jar_spec.cr
@@ -97,6 +97,13 @@ describe Lucky::CookieJar do
       jar.get_raw(:tabs_or_spaces).http_only.should be_false
       jar.get_raw(:tabs_or_spaces).expires.not_nil!.should eq(time)
     end
+
+    it "raises an error if the cookie is > 4096 bytes" do
+      expect_raises(Lucky::Exceptions::CookieOverflow) do
+        jar = Lucky::CookieJar.empty_jar
+        jar.set_raw(:overflow, "x" * (4097 - 27)) # "overflow=x...x; path=/; HttpOnly",
+      end
+    end
   end
 
   describe "delete" do

--- a/spec/lucky/session_handler_spec.cr
+++ b/spec/lucky/session_handler_spec.cr
@@ -67,15 +67,6 @@ describe Lucky::SessionHandler do
     context_2.session.get(:email).should eq("test@example.com")
   end
 
-  it "raises an error if the cookies are > 4096 bytes" do
-    context = build_context
-    context.cookies.set(:key, String.new(Bytes.new(size: 4094)))
-
-    expect_raises(Lucky::Exceptions::CookieOverflow) do
-      Lucky::SessionHandler.new.call(context)
-    end
-  end
-
   it "writes all the proper headers when a cookie is set" do
     context = build_context
     context

--- a/src/lucky/cookies/cookie_jar.cr
+++ b/src/lucky/cookies/cookie_jar.cr
@@ -87,6 +87,9 @@ class Lucky::CookieJar
     ).tap do |cookie|
       settings.on_set.try(&.call(cookie))
     end
+    if raw_cookie.to_set_cookie_header.bytesize > MAX_COOKIE_SIZE
+      raise Lucky::Exceptions::CookieOverflow.new("size of '#{key}' cookie is too big")
+    end
     cookies[key.to_s] = set_cookies[key.to_s] = raw_cookie
   end
 

--- a/src/lucky/session_handler.cr
+++ b/src/lucky/session_handler.cr
@@ -22,13 +22,6 @@ class Lucky::SessionHandler
       response.cookies[cookie.name] = cookie
     end
 
-    response.headers.delete("Set-Cookie")
-    response.cookies.each do |cookie|
-      set_cookie_header = cookie.to_set_cookie_header
-      if set_cookie_header && set_cookie_header.bytesize > Lucky::CookieJar::MAX_COOKIE_SIZE
-        raise Lucky::Exceptions::CookieOverflow.new("size of '#{cookie.name}' cookie is too big")
-      end
-      response.headers.add("Set-Cookie", cookie.to_set_cookie_header)
-    end
+    response.cookies.add_response_headers(response.headers)
   end
 end


### PR DESCRIPTION
Check cookie size when set it, not in middleware

## Purpose
Instead of check cookie size at end of request in middleware check it when set it.

## Description

Two props:
1. more simple code
2. error stack trace will show place where bad cookie was set

## Extra 

Rails do in same way, check when cookie is set. One difference rails check size only of encrypted/signed cookies. Plain cookies size not checked.

In this commit I still check size of all cookies, encrypted and raw.
Possible we not need to check size of raw cookies.

