### PR TITLE
Fix HSTS with Time::MonthSpan and release 0.15.1

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: lucky
-version: 0.15.0
+version: 0.15.1
 
 crystal: 0.29.0
 

--- a/spec/lucky/force_ssl_handler_spec.cr
+++ b/spec/lucky/force_ssl_handler_spec.cr
@@ -66,6 +66,12 @@ describe Lucky::ForceSSLHandler do
         run_force_ssl_handler context
         context.response.headers["Strict-Transport-Security"].should eq "max-age=15552000; includeSubDomains"
       end
+
+      # Should work with Time::MonthSpan, which is returned when using 'year'
+      with_strict_transport_security({max_age: 1.year, include_subdomains: false}) do
+        run_force_ssl_handler context
+        context.response.headers["Strict-Transport-Security"].should eq "max-age=31104000"
+      end
     end
   end
 end

--- a/src/lucky/version.cr
+++ b/src/lucky/version.cr
@@ -1,3 +1,3 @@
 module Lucky
-  VERSION = "0.15.0"
+  VERSION = "0.15.1"
 end


### PR DESCRIPTION
For some reason Int#year and Int#month return a Time::MonthSpan. This
made it so setting the max_age to `1.year` did not work.

This commit makes it so Time::MonthSpans are accepted and converted to a
regular Time::Span for use as the max_age

cc @jwoertink 

I'm gonna merge and tag this so it works with the example in the generated config/server.cr file. but wanted to let you know in case you run into it