### PR TITLE
Upgrade Crystal 0.28.0

### DIFF
--- a/src/lucky/params.cr
+++ b/src/lucky/params.cr
@@ -367,8 +367,9 @@ class Lucky::Params
     multipart_params = {} of String => String
     multipart_files = {} of String => Lucky::UploadedFile
     body_io = IO::Memory.new(body)
-    boundary =
-      HTTP::Multipart.parse_boundary(request.headers["Content-Type"]).to_s
+
+    boundary = MIME::Multipart.parse_boundary(request.headers["Content-Type"]).to_s
+
     HTTP::FormData.parse(body_io, boundary.to_s) do |part|
       case part.headers
       when .includes_word?("Content-Disposition", "filename")

--- a/src/lucky/support/message_verifier.cr
+++ b/src/lucky/support/message_verifier.cr
@@ -47,7 +47,7 @@ module Lucky
     end
 
     private def generate_digest(data) : String
-      encode(OpenSSL::HMAC.digest(@digest, @secret, data))
+      encode(OpenSSL::HMAC.digest(OpenSSL::Algorithm.parse(@digest.to_s), @secret, data))
     end
   end
 end


### PR DESCRIPTION
I found the following changes needed to upgrade to the upcoming Crystal 0.28.0.

If some macro `compare_versions` are added it should be possible to support current versions as well.

Feel free to extract these changes and close the PR if you prefer to handle the migration in a specific way.