### PR TITLE
Remove a redundant 'if'

### DIFF
--- a/src/lucky/page_helpers/text_helpers.cr
+++ b/src/lucky/page_helpers/text_helpers.cr
@@ -32,11 +32,9 @@ module Lucky::TextHelpers
   # "Four score and se...<a href="#">Read more</a>"
   # ```
   def truncate(text : String, length : Int32 = 30, omission : String = "...", separator : String | Nil = nil, escape : Bool = false, blk : Nil | Proc = nil) : Nil
-    if text
-      content = truncate_text(text, length, omission, separator)
-      raw (escape ? HTML.escape(content) : content)
-      blk.call if !blk.nil? && text.size > length
-    end
+    content = truncate_text(text, length, omission, separator)
+    raw (escape ? HTML.escape(content) : content)
+    blk.call if !blk.nil? && text.size > length
   end
 
   def truncate(text : String, length : Int32 = 30, omission : String = "...", separator : String | Nil = nil, escape : Bool = true, &block : -> _) : Nil


### PR DESCRIPTION
`text` is a `String` and won't ever be falsey.

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
