### PR TITLE
fixes nonsensical spec_helper requires. 

### DIFF
--- a/spec/lucky/action_callbacks_spec.cr
+++ b/spec/lucky/action_callbacks_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 include ContextHelper
 

--- a/spec/lucky/action_cookies_and_sessions_spec.cr
+++ b/spec/lucky/action_cookies_and_sessions_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 include ContextHelper
 

--- a/spec/lucky/action_redirect_spec.cr
+++ b/spec/lucky/action_redirect_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 include ContextHelper
 

--- a/spec/lucky/action_rendering_spec.cr
+++ b/spec/lucky/action_rendering_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 include ContextHelper
 

--- a/spec/lucky/action_route_params_spec.cr
+++ b/spec/lucky/action_route_params_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 include ContextHelper
 

--- a/spec/lucky/action_spec.cr
+++ b/spec/lucky/action_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 include ContextHelper
 

--- a/spec/lucky/assignable_spec.cr
+++ b/spec/lucky/assignable_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 class BasePage
   include Lucky::HTMLPage

--- a/spec/lucky/base_http_client_spec.cr
+++ b/spec/lucky/base_http_client_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 server = TestServer.new(6226)
 

--- a/spec/lucky/component_spec.cr
+++ b/spec/lucky/component_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 include ContextHelper
 

--- a/spec/lucky/cookies/flash_store_spec.cr
+++ b/spec/lucky/cookies/flash_store_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 include ContextHelper
 

--- a/spec/lucky/expose_spec.cr
+++ b/spec/lucky/expose_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 include ContextHelper
 

--- a/spec/lucky/fallback_action_spec.cr
+++ b/spec/lucky/fallback_action_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 include ContextHelper
 

--- a/spec/lucky/flash_handler_spec.cr
+++ b/spec/lucky/flash_handler_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 include ContextHelper
 

--- a/spec/lucky/forgery_protection_helpers_spec.cr
+++ b/spec/lucky/forgery_protection_helpers_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 include ContextHelper
 

--- a/spec/lucky/form_helpers_spec.cr
+++ b/spec/lucky/form_helpers_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 class FormHelpers::Index < Lucky::Action
   route { text "foo " }

--- a/spec/lucky/html_page_spec.cr
+++ b/spec/lucky/html_page_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 class TestRender
   include Lucky::HTMLPage

--- a/spec/lucky/infer_page_spec.cr
+++ b/spec/lucky/infer_page_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 class Rendering::CustomPage
   include Lucky::HTMLPage

--- a/spec/lucky/input_helpers_spec.cr
+++ b/spec/lucky/input_helpers_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 include ContextHelper
 

--- a/spec/lucky/label_helpers_spec.cr
+++ b/spec/lucky/label_helpers_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 class TestUser
   def first_name

--- a/spec/lucky/link_helpers_spec.cr
+++ b/spec/lucky/link_helpers_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 class LinkHelpers::Index < Lucky::Action
   route { text "foo" }

--- a/spec/lucky/namespaced_action_spec.cr
+++ b/spec/lucky/namespaced_action_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 class Admin::MultiWord::Users::Show < Lucky::Action
   route do

--- a/spec/lucky/nested_resource_action_spec.cr
+++ b/spec/lucky/nested_resource_action_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 class Projects::Tasks::Show < Lucky::Action
   nested_route do

--- a/spec/lucky/number_to_currency_spec.cr
+++ b/spec/lucky/number_to_currency_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 require "html"
 
 private class TestPage

--- a/spec/lucky/render_if_defined_spec.cr
+++ b/spec/lucky/render_if_defined_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 include ContextHelper
 

--- a/spec/lucky/router_spec.cr
+++ b/spec/lucky/router_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 describe Lucky::Router do
   it "routes based on the method name and path" do

--- a/spec/lucky/secure_headers_spec.cr
+++ b/spec/lucky/secure_headers_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 include ContextHelper
 

--- a/spec/lucky/select_helpers_spec.cr
+++ b/spec/lucky/select_helpers_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 private class TestPage
   include Lucky::HTMLPage

--- a/spec/lucky/specialty_tags_spec.cr
+++ b/spec/lucky/specialty_tags_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 include ContextHelper
 

--- a/spec/lucky/with_defaults_spec.cr
+++ b/spec/lucky/with_defaults_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 private class TestWithDefaultsPage
   include Lucky::HTMLPage

--- a/spec/tasks/build/release_spec.cr
+++ b/spec/tasks/build/release_spec.cr
@@ -1,4 +1,4 @@
-require "../../../spec_helper"
+require "../../spec_helper"
 
 include CleanupHelper
 

--- a/spec/tasks/exec_spec.cr
+++ b/spec/tasks/exec_spec.cr
@@ -1,4 +1,4 @@
-require "../../spec_helper"
+require "../spec_helper"
 
 describe Lucky::Exec do
   it "runs the editor" do


### PR DESCRIPTION
## Purpose
Actually fixes #548 (even though it's already closed)

## Description
Crystal currently has a bug where you can be a little lazy with your require and it still seems to work. [this PR](https://github.com/crystal-lang/crystal/pull/7758/files) will cause lucky specs to fail since most of these paths are technically wrong. This PR updates those paths. They work as they should, and shouldn't break on the next version of crystal.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
