### PR TITLE
Also fix replace_class without defaults

### DIFF
--- a/spec/lucky/with_defaults_spec.cr
+++ b/spec/lucky/with_defaults_spec.cr
@@ -29,6 +29,10 @@ private class TestWithDefaultsPage
       html.text_input append_class: "appended-without-default"
     end
 
+    with_defaults field: name_field do |html|
+      html.text_input replace_class: "replaced-without-default"
+    end
+
     view
   end
 end
@@ -49,6 +53,8 @@ describe "with_defaults" do
       .should contain %(<input type="text" id="user_name" name="user:name" value="" class="replaced">)
     contents
       .should contain %(<input type="text" id="user_name" name="user:name" value="" class="appended-without-default">)
+    contents
+      .should contain %(<input type="text" id="user_name" name="user:name" value="" class="replaced-without-default">)
   end
 end
 

--- a/src/lucky/tags/with_defaults.cr
+++ b/src/lucky/tags/with_defaults.cr
@@ -87,13 +87,13 @@ module Lucky::WithDefaults
         {% end %}
       )
 
-      # If there is no default class and we want to append one, then
+      # If there is no default class and we want to append/replace one, then
       # the compiler blows up because the @named_args type is a Union. Where
       # one type has the 'class' key and the other doesn't.
       #
       # We fix that by making sure there is always a class key if we try to
-      # append a class.
-      {% if appended_class_arg %}
+      # append/replace a class.
+      {% if appended_class_arg || replace_class_arg %}
         args = args.merge(class: "")
       {% end %}
 


### PR DESCRIPTION
Samea as #842 but for replace_class

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
