### PR TITLE
reverts returning a String for the highlight

### DIFF
--- a/spec/lucky/text_helpers/highlight_spec.cr
+++ b/spec/lucky/text_helpers/highlight_spec.cr
@@ -13,42 +13,42 @@ end
 describe Lucky::TextHelpers do
   describe "highlight" do
     it "highlights" do
-      view.highlight("This is a beautiful morning", "beautiful").should eq "This is a <mark>beautiful</mark> morning"
-      view.highlight("This is a beautiful morning, but also a beautiful day", "beautiful").should eq "This is a <mark>beautiful</mark> morning, but also a <mark>beautiful</mark> day"
-      view.highlight("This is a beautiful morning, but also a beautiful day", "beautiful", highlighter: "<b>\\1</b>").should eq "This is a <b>beautiful</b> morning, but also a <b>beautiful</b> day"
-      view.highlight("This text is not changed because we supplied an empty phrase", "").should eq "This text is not changed because we supplied an empty phrase"
+      view.highlight("This is a beautiful morning", "beautiful").to_s.should eq "This is a <mark>beautiful</mark> morning"
+      view.highlight("This is a beautiful morning, but also a beautiful day", "beautiful").to_s.should eq "This is a <mark>beautiful</mark> morning, but also a <mark>beautiful</mark> day"
+      view.highlight("This is a beautiful morning, but also a beautiful day", "beautiful", highlighter: "<b>\\1</b>").to_s.should eq "This is a <b>beautiful</b> morning, but also a <b>beautiful</b> day"
+      view.highlight("This text is not changed because we supplied an empty phrase", "").to_s.should eq "This text is not changed because we supplied an empty phrase"
     end
 
     it "does not highlight empty text" do
-      view.highlight("   ", "blank text is returned verbatim").should eq "   "
+      view.highlight("   ", "blank text is returned verbatim").to_s.should eq "   "
     end
 
     it "highlights with regexp" do
-      view.highlight("This is a beautiful! morning", "beautiful!").should eq "This is a <mark>beautiful!</mark> morning"
-      view.highlight("This is a beautiful! morning", "beautiful! morning").should eq "This is a <mark>beautiful! morning</mark>"
-      view.highlight("This is a beautiful? morning", "beautiful? morning").should eq "This is a <mark>beautiful? morning</mark>"
+      view.highlight("This is a beautiful! morning", "beautiful!").to_s.should eq "This is a <mark>beautiful!</mark> morning"
+      view.highlight("This is a beautiful! morning", "beautiful! morning").to_s.should eq "This is a <mark>beautiful! morning</mark>"
+      view.highlight("This is a beautiful? morning", "beautiful? morning").to_s.should eq "This is a <mark>beautiful? morning</mark>"
     end
 
     it "highlights accepts regexp" do
-      view.highlight("This day was challenging for judge Allen and his colleagues.", /\ballen\b/i).should eq "This day was challenging for judge <mark>Allen</mark> and his colleagues."
+      view.highlight("This day was challenging for judge Allen and his colleagues.", /\ballen\b/i).to_s.should eq "This day was challenging for judge <mark>Allen</mark> and his colleagues."
     end
 
     it "highlights with multiple phrases in one pass" do
-      view.highlight("wow em", %w(wow em), highlighter: "<em>\\1</em>").should eq %(<em>wow</em> <em>em</em>)
+      view.highlight("wow em", %w(wow em), highlighter: "<em>\\1</em>").to_s.should eq %(<em>wow</em> <em>em</em>)
     end
 
     it "highlights with html" do
-      view.highlight("<p>This is a beautiful morning, but also a beautiful day</p>", "beautiful").should eq "<p>This is a <mark>beautiful</mark> morning, but also a <mark>beautiful</mark> day</p>"
-      view.highlight("<p>This is a <em>beautiful</em> morning, but also a beautiful day</p>", "beautiful").should eq "<p>This is a <em><mark>beautiful</mark></em> morning, but also a <mark>beautiful</mark> day</p>"
-      view.highlight("<p>This is a <em class=\"error\">beautiful</em> morning, but also a beautiful <span class=\"last\">day</span></p>", "beautiful").should eq "<p>This is a <em class=\"error\"><mark>beautiful</mark></em> morning, but also a <mark>beautiful</mark> <span class=\"last\">day</span></p>"
-      view.highlight("<p class=\"beautiful\">This is a beautiful morning, but also a beautiful day</p>", "beautiful").should eq "<p class=\"beautiful\">This is a <mark>beautiful</mark> morning, but also a <mark>beautiful</mark> day</p>"
-      view.highlight("<p>This is a beautiful <a href=\"http://example.com/beautiful\#top?what=beautiful%20morning&when=now+then\">morning</a>, but also a beautiful day</p>", "beautiful").should eq "<p>This is a <mark>beautiful</mark> <a href=\"http://example.com/beautiful\#top?what=beautiful%20morning&when=now+then\">morning</a>, but also a <mark>beautiful</mark> day</p>"
-      view.highlight("<div>abc div</div>", "div", highlighter: "<b>\\1</b>").should eq "<div>abc <b>div</b></div>"
+      view.highlight("<p>This is a beautiful morning, but also a beautiful day</p>", "beautiful").to_s.should eq "<p>This is a <mark>beautiful</mark> morning, but also a <mark>beautiful</mark> day</p>"
+      view.highlight("<p>This is a <em>beautiful</em> morning, but also a beautiful day</p>", "beautiful").to_s.should eq "<p>This is a <em><mark>beautiful</mark></em> morning, but also a <mark>beautiful</mark> day</p>"
+      view.highlight("<p>This is a <em class=\"error\">beautiful</em> morning, but also a beautiful <span class=\"last\">day</span></p>", "beautiful").to_s.should eq "<p>This is a <em class=\"error\"><mark>beautiful</mark></em> morning, but also a <mark>beautiful</mark> <span class=\"last\">day</span></p>"
+      view.highlight("<p class=\"beautiful\">This is a beautiful morning, but also a beautiful day</p>", "beautiful").to_s.should eq "<p class=\"beautiful\">This is a <mark>beautiful</mark> morning, but also a <mark>beautiful</mark> day</p>"
+      view.highlight("<p>This is a beautiful <a href=\"http://example.com/beautiful\#top?what=beautiful%20morning&when=now+then\">morning</a>, but also a beautiful day</p>", "beautiful").to_s.should eq "<p>This is a <mark>beautiful</mark> <a href=\"http://example.com/beautiful\#top?what=beautiful%20morning&when=now+then\">morning</a>, but also a <mark>beautiful</mark> day</p>"
+      view.highlight("<div>abc div</div>", "div", highlighter: "<b>\\1</b>").to_s.should eq "<div>abc <b>div</b></div>"
     end
 
     it "highlights with block" do
-      view.highlight("one two three", ["one", "two", "three"]) { |word| "<b>#{word}</b>" }.should eq "<b>one</b> <b>two</b> <b>three</b>"
-      view.test_highlight.should eq "This is a <span data-highlight-word=\"beautiful\" data-color=\"yellow\" data-español=\"bello\">beautiful</span> morning, but also a <span data-highlight-word=\"beautiful\" data-color=\"yellow\" data-español=\"bello\">beautiful</span> day"
+      view.highlight("one two three", ["one", "two", "three"]) { |word| "<b>#{word}</b>" }.to_s.should eq "<b>one</b> <b>two</b> <b>three</b>"
+      view.test_highlight.to_s.should eq "This is a <span data-highlight-word=\"beautiful\" data-color=\"yellow\" data-español=\"bello\">beautiful</span> morning, but also a <span data-highlight-word=\"beautiful\" data-color=\"yellow\" data-español=\"bello\">beautiful</span> day"
     end
   end
 end

--- a/src/lucky/page_helpers/text_helpers.cr
+++ b/src/lucky/page_helpers/text_helpers.cr
@@ -76,6 +76,7 @@ module Lucky::TextHelpers
   # This can be customized with the `highlighter` argument.
   #
   # **Note: This method writes HTML directly to the page. It does not return a
+  # String**
   #
   # ```crystal
   # highlight("Crystal is type-safe and compiled.", phrases: ["type-safe", "compiled"])

--- a/src/lucky/page_helpers/text_helpers.cr
+++ b/src/lucky/page_helpers/text_helpers.cr
@@ -75,6 +75,8 @@ module Lucky::TextHelpers
   # `phrases` array. The default is to wrap each with the `<mark>` element.
   # This can be customized with the `highlighter` argument.
   #
+  # **Note: This method writes HTML directly to the page. It does not return a
+  #
   # ```crystal
   # highlight("Crystal is type-safe and compiled.", phrases: ["type-safe", "compiled"])
   # ```
@@ -96,18 +98,18 @@ module Lucky::TextHelpers
   # ```html
   # You're such a <strong>nice</strong> and <strong>attractive</strong> person.
   # ```
-  def highlight(text : String, phrases : Array(String | Regex), highlighter : Proc | String = "<mark>\\1</mark>") : String
+  def highlight(text : String, phrases : Array(String | Regex), highlighter : Proc | String = "<mark>\\1</mark>")
     if text.blank? || phrases.all?(&.to_s.blank?)
-      (text || "")
+      raw (text || "")
     else
       match = phrases.map do |p|
         p.is_a?(Regex) ? p.to_s : Regex.escape(p.to_s)
       end.join("|")
 
       if highlighter.is_a?(Proc)
-        text.gsub(/(#{match})(?![^<]*?>)/i, &highlighter)
+        raw text.gsub(/(#{match})(?![^<]*?>)/i, &highlighter)
       else
-        text.gsub(/(#{match})(?![^<]*?>)/i, highlighter)
+        raw text.gsub(/(#{match})(?![^<]*?>)/i, highlighter)
       end
     end
   end
@@ -117,16 +119,16 @@ module Lucky::TextHelpers
   # Exactly the same as the `highlight` that takes multiple phrases, but with a
   # singular `phrase` argument for readability.
   # ```
-  def highlight(text : String, phrases : Array(String | Regex), &block : String -> _) : String
+  def highlight(text : String, phrases : Array(String | Regex), &block : String -> _)
     highlight(text, phrases, highlighter: block)
   end
 
-  def highlight(text : String, phrase : String | Regex, highlighter : Proc | String = "<mark>\\1</mark>") : String
+  def highlight(text : String, phrase : String | Regex, highlighter : Proc | String = "<mark>\\1</mark>")
     phrases = [phrase] of String | Regex
     highlight(text, phrases, highlighter: highlighter)
   end
 
-  def highlight(text : String, phrase : String | Regex, &block : String -> _) : String
+  def highlight(text : String, phrase : String | Regex, &block : String -> _)
     phrases = [phrase] of String | Regex
     highlight(text, phrases, highlighter: block)
   end


### PR DESCRIPTION
## Purpose
fixes #792 

## Description
In https://github.com/luckyframework/lucky/pull/781 a few methods were changed to return a String instead of writing directly to the view. However, some of those methods return HTML and would still need to be passed in to `raw` to work. So this reverts this method to write back to the view.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
