### PR TITLE
removed Lucky::Action::Status in favor of new built in HTTP::Status enum

### DIFF
--- a/spec/lucky/action_redirect_spec.cr
+++ b/spec/lucky/action_redirect_spec.cr
@@ -29,7 +29,7 @@ describe Lucky::Action do
     should_redirect(action, to: "/somewhere", status: 301)
 
     action = RedirectAction.new(build_context, params)
-    action.redirect to: "/somewhere", status: Lucky::Action::Status::MovedPermanently
+    action.redirect to: "/somewhere", status: HTTP::Status::MOVED_PERMANENTLY
     should_redirect(action, to: "/somewhere", status: 301)
 
     action = RedirectAction.new(build_context, params)

--- a/spec/lucky/action_rendering_spec.cr
+++ b/spec/lucky/action_rendering_spec.cr
@@ -39,7 +39,7 @@ end
 
 class Rendering::JSON::WithTypedStatus < Lucky::Action
   get "/foo" do
-    json({name: "Paul"}, status: Status::Created)
+    json({name: "Paul"}, status: HTTP::Status::CREATED)
   end
 end
 
@@ -57,7 +57,7 @@ end
 
 class Rendering::HeadOnly::WithTypedStatus < Lucky::Action
   get "/foo" do
-    head status: Status::NoContent
+    head status: HTTP::Status::NO_CONTENT
   end
 end
 
@@ -81,7 +81,7 @@ end
 
 class Rendering::Text::WithTypedStatus < Lucky::Action
   get "/foo" do
-    text "Anything", status: Status::Created
+    text "Anything", status: HTTP::Status::CREATED
   end
 end
 

--- a/spec/lucky/action_rendering_spec.cr
+++ b/spec/lucky/action_rendering_spec.cr
@@ -37,12 +37,6 @@ class Rendering::JSON::WithStatus < Lucky::Action
   end
 end
 
-class Rendering::JSON::WithTypedStatus < Lucky::Action
-  get "/foo" do
-    json({name: "Paul"}, status: HTTP::Status::CREATED)
-  end
-end
-
 class Rendering::JSON::WithSymbolStatus < Lucky::Action
   get "/foo" do
     json({name: "Paul"}, status: :created)
@@ -52,12 +46,6 @@ end
 class Rendering::HeadOnly < Lucky::Action
   get "/foo" do
     head status: 204
-  end
-end
-
-class Rendering::HeadOnly::WithTypedStatus < Lucky::Action
-  get "/foo" do
-    head status: HTTP::Status::NO_CONTENT
   end
 end
 
@@ -76,12 +64,6 @@ end
 class Rendering::Text::WithStatus < Lucky::Action
   get "/foo" do
     text "Anything", status: 201
-  end
-end
-
-class Rendering::Text::WithTypedStatus < Lucky::Action
-  get "/foo" do
-    text "Anything", status: HTTP::Status::CREATED
   end
 end
 
@@ -150,9 +132,6 @@ describe Lucky::Action do
     status = Rendering::JSON::WithStatus.new(build_context, params).call.status
     status.should eq 201
 
-    status = Rendering::JSON::WithTypedStatus.new(build_context, params).call.status
-    status.should eq 201
-
     status = Rendering::JSON::WithSymbolStatus.new(build_context, params).call.status
     status.should eq 201
   end
@@ -160,9 +139,6 @@ describe Lucky::Action do
   it "renders head response with no body" do
     response = Rendering::HeadOnly.new(build_context, params).call
     response.body.should eq ""
-    response.status.should eq 204
-
-    response = Rendering::HeadOnly::WithTypedStatus.new(build_context, params).call
     response.status.should eq 204
 
     response = Rendering::HeadOnly::WithSymbolStatus.new(build_context, params).call
@@ -175,10 +151,6 @@ describe Lucky::Action do
     response.status.should eq 200
 
     response = Rendering::Text::WithStatus.new(build_context, params).call
-    response.body.should eq "Anything"
-    response.status.should eq 201
-
-    response = Rendering::Text::WithTypedStatus.new(build_context, params).call
     response.body.should eq "Anything"
     response.status.should eq 201
 

--- a/src/lucky/action.cr
+++ b/src/lucky/action.cr
@@ -16,7 +16,4 @@ abstract class Lucky::Action
   include Lucky::ParamHelpers
   include Lucky::ActionCallbacks
   include Lucky::Redirectable
-
-  # `Lucky::Action::Status` has been removed in favor of
-  # [HTTP::Status](https://crystal-lang.org/api/0.28.0/HTTP/Status.html)
 end

--- a/src/lucky/action.cr
+++ b/src/lucky/action.cr
@@ -17,65 +17,6 @@ abstract class Lucky::Action
   include Lucky::ActionCallbacks
   include Lucky::Redirectable
 
-  enum Status
-    Continue                      = 100
-    SwitchingProtocols            = 101
-    Processing                    = 102
-    OK                            = 200
-    Created                       = 201
-    Accepted                      = 202
-    NonAuthoritativeInformation   = 203
-    NoContent                     = 204
-    ResetContent                  = 205
-    PartialContent                = 206
-    MultiStatus                   = 207
-    AlreadyReported               = 208
-    IMUsed                        = 226
-    MultipleChoices               = 300
-    MovedPermanently              = 301
-    Found                         = 302
-    SeeOther                      = 303
-    NotModified                   = 304
-    UseProxy                      = 305
-    TemporaryRedirect             = 307
-    PermanentRedirect             = 308
-    BadRequest                    = 400
-    Unauthorized                  = 401
-    PaymentRequired               = 402
-    Forbidden                     = 403
-    NotFound                      = 404
-    MethodNotAllowed              = 405
-    NotAcceptable                 = 406
-    ProxyAuthenticationRequired   = 407
-    RequestTimeout                = 408
-    Conflict                      = 409
-    Gone                          = 410
-    LengthRequired                = 411
-    PreconditionFailed            = 412
-    PayloadTooLarge               = 413
-    URITooLong                    = 414
-    UnsupportedMediaType          = 415
-    RangeNotSatisfiable           = 416
-    ExpectationFailed             = 417
-    MisdirectedRequest            = 421
-    UnprocessableEntity           = 422
-    Locked                        = 423
-    FailedDependency              = 424
-    UpgradeRequired               = 426
-    PreconditionRequired          = 428
-    TooManyRequests               = 429
-    RequestHeaderFieldsTooLarge   = 431
-    UnavailableforLegalReasons    = 451
-    InternalServerError           = 500
-    NotImplemented                = 501
-    BadGateway                    = 502
-    ServiceUnavailable            = 503
-    GatewayTimeout                = 504
-    HTTPVersionNotSupported       = 505
-    VariantAlsoNegotiates         = 506
-    InsufficientStorage           = 507
-    LoopDetected                  = 508
-    NotExtended                   = 510
-    NetworkAuthenticationRequired = 511
-  end
+  # `Lucky::Action::Status` has been removed in favor of
+  # [HTTP::Status](https://crystal-lang.org/api/0.28.0/HTTP/Status.html)
 end

--- a/src/lucky/error_handler.cr
+++ b/src/lucky/error_handler.cr
@@ -38,6 +38,6 @@ class Lucky::ErrorHandler
   end
 
   private def status_code_by_error(error : Exception)
-    Lucky::Action::Status::InternalServerError.value
+    HTTP::Status::INTERNAL_SERVER_ERROR.value
   end
 end

--- a/src/lucky/exceptions.cr
+++ b/src/lucky/exceptions.cr
@@ -25,7 +25,7 @@ module Lucky
       end
 
       def http_error_code
-        Lucky::Action::Status::UnprocessableEntity.value
+        HTTP::Status::UNPROCESSABLE_ENTITY.value
       end
     end
 

--- a/src/lucky/file_response.cr
+++ b/src/lucky/file_response.cr
@@ -12,7 +12,7 @@
 # * `filename` - default `nil`. When overridden and paired with
 #   `disposition: "attachment"` this will download file with the provided
 #   filename.
-# * status - `Int32` or `HTTP::Status` - the HTTP status code to
+# * status - `Int32` - the HTTP status code to
 #   return with.
 #
 # Examples:

--- a/src/lucky/file_response.cr
+++ b/src/lucky/file_response.cr
@@ -12,7 +12,7 @@
 # * `filename` - default `nil`. When overridden and paired with
 #   `disposition: "attachment"` this will download file with the provided
 #   filename.
-# * status - `Int32` or `Lucky::Action::Status` - the HTTP status code to
+# * status - `Int32` or `HTTP::Status` - the HTTP status code to
 #   return with.
 #
 # Examples:

--- a/src/lucky/force_ssl_handler.cr
+++ b/src/lucky/force_ssl_handler.cr
@@ -27,7 +27,7 @@ class Lucky::ForceSSLHandler
   include HTTP::Handler
 
   Habitat.create do
-    setting redirect_status : Int32 = Lucky::Action::Status::PermanentRedirect.value
+    setting redirect_status : Int32 = HTTP::Status::PERMANENT_REDIRECT.value
     setting enabled : Bool
     setting strict_transport_security : NamedTuple(max_age: Time::Span, include_subdomains: Bool)?
   end

--- a/src/lucky/protect_from_forgery.cr
+++ b/src/lucky/protect_from_forgery.cr
@@ -43,6 +43,6 @@ module Lucky::ProtectFromForgery
   end
 
   def forbid_access_because_of_bad_token : Lucky::Response
-    head HTTP::Status::FORBIDDEN
+    head :forbidden
   end
 end

--- a/src/lucky/protect_from_forgery.cr
+++ b/src/lucky/protect_from_forgery.cr
@@ -43,6 +43,6 @@ module Lucky::ProtectFromForgery
   end
 
   def forbid_access_because_of_bad_token : Lucky::Response
-    head Lucky::Action::Status::Forbidden
+    head HTTP::Status::FORBIDDEN
   end
 end

--- a/src/lucky/redirectable.cr
+++ b/src/lucky/redirectable.cr
@@ -15,7 +15,7 @@
 # redirect to: Users::Index, status: 301
 #
 # # or use the built in enum value
-# redirect to: Users::Index, status: Status::MovedPermanently
+# redirect to: Users::Index, status: HTTP::Status::MOVED_PERMANENTLY
 # ```
 #
 # You can find a list of all of the possible statuses [here](https://github.com/luckyframework/lucky/blob/master/src/lucky/action.cr).
@@ -45,12 +45,12 @@ module Lucky::Redirectable
   # Redirect to the given path, with a human friendly status
   #
   # ```crystal
-  # redirect to: "/users", status: Status::MovedPermanently
+  # redirect to: "/users", status: HTTP::Status::MOVED_PERMANENTLY
   # # Symbols can be used in place of the enum. Crystal will convert these at compile time
   # redirect to: "/users", status: :moved_permanently
   # ```
   # You can find a list of all of the possible statuses [here](https://github.com/luckyframework/lucky/blob/master/src/lucky/action.cr).
-  def redirect(to path : String, status : Lucky::Action::Status) : Lucky::TextResponse
+  def redirect(to path : String, status : HTTP::Status) : Lucky::TextResponse
     redirect(path, status.value)
   end
 

--- a/src/lucky/redirectable.cr
+++ b/src/lucky/redirectable.cr
@@ -15,7 +15,7 @@
 # redirect to: Users::Index, status: 301
 #
 # # or use the built in enum value
-# redirect to: Users::Index, status: HTTP::Status::MOVED_PERMANENTLY
+# redirect to: Users::Index, status: :moved_permanently
 # ```
 #
 # You can find a list of all of the possible statuses [here](https://github.com/luckyframework/lucky/blob/master/src/lucky/action.cr).
@@ -45,8 +45,6 @@ module Lucky::Redirectable
   # Redirect to the given path, with a human friendly status
   #
   # ```crystal
-  # redirect to: "/users", status: HTTP::Status::MOVED_PERMANENTLY
-  # # Symbols can be used in place of the enum. Crystal will convert these at compile time
   # redirect to: "/users", status: :moved_permanently
   # ```
   # You can find a list of all of the possible statuses [here](https://github.com/luckyframework/lucky/blob/master/src/lucky/action.cr).

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -138,7 +138,7 @@ module Lucky::Renderable
                    content_type : String? = nil,
                    disposition : String = "attachment",
                    filename : String? = nil,
-                   status : Lucky::Action::Status = Lucky::Action::Status::OK) : Lucky::FileResponse
+                   status : HTTP::Status = HTTP::Status::OK) : Lucky::FileResponse
     file(path, content_type, disposition, filename, status.value)
   end
 
@@ -146,7 +146,7 @@ module Lucky::Renderable
     Lucky::TextResponse.new(context, "text/plain", body, status: status)
   end
 
-  private def text(body : String, status : Lucky::Action::Status) : Lucky::TextResponse
+  private def text(body : String, status : HTTP::Status) : Lucky::TextResponse
     Lucky::TextResponse.new(context, "text/plain", body, status: status.value)
   end
 
@@ -158,7 +158,7 @@ module Lucky::Renderable
     Lucky::TextResponse.new(context, content_type: "", body: "", status: status)
   end
 
-  private def head(status : Lucky::Action::Status) : Lucky::TextResponse
+  private def head(status : HTTP::Status) : Lucky::TextResponse
     head(status.value)
   end
 
@@ -166,7 +166,7 @@ module Lucky::Renderable
     Lucky::TextResponse.new(context, "application/json", body.to_json, status)
   end
 
-  private def json(body, status : Lucky::Action::Status = nil) : Lucky::TextResponse
+  private def json(body, status : HTTP::Status = nil) : Lucky::TextResponse
     json(body, status.value)
   end
 end


### PR DESCRIPTION
## Purpose
fixes #747 

## Description
This PR removes the `Lucky::Action::Status` in favor of the built in `HTTP::Status` since the built in includes more statuses, and will be easier to maintain plus consistency. 

Pros:
* Consistent with other frameworks that will use this
* Less code in Lucky
* Maintenance moved to language
* This enum includes statuses missing from Lucky::Action
* All symbol style calls still work as normal
* Less typing when used outside of action

Cons:
* Major breaking change
* Requires crystal 0.28+ to work
* No slow deprecation release really possible with how enums work
* More typing if used in an action (HTTP::Status::CREATED vs Status::Created)

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
