### PR TITLE
Added in memoize.

### DIFF
--- a/spec/lucky/memoize_spec.cr
+++ b/spec/lucky/memoize_spec.cr
@@ -2,76 +2,32 @@ require "../spec_helper"
 
 include ContextHelper
 
-class OnlyMemoize < Lucky::Action
-  @i = 0
-  memoize def long_task : Int32
-    proc = ->{ @i += 1 }
-    proc.call
+private class ObjectWithMemoizedMethods
+  include Lucky::Memoizable
+  getter times_method_1_called = 0
+  getter times_method_2_called = 0
+
+  memoize def method_1 : String
+    @times_method_1_called += 1
+    "method_1"
   end
 
-  get "/memoize/one" do
-    long_task
-    text long_task.to_s
-  end
-end
-
-class MultiMemoize < Lucky::Action
-  memoize def task_one : String
-    "running task_one"
-  end
-
-  memoize def task_two : Time
-    Time.utc
-  end
-
-  get "/memoize/multi" do
-    task_one
-    task_two
-    text "Still works"
-  end
-end
-
-class MemoizeOnPage < Lucky::Action
-  @seed = 0
-  memoize def big_data : Int32
-    proc = ->{ @seed += 1 }
-    proc.call
-  end
-
-  expose big_data
-
-  get "/memoze/on-page" do
-    render MemoizePage
-  end
-end
-
-class MemoizePage
-  include Lucky::HTMLPage
-
-  needs big_data : Int32
-
-  def render
-    h1 @big_data.to_s
-    h2 @big_data.to_s
-    h3 @big_data.to_s
-    h4 @big_data.to_s
-    h5 @big_data.to_s
+  memoize def method_2 : Int32
+    @times_method_2_called += 1
+    5
   end
 end
 
 describe "memoizations" do
   it "only calls the long_task once" do
-    response = OnlyMemoize.new(build_context, params).call
-    response.body.should contain "1"
-  end
+    object = ObjectWithMemoizedMethods.new
 
-  it "has no conflicts when memoizing numerous methods" do
-    response = MultiMemoize.new(build_context, params).call
-    response.body.should contain "Still works"
-  end
+    object.method_1.should eq "method_1"
+    2.times { object.method_1 }
+    object.times_method_1_called.should eq 1
 
-  it "can expose and pass memoized method to page" do
-    data = MemoizeOnPage.new(build_context, params).big_data
-    MemoizePage.new(build_context, big_data: data).render.to_s.should contain %(<h5>1</h5>)
+    object.method_2.should eq 5
+    9.times { object.method_2 }
+    object.times_method_2_called.should eq 1
   end
 end

--- a/spec/lucky/memoize_spec.cr
+++ b/spec/lucky/memoize_spec.cr
@@ -1,0 +1,77 @@
+require "../spec_helper"
+
+include ContextHelper
+
+class OnlyMemoize < Lucky::Action
+  @i = 0
+  memoize def long_task : Int32
+    proc = ->{ @i += 1 }
+    proc.call
+  end
+
+  get "/memoize/one" do
+    long_task
+    text long_task.to_s
+  end
+end
+
+class MultiMemoize < Lucky::Action
+  memoize def task_one : String
+    "running task_one"
+  end
+
+  memoize def task_two : Time
+    Time.utc
+  end
+
+  get "/memoize/multi" do
+    task_one
+    task_two
+    text "Still works"
+  end
+end
+
+class MemoizeOnPage < Lucky::Action
+  @seed = 0
+  memoize def big_data : Int32
+    proc = ->{ @seed += 1 }
+    proc.call
+  end
+
+  expose big_data
+
+  get "/memoze/on-page" do
+    render MemoizePage
+  end
+end
+
+class MemoizePage
+  include Lucky::HTMLPage
+
+  needs big_data : Int32
+
+  def render
+    h1 @big_data.to_s
+    h2 @big_data.to_s
+    h3 @big_data.to_s
+    h4 @big_data.to_s
+    h5 @big_data.to_s
+  end
+end
+
+describe "memoizations" do
+  it "only calls the long_task once" do
+    response = OnlyMemoize.new(build_context, params).call
+    response.body.should contain "1"
+  end
+
+  it "has no conflicts when memoizing numerous methods" do
+    response = MultiMemoize.new(build_context, params).call
+    response.body.should contain "Still works"
+  end
+
+  it "can expose and pass memoized method to page" do
+    data = MemoizeOnPage.new(build_context, params).big_data
+    MemoizePage.new(build_context, big_data: data).render.to_s.should contain %(<h5>1</h5>)
+  end
+end

--- a/spec/lucky/memoize_spec.cr
+++ b/spec/lucky/memoize_spec.cr
@@ -19,7 +19,7 @@ private class ObjectWithMemoizedMethods
 end
 
 describe "memoizations" do
-  it "only calls the long_task once" do
+  it "only calls the method body once" do
     object = ObjectWithMemoizedMethods.new
 
     object.method_1.should eq "method_1"

--- a/src/lucky/action.cr
+++ b/src/lucky/action.cr
@@ -11,6 +11,7 @@ abstract class Lucky::Action
   include Lucky::ActionDelegates
   include Lucky::RequestTypeHelpers
   include Lucky::Exposable
+  include Lucky::Memoizable
   include Lucky::Routable
   include Lucky::Renderable
   include Lucky::ParamHelpers

--- a/src/lucky/memoizable.cr
+++ b/src/lucky/memoizable.cr
@@ -1,0 +1,38 @@
+module Lucky::Memoizable
+  # Creates an instance variable to store the return value of the method.
+  #
+  # This allows you to create a method with an expensive or long running task
+  # that may be called multiple times without re-evaluating the method on each call.
+  #
+  # To define a memoized method, you'll use this `memoize` macro like this:
+  # ```
+  # class BrowserAction
+  #   memoize def calculate_data : ReportData
+  #     # some heavy task to return data
+  #   end
+  # end
+  # ```
+  #
+  # Now you can use the `calculate_data` method, and it will only run the heavy task
+  # the first time you call it. Each subsequent call returns the calculated value.
+  #
+  # The `memoize` method will raise a compile time exception if you forget to include
+  # a return type for your method, or if your return type is a `Union`.
+  macro memoize(method_def)
+    {% raise "Return type must not be a Union" if method_def.return_type.is_a?(Union) %}
+    {% raise "You must include a return type for memoize methods" if method_def.return_type.is_a?(Nop) %}
+
+    @__{{ method_def.name }} : {{ method_def.return_type }}? = nil
+
+    def _{{ method_def.name }}{% if method_def.args.size > 0 %}({{ method_def.args }}){% end %} : {{ method_def.return_type }}
+      {{ method_def.body }}
+    end
+
+    def {{ method_def.name }}{% if method_def.args.size > 0 %}({{ method_def.args }}){% end %} : {{ method_def.return_type }}
+      @__{{ method_def.name }} ||= -> do
+        _{{ method_def.name }}{% if method_def.args.size > 0 %}({{ method_def.args }}){% end %}
+      end.call.not_nil!
+    end
+
+  end
+end

--- a/src/lucky/memoizable.cr
+++ b/src/lucky/memoizable.cr
@@ -1,6 +1,5 @@
 module Lucky::Memoizable
-  # Caches the return value of the method. Helpful for expensive methods that are called
-  # more than once.
+  # Caches the return value of the method. Helpful for expensive methods that are called more than once.
   #
   # To memoize a method, prefix it with `memoize`:
   #


### PR DESCRIPTION
## Purpose
fixes #35

## Description
This PR gives a new macro called `memoize`. The purpose of the `memoize` macro is to allow you to define a method in your `Lucky::Action` class that may be an expensive or long running task, and have the value of that method only calculated once. 

```crystal
class SomeAction < Lucky::Action
  memoize def current_user : User
    UserQuery.first
  end
 
  expose current_user

  get "/some-action" do
    render UserPage
  end
end
```

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
