### PR TITLE
Upgrade to Crystal 0.29.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.28.0
+FROM crystallang/crystal:0.29.0
 
 RUN apt-get update && \
   apt-get install -y libgconf-2-4 build-essential curl libreadline-dev libevent-dev libssl-dev libxml2-dev libyaml-dev libgmp-dev git  && \

--- a/shard.yml
+++ b/shard.yml
@@ -1,7 +1,7 @@
 name: lucky
 version: 0.13.3
 
-crystal: 0.27.2
+crystal: 0.29.0
 
 authors:
   - Paul Smith <paulcsmith0218@gmail.com>
@@ -60,7 +60,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: veelenga/ameba
-    version: ~> 0.9.0
+    version: ~> 0.10.0
 
 scripts:
   postinstall: script/precompile_tasks


### PR DESCRIPTION
## Purpose
Fixes #796.
## Description
This upgrades Ameba to version 0.10.0 while setting the Crystal version to 0.29.0 both in `shards.yml` and `Dockerfile`.

## Checklist
* [x] An issue already exists detailing the issue/or feature request that this PR fixes
* [x] All specs are formatted with `crystal tool format spec src`
* [ ] Inline documentation has been added and/or updated
* [x] Lucky builds on docker with `./script/setup`
* [x] All builds and specs pass on docker with `./script/test`
