### PR TITLE
number_to_currency now returns a String instead of writing to the view

### DIFF
--- a/spec/lucky/number_to_currency_spec.cr
+++ b/spec/lucky/number_to_currency_spec.cr
@@ -11,44 +11,44 @@ end
 describe Lucky::NumberToCurrency do
   describe "number_to_currency" do
     it "accepts Float" do
-      view.number_to_currency(29.92).to_s.should eq(HTML.escape("$29.92"))
+      view.number_to_currency(29.92).should eq(HTML.escape("$29.92"))
     end
 
     it "accepts String" do
-      view.number_to_currency("92.29").to_s.should eq(HTML.escape("$92.29"))
+      view.number_to_currency("92.29").should eq(HTML.escape("$92.29"))
     end
 
     it "accepts Integer" do
-      view.number_to_currency(92).to_s.should eq(HTML.escape("$92.00"))
+      view.number_to_currency(92).should eq(HTML.escape("$92.00"))
     end
 
     describe "options" do
       it "accepts precision" do
-        view.number_to_currency(29.929_123, precision: 3).to_s.should eq(HTML.escape("$29.929"))
+        view.number_to_currency(29.929_123, precision: 3).should eq(HTML.escape("$29.929"))
       end
 
       it "accepts unit" do
-        view.number_to_currency(29.92, unit: "CAD").to_s.should eq "CAD29.92"
+        view.number_to_currency(29.92, unit: "CAD").should eq "CAD29.92"
       end
 
       it "accepts separator" do
-        view.number_to_currency(29.92, separator: "-").to_s.should eq(HTML.escape("$29-92"))
+        view.number_to_currency(29.92, separator: "-").should eq(HTML.escape("$29-92"))
       end
 
       it "accepts delimiter" do
-        view.number_to_currency(1_234_567_890.29, delimiter: "-").to_s.should eq(HTML.escape("$1-234-567-890.29"))
+        view.number_to_currency(1_234_567_890.29, delimiter: "-").should eq(HTML.escape("$1-234-567-890.29"))
       end
 
       it "accepts delimiter pattern" do
-        view.number_to_currency(1_230_000, delimiter_pattern: /(\d+?)(?=(\d\d)+(\d)(?!\d))/).to_s.should eq(HTML.escape("$12,30,000.00"))
+        view.number_to_currency(1_230_000, delimiter_pattern: /(\d+?)(?=(\d\d)+(\d)(?!\d))/).should eq(HTML.escape("$12,30,000.00"))
       end
 
       it "accepts format" do
-        view.number_to_currency("1234567890.50", format: "%n ** %u").to_s.should eq(HTML.escape("1,234,567,890.50 ** $"))
+        view.number_to_currency("1234567890.50", format: "%n ** %u").should eq(HTML.escape("1,234,567,890.50 ** $"))
       end
 
       it "accepts negative format" do
-        view.number_to_currency("-1234567890.50", negative_format: "%n ** - %u").to_s.should eq(HTML.escape("1,234,567,890.50 ** - $"))
+        view.number_to_currency("-1234567890.50", negative_format: "%n ** - %u").should eq(HTML.escape("1,234,567,890.50 ** - $"))
       end
     end
   end

--- a/src/lucky/page_helpers/number_to_currency.cr
+++ b/src/lucky/page_helpers/number_to_currency.cr
@@ -13,7 +13,7 @@ module Lucky::NumberToCurrency
                          delimiter : String = DEFAULT_DELIMITER,
                          delimiter_pattern : Regex = DEFAULT_DELIMITER_REGEX,
                          format : String = DEFAULT_FORMAT,
-                         negative_format : String = DEFAULT_FORMAT)
+                         negative_format : String = DEFAULT_FORMAT) : String
     value = value.to_s
 
     if value.to_f.sign == -1
@@ -30,6 +30,6 @@ module Lucky::NumberToCurrency
 
     number = "#{left}#{separator}#{right}"
 
-    text format.gsub("%n", number).gsub("%u", unit)
+    format.gsub("%n", number).gsub("%u", unit)
   end
 end


### PR DESCRIPTION
## Purpose
fixes #790

## Description
In a recent PR, most of the page helpers were converted to return a String instead of writing to the view via `text`. The rule is now if the method generates HTML, it writes to the view, otherwise it should return a String. This method was missed during that commit.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [ ] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [ ] - Lucky builds on docker with `./script/setup`
* [ ] - All builds and specs pass on docker with `./script/test`

Specs pass when settings avram back to 0.9.4. Since Avram renamed Field and Form stuff recently, and Lucky pulls from Avram master, specs fail. 