### PR TITLE
Adding in table_for usage

### DIFF
--- a/spec/tasks/gen/model_spec.cr
+++ b/spec/tasks/gen/model_spec.cr
@@ -15,7 +15,7 @@ describe Gen::Model do
 
         should_generate_migration named: "create_contact_infos.cr"
         should_create_files_with_contents io,
-          "./src/models/contact_info.cr": "table :contact_infos"
+          "./src/models/contact_info.cr": "table"
         should_create_files_with_contents io,
           "./src/models/contact_info.cr": "class ContactInfo < BaseModel",
           "./src/operations/save_contact_info.cr": "class SaveContactInfo < ContactInfo::SaveOperation",

--- a/tasks/gen/model.cr
+++ b/tasks/gen/model.cr
@@ -5,7 +5,7 @@ require "./templates/model_template"
 require "wordsmith"
 
 class Gen::Model < LuckyCli::Task
-  summary "Generate a model, query, and form"
+  summary "Generate a model, query, and save operation"
   getter io : IO = STDOUT
 
   def call(@io : IO = STDOUT)
@@ -19,7 +19,24 @@ class Gen::Model < LuckyCli::Task
   end
 
   def create_migration
-    Avram::Migrator::MigrationGenerator.new("Create#{pluralized_model_name}").generate
+    Avram::Migrator::MigrationGenerator.new(
+      "Create#{pluralized_model_name}",
+      migrate_contents: migrate_contents,
+      rollback_contents: rollback_contents
+    ).generate
+  end
+
+  private def migrate_contents
+    String.build do |string|
+      string << "create table_for(#{model_name}) do\n"
+      string << "  primary_key id : Int64\n"
+      string << "  add_timestamps\n"
+      string << "end"
+    end
+  end
+
+  private def rollback_contents : String
+    "drop table_for(#{model_name})"
   end
 
   private def pluralized_model_name

--- a/tasks/gen/resource/browser.cr
+++ b/tasks/gen/resource/browser.cr
@@ -49,7 +49,7 @@ class Gen::Resource::Browser < LuckyCli::Task
 
   private def migrate_contents : String
     String.build do |string|
-      string << "create :#{pluralized_resource.underscore} do\n"
+      string << "create table_for(#{resource_name}) do\n"
       columns.each do |column|
         string << "  add #{column.name} : #{column.type}\n"
       end

--- a/tasks/gen/templates/model/models/{{underscored_name}}.cr.ecr
+++ b/tasks/gen/templates/model/models/{{underscored_name}}.cr.ecr
@@ -1,4 +1,4 @@
 class <%= @name %> < BaseModel
-  table :<%= @pluralized_name %> do
+  table do
   end
 end


### PR DESCRIPTION
## Purpose
Companion PR to https://github.com/luckyframework/avram/pull/123

## Description
Once that Avram PR is merged in, this one can be merged in. This updates the generators to take use of the `table_for` macro. It also updates the model generation to include actual code instead of relying on comments to be added in.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
