### PR TITLE
passing in context to forgery meta tags. 

### DIFF
--- a/spec/lucky/forgery_protection_helpers_spec.cr
+++ b/spec/lucky/forgery_protection_helpers_spec.cr
@@ -14,7 +14,7 @@ describe Lucky::ForgeryProtectionHelpers do
     context = build_context
     context.session.set(Lucky::ProtectFromForgery::SESSION_KEY, "my_token")
 
-    view(context).csrf_hidden_input.to_s.should contain <<-HTML
+    view(context).csrf_hidden_input(context).to_s.should contain <<-HTML
     <input type="hidden" name="#{Lucky::ProtectFromForgery::PARAM_KEY}" value="my_token">
     HTML
   end
@@ -24,7 +24,7 @@ describe Lucky::ForgeryProtectionHelpers do
     context.session.set(Lucky::ProtectFromForgery::SESSION_KEY, "my_token")
     page = view(context)
 
-    page.csrf_meta_tags
+    page.csrf_meta_tags(context)
     rendered = page.perform_render.to_s
 
     rendered.should contain <<-HTML

--- a/src/lucky/tags/forgery_protection_helpers.cr
+++ b/src/lucky/tags/forgery_protection_helpers.cr
@@ -5,10 +5,10 @@ module Lucky::ForgeryProtectionHelpers
   # `Lucky::FormHelpers#form_for`. It creates a hidden input with the CSRF
   # token. THis ensures that the form is safe. If you try to submit a form
   # without a CSRF token it will fail with a 403 forbidden status code.
-  def csrf_hidden_input
+  def csrf_hidden_input(context : HTTP::Server::Context)
     input type: "hidden",
       name: ProtectFromForgery::PARAM_KEY,
-      value: ProtectFromForgery.get_token(@context)
+      value: ProtectFromForgery.get_token(context)
   end
 
   # Meta tags used for submitting AJAX links and forms
@@ -16,10 +16,10 @@ module Lucky::ForgeryProtectionHelpers
   # These tags are automatically added to MainLayout when generating a new
   # project. They are used by Rails UJS to safely submit forms and non-GET AJAZ
   # requests
-  def csrf_meta_tags
+  def csrf_meta_tags(context : HTTP::Server::Context)
     meta name: "csrf-param",
       content: ProtectFromForgery::PARAM_KEY
     meta name: "csrf-token",
-      content: ProtectFromForgery.get_token(@context)
+      content: ProtectFromForgery.get_token(context)
   end
 end


### PR DESCRIPTION
## Purpose
fixes #836 (I looked at the wrong one. #831 was already closed 😛 )

## Description
This PR fixes a little confusion. The `Shared::LayoutHead` component needs the context when it's mounted; however, if you look at the component class, there's no mention of actually using the @context, so at first glance it seems it's not needed. By passing it in to the method, we expose where it's used so it doesn't seem so "magical".

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
