### PR TITLE
remove file extenions from path params

### DIFF
--- a/spec/lucky/action_route_params_spec.cr
+++ b/spec/lucky/action_route_params_spec.cr
@@ -1,9 +1,15 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 include ContextHelper
 
 private class TestAction < Lucky::Action
   get "/test/:param_1/:param_2" do
+    text "test"
+  end
+end
+
+private class TestWithFileExtensionAction < Lucky::Action
+  get "/test/:param_1.csv" do
     text "test"
   end
 end
@@ -15,5 +21,13 @@ describe "Automatically generated param helpers" do
     action.param_2.should eq "param_2_value"
     typeof(action.param_1).should eq String
     typeof(action.param_2).should eq String
+  end
+end
+
+describe "Testing params that end with file extension" do
+  it "generates helpers for the param name" do
+    action = TestWithFileExtensionAction.new(build_context, {"param_1" => "param_1_value"})
+    action.param_1.should eq "param_1_value"
+    typeof(action.param_1).should eq String
   end
 end

--- a/src/lucky/routeable.cr
+++ b/src/lucky/routeable.cr
@@ -160,16 +160,15 @@ module Lucky::Routeable
   macro add_route(method, path, action)
     Lucky::Router.add({{ method }}, {{ path }}, {{ @type.name.id }})
 
-    {% path_parts = path.split("/").reject(&.empty?) %}
-    {% path_params = path_parts.select(&.starts_with?(":")) %}
+    {% path_parts = path.split('/').reject(&.empty?) %}
+    # gets all the params in the path, and removes any file extensions that may be present
+    {% path_params = path_parts.select(&.starts_with?(':')).map(&.gsub(/\.\w+.+$/, "")) %}
 
-    {% for part in path_parts %}
-      {% if part.starts_with?(":") %}
-        {% part = part.gsub(/:/, "").id %}
-        def {{ part }} : String
-          params.get(:{{ part }})
-        end
-      {% end %}
+    {% for part in path_params %}
+      {% part = part.gsub(/:/, "") %}
+      def {{ part.id }} : String
+        params.get(:{{ part }})
+      end
     {% end %}
 
     def self.path(*args, **named_args) : String


### PR DESCRIPTION
## Purpose
fixes #771

## Description
If you have a route that ends in a path param as well as using a file extension, you'll get a compile time error showing a syntax error. This is because it assumed the whole path param included the file extension, then tried to make a method call `def whatever.txt`. This PR removes the file extensions if they exist, even if they are doubled up like `.xml.rss`. 

```crystal
class Reports < Lucky::Action
  get "/reports/:report_id.csv" do
    text "1,2,3"
  end
end
```

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
