### PR TITLE
Add spec showing that HttpMethodOverrideHandler fails on invalid json

### DIFF
--- a/spec/http_method_override_handler_spec.cr
+++ b/spec/http_method_override_handler_spec.cr
@@ -21,6 +21,14 @@ describe Lucky::HttpMethodOverrideHandler do
     it "works when there is no overridden method" do
       should_handle "GET", overridden_method: nil, and_return: "GET"
     end
+
+    it "fails if request body contains malformed json" do
+      request = build_request "GET", body: "{ \"bad_json\": 123", content_type: "application/json"
+
+      expect_raises(JSON::ParseException) do
+        Lucky::HttpMethodOverrideHandler.new.call(build_context(request: request))
+      end
+    end
   end
 end
 


### PR DESCRIPTION
Because part of this handler looks at the request body ([here](https://github.com/luckyframework/lucky/blob/master/src/lucky/params.cr#L324)), it can fail if the json is malformed.  I believe this is totally acceptable behavior.  The reason I point this out is because in lucky-cli, this handler is put before the ErrorHandler ([reference](https://github.com/luckyframework/lucky_cli/blob/master/src/web_app_skeleton/src/app_server.cr.ecr\#L5-L15)) when it probably shouldn't be. This is most likely the cause of https://github.com/luckyframework/lucky/issues/852
