### PR TITLE
change `Sentry` to `LuckySentry`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Changes since v0.14
+
+- Change `Sentry` to `LuckySentry`
+
 ### Changes since v0.13
 
 - Change `Lucky::BaseApp` to `Lucky::BaseAppServer`

--- a/tasks/watch.cr
+++ b/tasks/watch.cr
@@ -6,7 +6,7 @@ require "../src/lucky/server_settings"
 require "option_parser"
 
 # Based on the sentry shard with some modifications to outut and build process.
-module Sentry
+module LuckySentry
   FILE_TIMESTAMPS  = {} of String => String # {file => timestamp}
   BROWSERSYNC_PORT = 3001
 
@@ -211,7 +211,7 @@ class Watch < LuckyCli::Task
     run_commands = ["./start_server"]
     files = ["./src/**/*.cr", "./src/**/*.ecr", "./config/**/*.cr", "./shard.lock"]
 
-    process_runner = Sentry::ProcessRunner.new(
+    process_runner = LuckySentry::ProcessRunner.new(
       files: files,
       build_commands: build_commands,
       run_commands: run_commands,


### PR DESCRIPTION
## Purpose
Fixes #782 

## Description
We can't use `Sentry` in a Lucky project right now since our own version of `Sentry` is in that namespace. This PR fixes that. I'm also open to the format `Lucky::Sentry` but perhaps we want to wait on that until we are actually rolling our own `Sentry` for users to consume.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
