### PR TITLE
Update shard.yml and version.cr to v0.14.0 and crystal 0.28.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,7 +1,7 @@
 name: lucky
-version: 0.13.3
+version: 0.14.0
 
-crystal: 0.27.2
+crystal: 0.28.0
 
 authors:
   - Paul Smith <paulcsmith0218@gmail.com>

--- a/src/lucky/version.cr
+++ b/src/lucky/version.cr
@@ -1,3 +1,3 @@
 module Lucky
-  VERSION = "0.13.3"
+  VERSION = "0.14.0"
 end


### PR DESCRIPTION
I saw that you had [updated the version file to 0.14.0](https://github.com/luckyframework/lucky/commit/5d0d9cf2fd7e68baf018cc2e91eafcd527b9853a) but it looks like it never got merged into master. Was this a mistake?