### PR TITLE
Added finishing comment to mounted components.

### DIFF
--- a/spec/lucky/component_spec.cr
+++ b/spec/lucky/component_spec.cr
@@ -68,8 +68,10 @@ describe "components rendering" do
   it "prints a comment when configured to do so" do
     Lucky::HTMLPage.temp_config(render_component_comments: true) do
       contents = TestMountPage.new(build_context).render.to_s
-      contents.should contain("<!-- Rendered by ComplexTestComponent -->")
-      contents.should contain("<!-- Rendered by ComponentWithBlock -->")
+      contents.should contain("<!-- Started: ComplexTestComponent -->")
+      contents.should contain("<!-- Finished: ComplexTestComponent -->")
+      contents.should contain("<!-- Started: ComponentWithBlock -->")
+      contents.should contain("<!-- Finished: ComponentWithBlock -->")
     end
   end
 end

--- a/src/lucky/mount_component.cr
+++ b/src/lucky/mount_component.cr
@@ -1,19 +1,46 @@
 module Lucky::MountComponent
+  # Appends the `component` to the view.
+  #
+  # When `Lucky::HTMLPage.settings.render_component_comments` is
+  # set to `true`, it will render HTML comments showing where the component
+  # starts and ends.
+  #
+  # ```
+  # mount MyComponent.new
+  # ```
   def mount(component : Lucky::BaseComponent) : Nil
-    print_component_comment(component)
-    component.view(view).render
-  end
-
-  def mount(component : Lucky::BaseComponent) : Nil
-    print_component_comment(component)
-    component.view(view).render do |*yield_args|
-      yield *yield_args
+    print_component_comment(component) do
+      component.view(view).render
     end
   end
 
-  private def print_component_comment(component : Lucky::BaseComponent)
+  # Appends the `component` to the view. Takes a block, and yields the
+  # args passed to the component.
+  #
+  # When `Lucky::HTMLPage.settings.render_component_comments` is
+  # set to `true`, it will render HTML comments showing where the component
+  # starts and ends.
+  #
+  # ```
+  # mount MyComponent.new("jane") do |name|
+  #   text name.upcase
+  # end
+  # ```
+  def mount(component : Lucky::BaseComponent) : Nil
+    print_component_comment(component) do
+      component.view(view).render do |*yield_args|
+        yield *yield_args
+      end
+    end
+  end
+
+  private def print_component_comment(component : Lucky::BaseComponent) : Nil
     if Lucky::HTMLPage.settings.render_component_comments
-      raw "<!-- Rendered by #{component.class.name} -->"
+      raw "<!-- Started: #{component.class.name} -->"
+      yield
+      raw "<!-- Finished: #{component.class.name} -->"
+    else
+      yield
     end
   end
 end


### PR DESCRIPTION
## Purpose
fixes #793 

## Description
This adds an additional ending HTML comment to show where the mounted components both start and end.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
