### PR TITLE
Fix append/replace_class with no default

### DIFF
--- a/spec/lucky/with_defaults_spec.cr
+++ b/spec/lucky/with_defaults_spec.cr
@@ -24,6 +24,11 @@ private class TestWithDefaultsPage
       html.text_input replace_class: "replaced"
     end
 
+    # No default 'class'
+    with_defaults field: name_field do |html|
+      html.text_input append_class: "appended-without-default"
+    end
+
     view
   end
 end
@@ -42,6 +47,8 @@ describe "with_defaults" do
       .should contain %(<input type="text" id="user_name" name="user:name" value="" class="default appended classes">)
     contents
       .should contain %(<input type="text" id="user_name" name="user:name" value="" class="replaced">)
+    contents
+      .should contain %(<input type="text" id="user_name" name="user:name" value="" class="appended-without-default">)
   end
 end
 


### PR DESCRIPTION
Closes #841

This fixes an issue where 'append_class' did not work if there was no default class

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
