### PR TITLE
Add skip_if option for LogHandler

### DIFF
--- a/spec/lucky/log_handler_spec.cr
+++ b/spec/lucky/log_handler_spec.cr
@@ -17,6 +17,19 @@ describe Lucky::LogHandler do
     called.should be_true
   end
 
+  it "skips logging if skip_if function returns true" do
+    Lucky::LogHandler.temp_config(skip_if: ->(context : HTTP::Server::Context) { true }) do
+      called = false
+      log_io = IO::Memory.new
+      context = build_context_with_io(log_io)
+
+      call_log_handler_with(log_io, context) { called = true }
+
+      log_io.to_s.should eq("")
+      called.should be_true
+    end
+  end
+
   it "logs errors" do
     log_io = IO::Memory.new
     context = build_context_with_io(log_io)
@@ -26,21 +39,6 @@ describe Lucky::LogHandler do
     end
     log_output = log_io.to_s
     log_output.should contain("an error")
-  end
-
-  context "when context is configured to be hidden from logs" do
-    it "does not log anything" do
-      called = false
-      log_io = IO::Memory.new
-      context = build_context_with_io(log_io)
-      context.hide_from_logs = true
-
-      call_log_handler_with(log_io, context) { called = true }
-
-      log_output = log_io.to_s
-      log_output.should eq("")
-      called.should be_true
-    end
   end
 end
 

--- a/spec/lucky/static_file_handler_spec.cr
+++ b/spec/lucky/static_file_handler_spec.cr
@@ -3,30 +3,13 @@ require "../spec_helper"
 include ContextHelper
 
 describe Lucky::StaticFileHandler do
-  it "hides static files from logs" do
-    Lucky::StaticFileHandler.temp_config(hide_from_logs: true) do
-      context = build_context
-      context.hide_from_logs?.should be_false
-      called = false
-
-      call_file_handler_with(context) { called = true }
-
-      called.should be_true
-      context.hide_from_logs?.should be_true
-    end
-  end
-
   it "shows static files in logs" do
-    Lucky::StaticFileHandler.temp_config(hide_from_logs: false) do
-      context = build_context
-      context.hide_from_logs?.should be_false
-      called = false
+    context = build_context
+    called = false
 
-      call_file_handler_with(context) { called = true }
+    call_file_handler_with(context) { called = true }
 
-      called.should be_true
-      context.hide_from_logs?.should be_false
-    end
+    called.should be_true
   end
 end
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -35,10 +35,6 @@ Lucky::ErrorHandler.configure do |settings|
   settings.show_debug_output = false
 end
 
-Lucky::StaticFileHandler.configure do |settings|
-  settings.hide_from_logs = true
-end
-
 Lucky::ForceSSLHandler.configure do |settings|
   settings.enabled = true
 end

--- a/src/charms/static_file_handler.cr
+++ b/src/charms/static_file_handler.cr
@@ -1,12 +1,11 @@
 require "http/server"
 
 class Lucky::StaticFileHandler < HTTP::StaticFileHandler
-  Habitat.create do
-    setting hide_from_logs : Bool
+  def call(context : HTTP::Server::Context)
+    super(context)
   end
 
-  def call(context : HTTP::Server::Context)
-    context.hide_from_logs = settings.hide_from_logs
-    super(context)
+  def self.configure(*args, **named_args, &block)
+    {% raise "All settings were removed from Lucky::StaticFileHandler. You can remove the Lucky::StaticFileHandler.configure block." %}
   end
 end

--- a/src/lucky/context_extensions.cr
+++ b/src/lucky/context_extensions.cr
@@ -1,6 +1,4 @@
 class HTTP::Server::Context
-  property? hide_from_logs : Bool = false
-
   @_cookies : Lucky::CookieJar?
 
   def cookies : Lucky::CookieJar

--- a/src/server.cr
+++ b/src/server.cr
@@ -26,10 +26,6 @@ Avram::Repo.configure do |settings|
   settings.url = ""
 end
 
-Lucky::StaticFileHandler.configure do |settings|
-  settings.hide_from_logs = true
-end
-
 Lucky::ErrorHandler.configure do |settings|
   settings.show_debug_output = true
 end


### PR DESCRIPTION
This will allow us to skip logging static files. It also allows users
to skip any kind of log they want, or to log static files if they'd
prefer.

Closes #701 