### PR TITLE
Locking down 3rd party shards. Part of #806

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -60,7 +60,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: veelenga/ameba
-    version: ~> 0.10.0
+    version: 0.10.0
 
 scripts:
   postinstall: script/precompile_tasks


### PR DESCRIPTION
## Purpose
Part of #806

## Description
TL;DR: when running `shards update`, things can break. This helps to minimize that.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
