### PR TITLE
Upgrade to Crystal v0.30.0

### DIFF
--- a/spec/lucky/error_handling_spec.cr
+++ b/spec/lucky/error_handling_spec.cr
@@ -11,7 +11,7 @@ end
 private class ShortAndStoutError < Exception
   include Lucky::HttpRespondable
 
-  def http_error_code
+  def http_error_code : Int32
     418
   end
 end
@@ -20,11 +20,11 @@ private class InvalidParam < Lucky::Exceptions::InvalidParam
 end
 
 private class FakeErrorAction < Lucky::ErrorAction
-  def handle_error(error : FakeError)
+  def handle_error(error : FakeError) : Lucky::Response
     head status: 404
   end
 
-  def handle_error(error : Exception)
+  def handle_error(error : Exception) : Lucky::Response
     plain_text "Oops"
   end
 end

--- a/spec/lucky/secure_headers_spec.cr
+++ b/spec/lucky/secure_headers_spec.cr
@@ -9,7 +9,7 @@ class FrameGuardRoutes::WithSameorigin < Lucky::Action
     plain_text "test"
   end
 
-  def frame_guard_value
+  def frame_guard_value : String
     "sameorigin"
   end
 end
@@ -21,7 +21,7 @@ class FrameGuardRoutes::WithDeny < Lucky::Action
     plain_text "test"
   end
 
-  def frame_guard_value
+  def frame_guard_value : String
     "deny"
   end
 end
@@ -33,7 +33,7 @@ class FrameGuardRoutes::WithURL < Lucky::Action
     plain_text "test"
   end
 
-  def frame_guard_value
+  def frame_guard_value : String
     "https://tacotrucks.food"
   end
 end
@@ -45,7 +45,7 @@ class FrameGuardRoutes::WithBadValue < Lucky::Action
     plain_text "test"
   end
 
-  def frame_guard_value
+  def frame_guard_value : String
     "hax0rz"
   end
 end

--- a/spec/support/raw_log_formatter.cr
+++ b/spec/support/raw_log_formatter.cr
@@ -1,5 +1,5 @@
 struct RawLogFormatter < Dexter::Formatters::BaseLogFormatter
-  def format(data)
+  def format(data) : Nil
     io << data
   end
 end

--- a/src/lucky/error_action.cr
+++ b/src/lucky/error_action.cr
@@ -30,7 +30,7 @@ abstract class Lucky::ErrorAction
       head, render, redirect, json, text, etc.
 
       Example:
-        def handle_error(error : Exception)
+        def handle_error(error : Exception) : Lucky::Response
           # Returns a Lucky::Response
           # Could also be render, json, text, etc.
           head status: 500

--- a/src/lucky/exception_page.cr
+++ b/src/lucky/exception_page.cr
@@ -1,5 +1,5 @@
 class Lucky::ExceptionPage < ExceptionPage
-  def styles
+  def styles : ExceptionPage::Styles
     Styles.new(accent: lucky_green)
   end
 

--- a/src/lucky/exceptions.cr
+++ b/src/lucky/exceptions.cr
@@ -24,7 +24,7 @@ module Lucky
         "Required param \"#{param_name}\" with value \"#{param_value}\" couldn't be parsed to a \"#{param_type}\""
       end
 
-      def http_error_code
+      def http_error_code : Int32
         HTTP::Status::UNPROCESSABLE_ENTITY.value
       end
     end

--- a/src/lucky/page_helpers/time_helpers.cr
+++ b/src/lucky/page_helpers/time_helpers.cr
@@ -19,13 +19,13 @@ module Lucky::TimeHelpers
     case distance
     when 1...27   then distance == 1 ? "a day" : "#{distance} days"
     when 27...60  then "about a month"
-    when 60...365 then "#{(distance / 30).round} months"
+    when 60...365 then "#{(distance / 30).round.to_i} months"
     when 365...730
       "about a year"
     when 730...1460
-      "over #{(distance / 365).round} years"
+      "over #{(distance / 365).round.to_i} years"
     else
-      "almost #{(distance / 365).round} years"
+      "almost #{(distance / 365).round.to_i} years"
     end
   end
 

--- a/src/lucky/pretty_log_formatter.cr
+++ b/src/lucky/pretty_log_formatter.cr
@@ -84,7 +84,7 @@ struct Lucky::PrettyLogFormatter < Dexter::Formatters::BaseLogFormatter
     AnyOtherDataFormatter,
   ]
 
-  def format(data : NamedTuple) : Void
+  def format(data : NamedTuple) : Nil
     MESSAGE_FORMATTERS.each do |message_formatter|
       result = message_formatter.new(io, severity).format(data)
       break unless result.is_a?(MessageFormatter::Continue)

--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -234,7 +234,7 @@ module Lucky::Routable
 
       anchor.try do |value|
         path += "#"
-        path += URI.escape(value)
+        path += URI.encode_www_form(value)
       end
 
       Lucky::RouteHelper.new {{ method }}, path
@@ -257,9 +257,9 @@ module Lucky::Routable
         {% for part in path_parts %}
           path << "/"
           {% if part.starts_with?(":") %}
-            path << URI.escape({{ part.gsub(/:/, "").id }}.to_param)
+            path << URI.encode_www_form({{ part.gsub(/:/, "").id }}.to_param)
           {% else %}
-            path << URI.escape({{ part }})
+            path << URI.encode_www_form({{ part }})
           {% end %}
         {% end %}
       end


### PR DESCRIPTION
A `Crystal::VERSION` check around URI.encode_www_form should be added if you want lucky to be warning free but also keep working in 0.29.0.

You can double-check in crystal-lang/crystal#7997 which encode/decode method applies better.

A couple of dependencies need to be updated also as stated in https://github.com/bcardiff/lucky/commit/053b5591493bcc71b7328b85e7dd6134e931b807 after each of them are released. Do not use my forks as dependencies.

- [ ] https://github.com/luckyframework/lucky_cli/pull/379
- [x] https://github.com/luckyframework/avram/pull/176
- [x] https://github.com/paulcsmith/cry/pull/2
- [x] https://github.com/luckyframework/dexter/pull/8

There is one fix I notice along the way regarding `distance_in_days`.

Feel free to use as-is or close and use as a reference.

Thanks for all the specs that helped us discovering https://github.com/crystal-lang/crystal/issues/8020 before releasing.