### PR TITLE
New XML rendering option

### DIFF
--- a/spec/lucky/action_callbacks_spec.cr
+++ b/spec/lucky/action_callbacks_spec.cr
@@ -6,7 +6,7 @@ class CallbackFromActionMacro::Index < Lucky::Action
   before set_before_cookie
 
   route do
-    text "Body"
+    plain_text "Body"
   end
 
   def set_before_cookie
@@ -34,7 +34,7 @@ class Callbacks::Skipped < InheritableCallbacks
   skip set_before_cookie, overwrite_after_cookie
 
   get "/skipped-callbacks" do
-    text "Body"
+    plain_text "Body"
   end
 end
 
@@ -44,7 +44,7 @@ class Callbacks::Index < InheritableCallbacks
 
   get "/callbacks" do
     cookies.set("after", "This should be overwritten by the after ballback")
-    text "not_from_callback"
+    plain_text "not_from_callback"
   end
 
   def set_second_before_cookie
@@ -63,7 +63,7 @@ class Callbacks::HaltedBefore < Lucky::Action
   before should_not_be_reached
 
   get "/before_callbacks" do
-    text "this should not be reached"
+    plain_text "this should not be reached"
   end
 
   def redirect_me
@@ -81,7 +81,7 @@ class Callbacks::HaltedAfter < Lucky::Action
   after should_not_be_reached
 
   get "/after_callbacks" do
-    text "this should not be reached"
+    plain_text "this should not be reached"
   end
 
   def redirect_me
@@ -104,7 +104,7 @@ class Callbacks::OrderDependent < Lucky::Action
   after yellow
 
   get "/order_dependent" do
-    text "rendered"
+    plain_text "rendered"
   end
 
   def dog

--- a/spec/lucky/action_cookies_and_sessions_spec.cr
+++ b/spec/lucky/action_cookies_and_sessions_spec.cr
@@ -7,13 +7,13 @@ class Cookies::Index < Lucky::Action
     cookies.set :my_cookie, "cookie"
     session.set :my_session, "session"
 
-    text "#{cookies.get(:my_cookie)} - #{session.get(:my_session)}"
+    plain_text "#{cookies.get(:my_cookie)} - #{session.get(:my_session)}"
   end
 end
 
 class PreCookies::Index < Lucky::Action
   get "/pre_cookies" do
-    text "#{cookies.get?(:my_cookie)}"
+    plain_text "#{cookies.get?(:my_cookie)}"
   end
 end
 
@@ -21,7 +21,7 @@ class FlashCookies::Index < Lucky::Action
   get "/flash" do
     flash.success = "You did it!"
 
-    text "#{flash.success}"
+    plain_text "#{flash.success}"
   end
 end
 

--- a/spec/lucky/action_redirect_spec.cr
+++ b/spec/lucky/action_redirect_spec.cr
@@ -4,7 +4,7 @@ include ContextHelper
 
 class RedirectAction < Lucky::Action
   get "/redirect_test" do
-    text "does not matter"
+    plain_text "does not matter"
   end
 end
 

--- a/spec/lucky/action_rendering_spec.cr
+++ b/spec/lucky/action_rendering_spec.cr
@@ -73,6 +73,24 @@ class Rendering::Text::WithSymbolStatus < Lucky::Action
   end
 end
 
+class Rendering::Xml::Index < Lucky::Action
+  get "/foo" do
+    xml "<anything />"
+  end
+end
+
+class Rendering::Xml::WithStatus < Lucky::Action
+  get "/foo" do
+    xml "<anything />", status: 418
+  end
+end
+
+class Rendering::Xml::WithSymbolStatus < Lucky::Action
+  get "/foo" do
+    xml "<anything />", status: :im_a_teapot
+  end
+end
+
 class Rendering::File < Lucky::Action
   get "/file" do
     file "spec/fixtures/lucky_logo.png"
@@ -134,6 +152,18 @@ describe Lucky::Action do
 
     status = Rendering::JSON::WithSymbolStatus.new(build_context, params).call.status
     status.should eq 201
+  end
+
+  it "renders XML" do
+    response = Rendering::Xml::Index.new(build_context, params).call
+    response.body.should eq %(<anything />)
+    response.status.should eq 200
+
+    status = Rendering::Xml::WithStatus.new(build_context, params).call.status
+    status.should eq 418
+
+    status = Rendering::Xml::WithSymbolStatus.new(build_context, params).call.status
+    status.should eq 418
   end
 
   it "renders head response with no body" do

--- a/spec/lucky/action_rendering_spec.cr
+++ b/spec/lucky/action_rendering_spec.cr
@@ -57,19 +57,19 @@ end
 
 class Rendering::Text::Index < Lucky::Action
   route do
-    text "Anything"
+    plain_text "Anything"
   end
 end
 
 class Rendering::Text::WithStatus < Lucky::Action
   get "/foo" do
-    text "Anything", status: 201
+    plain_text "Anything", status: 201
   end
 end
 
 class Rendering::Text::WithSymbolStatus < Lucky::Action
   get "/foo" do
-    text "Anything", status: :created
+    plain_text "Anything", status: :created
   end
 end
 

--- a/spec/lucky/action_route_params_spec.cr
+++ b/spec/lucky/action_route_params_spec.cr
@@ -4,7 +4,7 @@ include ContextHelper
 
 private class TestAction < Lucky::Action
   get "/test/:param_1/:param_2" do
-    text "test"
+    plain_text "test"
   end
 end
 

--- a/spec/lucky/action_spec.cr
+++ b/spec/lucky/action_spec.cr
@@ -4,43 +4,43 @@ include ContextHelper
 
 class CustomRoutes::Index < Lucky::Action
   get "/so_custom" do
-    text "test"
+    plain_text "test"
   end
 end
 
 class CustomRoutes::Put < Lucky::Action
   put "/so_custom" do
-    text "test"
+    plain_text "test"
   end
 end
 
 class CustomRoutes::Post < Lucky::Action
   post "/so_custom" do
-    text "test"
+    plain_text "test"
   end
 end
 
 class CustomRoutes::Patch < Lucky::Action
   patch "/so_custom" do
-    text "test"
+    plain_text "test"
   end
 end
 
 class CustomRoutes::Trace < Lucky::Action
   trace "/so_custom" do
-    text "test"
+    plain_text "test"
   end
 end
 
 class CustomRoutes::Delete < Lucky::Action
   delete "/so_custom" do
-    text "test"
+    plain_text "test"
   end
 end
 
 class CustomRoutes::Match < Lucky::Action
   match :options, "/so_custom" do
-    text "test"
+    plain_text "test"
   end
 end
 
@@ -60,43 +60,43 @@ end
 
 class Tests::New < Lucky::Action
   route do
-    text "test"
+    plain_text "test"
   end
 end
 
 class Tests::Edit < Lucky::Action
   route do
-    text "test"
+    plain_text "test"
   end
 end
 
 class Tests::Show < Lucky::Action
   route do
-    text "test"
+    plain_text "test"
   end
 end
 
 class Tests::Delete < Lucky::Action
   route do
-    text "test"
+    plain_text "test"
   end
 end
 
 class Tests::Update < Lucky::Action
   route do
-    text "test"
+    plain_text "test"
   end
 end
 
 class Tests::Create < Lucky::Action
   route do
-    text "test"
+    plain_text "test"
   end
 end
 
 class PlainText::Index < Lucky::Action
   route do
-    text "plain"
+    plain_text "plain"
   end
 end
 
@@ -104,7 +104,7 @@ class RequiredParams::Index < Lucky::Action
   param required_page : Int32
 
   route do
-    text "required param: #{required_page}"
+    plain_text "required param: #{required_page}"
   end
 end
 
@@ -114,7 +114,7 @@ end
 
 class InheritedParams::Index < BaseActionWithParams
   route do
-    text "inherited param: #{inherit_me}"
+    plain_text "inherited param: #{inherit_me}"
   end
 end
 
@@ -129,7 +129,7 @@ class OptionalParams::Index < Lucky::Action
   param nilable_with_explicit_nil : Int32? = nil
 
   route do
-    text "optional param: #{page} #{with_int_default} #{with_int_never_nil}"
+    plain_text "optional param: #{page} #{with_int_default} #{with_int_never_nil}"
   end
 end
 
@@ -139,7 +139,7 @@ class ParamsWithDefaultParamsLast < Lucky::Action
   param no_default : String
 
   get "/args-with-defaults" do
-    text "doesn't matter"
+    plain_text "doesn't matter"
   end
 end
 

--- a/spec/lucky/error_handling_spec.cr
+++ b/spec/lucky/error_handling_spec.cr
@@ -25,7 +25,7 @@ private class FakeErrorAction < Lucky::ErrorAction
   end
 
   def handle_error(error : Exception)
-    text "Oops"
+    plain_text "Oops"
   end
 end
 

--- a/spec/lucky/fallback_action_spec.cr
+++ b/spec/lucky/fallback_action_spec.cr
@@ -4,7 +4,7 @@ include ContextHelper
 
 class Rendering::FallbackRoute < Lucky::Action
   fallback do
-    text "Hey, you found me!"
+    plain_text "Hey, you found me!"
   end
 end
 

--- a/spec/lucky/form_helpers_spec.cr
+++ b/spec/lucky/form_helpers_spec.cr
@@ -1,15 +1,15 @@
 require "../spec_helper"
 
 class FormHelpers::Index < Lucky::Action
-  route { text "foo " }
+  route { plain_text "foo " }
 end
 
 class FormHelpers::Update < Lucky::Action
-  route { text "foo " }
+  route { plain_text "foo " }
 end
 
 class FormHelpers::Create < Lucky::Action
-  route { text "foo" }
+  route { plain_text "foo" }
 end
 
 private class TestPage

--- a/spec/lucky/link_helpers_spec.cr
+++ b/spec/lucky/link_helpers_spec.cr
@@ -1,11 +1,11 @@
 require "../spec_helper"
 
 class LinkHelpers::Index < Lucky::Action
-  route { text "foo" }
+  route { plain_text "foo" }
 end
 
 class LinkHelpers::Create < Lucky::Action
-  route { text "foo" }
+  route { plain_text "foo" }
 end
 
 private class TestPage

--- a/spec/lucky/namespaced_action_spec.cr
+++ b/spec/lucky/namespaced_action_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 class Admin::MultiWord::Users::Show < Lucky::Action
   route do
-    text "plain"
+    plain_text "plain"
   end
 end
 

--- a/spec/lucky/nested_resource_action_spec.cr
+++ b/spec/lucky/nested_resource_action_spec.cr
@@ -2,13 +2,13 @@ require "../spec_helper"
 
 class Projects::Tasks::Show < Lucky::Action
   nested_route do
-    text "plain"
+    plain_text "plain"
   end
 end
 
 class Admin::Projects::Tasks::Show < Lucky::Action
   nested_route do
-    text "plain"
+    plain_text "plain"
   end
 end
 

--- a/spec/lucky/protect_from_forgery_spec.cr
+++ b/spec/lucky/protect_from_forgery_spec.cr
@@ -5,7 +5,7 @@ include ContextHelper
 class ProtectedAction::Index < Lucky::Action
   include Lucky::ProtectFromForgery
 
-  route { text "Passed" }
+  route { plain_text "Passed" }
 end
 
 describe Lucky::ProtectFromForgery do

--- a/spec/lucky/root_spec.cr
+++ b/spec/lucky/root_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 class RootAction < Lucky::Action
   get "/" do
-    text "Hello there"
+    plain_text "Hello there"
   end
 end
 

--- a/spec/lucky/route_not_found_handler_spec.cr
+++ b/spec/lucky/route_not_found_handler_spec.cr
@@ -4,7 +4,7 @@ include ContextHelper
 
 class SampleFallbackAction::Index < Lucky::Action
   fallback do
-    text "Last chance"
+    plain_text "Last chance"
   end
 end
 

--- a/spec/lucky/secure_headers_spec.cr
+++ b/spec/lucky/secure_headers_spec.cr
@@ -6,7 +6,7 @@ class FrameGuardRoutes::WithSameorigin < Lucky::Action
   include Lucky::SecureHeaders::SetFrameGuard
 
   get "/so_custom" do
-    text "test"
+    plain_text "test"
   end
 
   def frame_guard_value
@@ -18,7 +18,7 @@ class FrameGuardRoutes::WithDeny < Lucky::Action
   include Lucky::SecureHeaders::SetFrameGuard
 
   get "/so_custom" do
-    text "test"
+    plain_text "test"
   end
 
   def frame_guard_value
@@ -30,7 +30,7 @@ class FrameGuardRoutes::WithURL < Lucky::Action
   include Lucky::SecureHeaders::SetFrameGuard
 
   get "/so_custom" do
-    text "test"
+    plain_text "test"
   end
 
   def frame_guard_value
@@ -42,7 +42,7 @@ class FrameGuardRoutes::WithBadValue < Lucky::Action
   include Lucky::SecureHeaders::SetFrameGuard
 
   get "/so_custom" do
-    text "test"
+    plain_text "test"
   end
 
   def frame_guard_value
@@ -54,7 +54,7 @@ class XSSGuardRoutes::Index < Lucky::Action
   include Lucky::SecureHeaders::SetXSSGuard
 
   get "/so_custom" do
-    text "test"
+    plain_text "test"
   end
 end
 
@@ -62,7 +62,7 @@ class SniffGuardRoutes::Index < Lucky::Action
   include Lucky::SecureHeaders::SetSniffGuard
 
   get "/so_custom" do
-    text "test"
+    plain_text "test"
   end
 end
 

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -154,6 +154,10 @@ module Lucky::Renderable
     plain_text(body, status: status.value)
   end
 
+  private def text(*args, **named_args)
+    {% raise "'text' in actions has been renamed to 'plain_text'" %}
+  end
+
   @[Deprecated("`render_text deprecated. Use `plain_text` instead")]
   private def render_text(*args, **named_args) : Lucky::TextResponse
     plain_text(*args, **named_args)

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -142,24 +142,25 @@ module Lucky::Renderable
     file(path, content_type, disposition, filename, status.value)
   end
 
-  private def send_response(body : String, content_type : String, status : Int32? = nil) : Lucky::TextResponse
+  private def send_text_response(body : String, content_type : String, status : Int32? = nil) : Lucky::TextResponse
     Lucky::TextResponse.new(context, content_type, body, status: status)
   end
 
-  private def text(body : String, status : Int32? = nil) : Lucky::TextResponse
-    send_response(body, "text/plain", status)
+  private def plain_text(body : String, status : Int32? = nil) : Lucky::TextResponse
+    send_text_response(body, "text/plain", status)
   end
 
-  private def text(body : String, status : HTTP::Status) : Lucky::TextResponse
-    text(body, status: status.value)
+  private def plain_text(body : String, status : HTTP::Status) : Lucky::TextResponse
+    plain_text(body, status: status.value)
   end
 
+  @[Deprecated("`render_text deprecated. Use `plain_text` instead")]
   private def render_text(*args, **named_args) : Lucky::TextResponse
-    text(*args, **named_args)
+    plain_text(*args, **named_args)
   end
 
   private def head(status : Int32) : Lucky::TextResponse
-    send_response(body: "", content_type: "", status: status)
+    send_text_response(body: "", content_type: "", status: status)
   end
 
   private def head(status : HTTP::Status) : Lucky::TextResponse
@@ -167,7 +168,7 @@ module Lucky::Renderable
   end
 
   private def json(body, status : Int32? = nil) : Lucky::TextResponse
-    send_response(body.to_json, "application/json", status)
+    send_text_response(body.to_json, "application/json", status)
   end
 
   private def json(body, status : HTTP::Status) : Lucky::TextResponse
@@ -175,10 +176,10 @@ module Lucky::Renderable
   end
 
   private def xml(body : String, status : Int32? = nil) : Lucky::TextResponse
-    send_response(body, "text/xml", status)
+    send_text_response(body, "text/xml", status)
   end
 
-  private def xml(body, status : HTTP::Status)
+  private def xml(body, status : HTTP::Status) : Lucky::TextResponse
     xml(body, status: status.value)
   end
 end

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -142,12 +142,16 @@ module Lucky::Renderable
     file(path, content_type, disposition, filename, status.value)
   end
 
+  private def send_response(body : String, content_type : String, status : Int32? = nil) : Lucky::TextResponse
+    Lucky::TextResponse.new(context, content_type, body, status: status)
+  end
+
   private def text(body : String, status : Int32? = nil) : Lucky::TextResponse
-    Lucky::TextResponse.new(context, "text/plain", body, status: status)
+    send_response(body, "text/plain", status)
   end
 
   private def text(body : String, status : HTTP::Status) : Lucky::TextResponse
-    Lucky::TextResponse.new(context, "text/plain", body, status: status.value)
+    text(body, status: status.value)
   end
 
   private def render_text(*args, **named_args) : Lucky::TextResponse
@@ -155,7 +159,7 @@ module Lucky::Renderable
   end
 
   private def head(status : Int32) : Lucky::TextResponse
-    Lucky::TextResponse.new(context, content_type: "", body: "", status: status)
+    send_response(body: "", content_type: "", status: status)
   end
 
   private def head(status : HTTP::Status) : Lucky::TextResponse
@@ -163,10 +167,18 @@ module Lucky::Renderable
   end
 
   private def json(body, status : Int32? = nil) : Lucky::TextResponse
-    Lucky::TextResponse.new(context, "application/json", body.to_json, status)
+    send_response(body.to_json, "application/json", status)
   end
 
-  private def json(body, status : HTTP::Status = nil) : Lucky::TextResponse
-    json(body, status.value)
+  private def json(body, status : HTTP::Status) : Lucky::TextResponse
+    json(body, status: status.value)
+  end
+
+  private def xml(body : String, status : Int32? = nil) : Lucky::TextResponse
+    send_response(body, "text/xml", status)
+  end
+
+  private def xml(body, status : HTTP::Status)
+    xml(body, status: status.value)
   end
 end

--- a/tasks/gen/templates/action/{{action}}.cr.ecr
+++ b/tasks/gen/templates/action/{{action}}.cr.ecr
@@ -1,5 +1,5 @@
 class <%= @name %> < <%= @inherit_from %>
   route do
-    text "Render something in <%= @name %>"
+    plain_text "Render something in <%= @name %>"
   end
 end


### PR DESCRIPTION
## Purpose
fixes #803

## Description
This adds in a new action render method `xml` similar to `json` and `text`. This also refactors the methods a bit to proxy down to a `send_response` method which actually handles it. I also noticed a possible bug where settings a status on json requests was probably a little weird. 

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`

Site note, I wonder if these methods shouldn't be private so we can add docs to some of them and have it generated with `crystal docs`?
