### PR TITLE
Reference PermittedAttribute instead of FillableField

### DIFF
--- a/spec/lucky/input_helpers_spec.cr
+++ b/spec/lucky/input_helpers_spec.cr
@@ -10,30 +10,30 @@ end
 
 class InputTestForm
   def first_name
-    Avram::Field(String).new(
+    Avram::PermittedAttribute(String).new(
       name: :first_name,
       param: "My name",
       value: "",
       form_name: "user"
-    ).fillable
+    )
   end
 
   def eula(value : String)
-    Avram::Field(String?).new(
+    Avram::PermittedAttribute(String?).new(
       name: :eula,
       param: nil,
       value: value,
       form_name: "user"
-    ).fillable
+    )
   end
 
   def admin(checked : Bool)
-    Avram::Field(Bool?).new(
+    Avram::PermittedAttribute(Bool?).new(
       name: :admin,
       param: nil,
       value: checked,
       form_name: "user"
-    ).fillable
+    )
   end
 end
 

--- a/spec/lucky/label_helpers_spec.cr
+++ b/spec/lucky/label_helpers_spec.cr
@@ -8,12 +8,12 @@ end
 
 class TestForm
   def first_name
-    Avram::Field(String).new(
+    Avram::PermittedAttribute(String).new(
       name: :first_name,
       param: "",
       value: "",
       form_name: "user"
-    ).fillable
+    )
   end
 end
 

--- a/spec/lucky/select_helpers_spec.cr
+++ b/spec/lucky/select_helpers_spec.cr
@@ -24,12 +24,12 @@ end
 
 class SomeFormWithCompany
   def company_id
-    Avram::Field(String).new(
+    Avram::PermittedAttribute(String).new(
       name: :company_id,
       param: "1",
       value: "",
       form_name: "company"
-    ).fillable
+    )
   end
 end
 

--- a/spec/lucky/with_defaults_spec.cr
+++ b/spec/lucky/with_defaults_spec.cr
@@ -46,7 +46,7 @@ describe "with_defaults" do
 end
 
 private def name_field
-  Avram::FillableField(String).new(
+  Avram::PermittedAttribute(String).new(
     name: :name,
     param: "",
     value: "",

--- a/src/lucky/tags/input_helpers.cr
+++ b/src/lucky/tags/input_helpers.cr
@@ -1,16 +1,18 @@
 module Lucky::InputHelpers
   macro error_message_for_unallowed_field
     {% raise <<-ERROR
-      The field is not fillable.
+      The attribute is not permitted.
 
       Try this...
 
-        ▸ Allow the field to be filled by adding 'fillable {field_name}' to your form object.
+        ▸ Allow the attribute to be filled by adding
+        'permit_columns {attribute_name}' to your form object.
 
-      Q. Why aren't fields fillable by default?
-      A. Malicious users could submit any field they want. For example: you
-         might have an 'admin' flag on a User. If all fields were fillable,
-         a malicious user could set the 'admin' flag to 'true' on any form.
+      Q. Why aren't column attributes permitted by default?
+      A. Malicious users could submit any value they want. For example: you
+         might have an 'admin' flag on a User. If all attributes were
+         permitted, a malicious user could set the 'admin' flag to 'true'
+         on any form.
 
       ERROR
     %}
@@ -28,14 +30,14 @@ module Lucky::InputHelpers
 
   generate_helpful_error_for textarea
 
-  def textarea(field : Avram::FillableField, **html_options)
+  def textarea(field : Avram::PermittedAttribute, **html_options)
     textarea field.param.to_s, merge_options(html_options, {
       "id"   => input_id(field),
       "name" => input_name(field),
     })
   end
 
-  def checkbox(field : Avram::FillableField(T),
+  def checkbox(field : Avram::PermittedAttribute(T),
                unchecked_value : String,
                checked_value : String,
                **html_options) forall T
@@ -47,7 +49,7 @@ module Lucky::InputHelpers
     generate_input(field, "checkbox", html_options)
   end
 
-  def checkbox(field : Avram::FillableField(Bool?), **html_options)
+  def checkbox(field : Avram::PermittedAttribute(Bool?), **html_options)
     unchecked_value = "false"
     if field.value
       html_options = merge_options(html_options, {"checked" => "true"})
@@ -62,32 +64,32 @@ module Lucky::InputHelpers
   {% for input_type in ["text", "email", "file", "color", "hidden", "number", "url", "search", "range"] %}
     generate_helpful_error_for {{input_type.id}}_input
 
-    def {{input_type.id}}_input(field : Avram::FillableField, **html_options)
+    def {{input_type.id}}_input(field : Avram::PermittedAttribute, **html_options)
       generate_input(field, {{input_type}}, html_options)
     end
 
-    def {{input_type.id}}_input(field : Avram::FillableField, attrs : Array(Symbol), **html_options)
+    def {{input_type.id}}_input(field : Avram::PermittedAttribute, attrs : Array(Symbol), **html_options)
       generate_input(field, {{input_type}}, html_options, attrs: attrs)
     end
   {% end %}
 
   generate_helpful_error_for telephone_input
 
-  def telephone_input(field : Avram::FillableField, **html_options)
+  def telephone_input(field : Avram::PermittedAttribute, **html_options)
     generate_input(field, "tel", html_options)
   end
 
-  def telephone_input(field : Avram::FillableField, attrs : Array(Symbol), **html_options)
+  def telephone_input(field : Avram::PermittedAttribute, attrs : Array(Symbol), **html_options)
     generate_input(field, "tel", html_options, attrs: attrs)
   end
 
   generate_helpful_error_for password_input
 
-  def password_input(field : Avram::FillableField, **html_options)
+  def password_input(field : Avram::PermittedAttribute, **html_options)
     generate_input(field, "password", html_options, {"value" => ""})
   end
 
-  def password_input(field : Avram::FillableField, attrs : Array(Symbol), **html_options)
+  def password_input(field : Avram::PermittedAttribute, attrs : Array(Symbol), **html_options)
     generate_input(field, "password", html_options, {"value" => ""}, attrs)
   end
 

--- a/src/lucky/tags/label_helpers.cr
+++ b/src/lucky/tags/label_helpers.cr
@@ -1,5 +1,5 @@
 module Lucky::LabelHelpers
-  def label_for(field : Avram::FillableField, **html_options)
+  def label_for(field : Avram::PermittedAttribute, **html_options)
     label_for(
       field,
       Wordsmith::Inflector.humanize(field.name.to_s),
@@ -7,14 +7,14 @@ module Lucky::LabelHelpers
     )
   end
 
-  def label_for(field : Avram::FillableField, text : String, **html_options)
+  def label_for(field : Avram::PermittedAttribute, text : String, **html_options)
     label(
       text,
       merge_options(html_options, {"for" => input_id(field)})
     )
   end
 
-  def label_for(field : Avram::FillableField, **html_options)
+  def label_for(field : Avram::PermittedAttribute, **html_options)
     label(merge_options(html_options, {"for" => input_id(field)})) do
       yield
     end

--- a/src/lucky/tags/select_helpers.cr
+++ b/src/lucky/tags/select_helpers.cr
@@ -1,13 +1,13 @@
 module Lucky::SelectHelpers
   alias SelectOption = (String | Int32 | Int64)
 
-  def select_input(field : Avram::FillableField, **html_options)
+  def select_input(field : Avram::PermittedAttribute, **html_options)
     select_tag merge_options(html_options, {"name" => input_name(field)}) do
       yield
     end
   end
 
-  def options_for_select(field : Avram::FillableField, select_options : Array(Tuple(String, SelectOption)), **html_options)
+  def options_for_select(field : Avram::PermittedAttribute, select_options : Array(Tuple(String, SelectOption)), **html_options)
     select_options.each do |option_name, option_value|
       attributes = {"value" => option_value.to_s}
 


### PR DESCRIPTION
## Purpose
This syncs up with Avram's recent commits:

d3503a161670077c1d7b14484382132ea3ab423d
b32b5a9b53688762e22c063ebad9f858cba636c0

## Description
Since Avaram's `Field`s are now called `Attribute`s, and they are `permitted_params` not `fllable` a bunch of naming changes had to happen on the lucky side.

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [ ] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
