### PR TITLE
Rename modules with misspelled names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### Changes since v0.15
+
+- `Lucky::Exposeable` has been renamed to `Lucky::Exposable`
+- `Lucky::Routeable` has been renamed to `Lucky::Routable`
+
 ### v0.15 (2019-06-12)
 
 - Removed `Lucky::Action::Status`. Use Crystal's `HTTP::Status` enum. [#769](https://github.com/luckyframework/lucky/pull/769)

--- a/src/lucky/action.cr
+++ b/src/lucky/action.cr
@@ -10,8 +10,8 @@ abstract class Lucky::Action
 
   include Lucky::ActionDelegates
   include Lucky::RequestTypeHelpers
-  include Lucky::Exposeable
-  include Lucky::Routeable
+  include Lucky::Exposable
+  include Lucky::Routable
   include Lucky::Renderable
   include Lucky::ParamHelpers
   include Lucky::ActionCallbacks

--- a/src/lucky/error_action.cr
+++ b/src/lucky/error_action.cr
@@ -5,7 +5,7 @@ abstract class Lucky::ErrorAction
   include Lucky::Renderable
   include Lucky::Redirectable
   include Lucky::RequestTypeHelpers
-  include Lucky::Exposeable
+  include Lucky::Exposable
 
   getter context
 

--- a/src/lucky/exposable.cr
+++ b/src/lucky/exposable.cr
@@ -1,4 +1,4 @@
-module Lucky::Exposeable
+module Lucky::Exposable
   macro included
     EXPOSURES = [] of Symbol
 

--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -1,5 +1,5 @@
 # Methods for routing HTTP requests and their parameters to actions.
-module Lucky::Routeable
+module Lucky::Routable
   macro fallback
     Lucky::RouteNotFoundHandler.fallback_action = {{ @type.name.id }}
     setup_call_method({{ yield }})

--- a/src/lucky/route_not_found_handler.cr
+++ b/src/lucky/route_not_found_handler.cr
@@ -4,7 +4,7 @@
 #
 # This handler should be used after the `Lucky::RouteHandler`.
 #
-# See `Lucky::Routeable.fallback` for implementing the `fallback_action`.
+# See `Lucky::Routable.fallback` for implementing the `fallback_action`.
 class Lucky::RouteNotFoundHandler
   include HTTP::Handler
   class_property fallback_action : Lucky::Action.class | Nil


### PR DESCRIPTION
Fixes #825.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
