### PR TITLE
Adding support for an AssetHost

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -60,7 +60,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: veelenga/ameba
-    version: ~> 0.9
+    version: ~> 0.9.0
 
 scripts:
   postinstall: script/precompile_tasks

--- a/spec/lucky/asset_helpers_spec.cr
+++ b/spec/lucky/asset_helpers_spec.cr
@@ -50,6 +50,12 @@ describe Lucky::AssetHelpers do
     it "strips the prefixed '/assets/ in path" do
       TestPage.new.strips_prefixed_asset_path.should eq "/assets/images/inside-assets-folder.png"
     end
+
+    it "prepends the asset_host configuration option" do
+      Lucky::Server.temp_config(asset_host: "https://production.com") do
+        TestPage.new.asset_path.should eq "https://production.com/images/logo-with-hash.png"
+      end
+    end
   end
 
   describe "dynamic asset helper" do
@@ -64,6 +70,12 @@ describe Lucky::AssetHelpers do
     it "raises a helpful error" do
       expect_raises Exception, "Missing asset: woops!.png" do
         TestPage.new.missing_dynamic_asset_path
+      end
+    end
+
+    it "prepends the asset_host configuration option" do
+      Lucky::Server.temp_config(asset_host: "https://production.com") do
+        TestPage.new.dynamic_asset_path.should eq "https://production.com/images/logo-with-hash.png"
       end
     end
   end

--- a/src/lucky/asset_helpers.cr
+++ b/src/lucky/asset_helpers.cr
@@ -14,7 +14,7 @@ module Lucky::AssetHelpers
 
     {% if path.is_a?(StringLiteral) %}
       {% if Lucky::AssetHelpers::ASSET_MANIFEST[path] %}
-        {{ Lucky::AssetHelpers::ASSET_MANIFEST[path] }}
+        Lucky::Server.settings.asset_host + {{ Lucky::AssetHelpers::ASSET_MANIFEST[path] }}
       {% else %}
         {% asset_paths = Lucky::AssetHelpers::ASSET_MANIFEST.keys.join(",") %}
         {{ run "../run_macros/missing_asset", path, asset_paths }}
@@ -48,7 +48,7 @@ module Lucky::AssetHelpers
   def dynamic_asset(path)
     fingerprinted_path = Lucky::AssetHelpers::ASSET_MANIFEST[path]?
     if fingerprinted_path
-      fingerprinted_path
+      Lucky::Server.settings.asset_host + fingerprinted_path
     else
       raise "Missing asset: #{path}"
     end

--- a/src/lucky/server.cr
+++ b/src/lucky/server.cr
@@ -3,5 +3,6 @@ class Lucky::Server
     setting secret_key_base : String
     setting host : String
     setting port : Int32
+    setting asset_host : String = ""
   end
 end


### PR DESCRIPTION
Added an asset_host option to the Lucky::Server.settings
That setting is prepended to the asset path. It can be configured in the
application the same way host and port are.

## Purpose
Adding an asset_host option provides a reasonable way to configure production apps to use a cdn for assets.

fixes #794 

## Description
```
Lucky::Server.configure do |settings|
  if Lucky::Env.production?
    settings.asset_host = "production.com"
  else
    settings.asset_host = "/"
  end
end
```

## Checklist
* [X] - An issue already exists detailing the issue/or feature request that this PR fixes
* [X] - All specs are formatted with `crystal tool format spec src`
* [NA] - Inline documentation has been added and/or updated
* [X] - Lucky builds on docker with `./script/setup`
* [X] - All builds and specs pass on docker with `./script/test`
