### PR TITLE
Revamp mime type negotiation and verification 

### DIFF
--- a/spec/lucky/action_callbacks_spec.cr
+++ b/spec/lucky/action_callbacks_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 include ContextHelper
 
-class CallbackFromActionMacro::Index < Lucky::Action
+class CallbackFromActionMacro::Index < TestAction
   before set_before_cookie
 
   route do
@@ -15,7 +15,7 @@ class CallbackFromActionMacro::Index < Lucky::Action
   end
 end
 
-abstract class InheritableCallbacks < Lucky::Action
+abstract class InheritableCallbacks < TestAction
   before set_before_cookie
   after overwrite_after_cookie
 
@@ -58,7 +58,7 @@ class Callbacks::Index < InheritableCallbacks
   end
 end
 
-class Callbacks::HaltedBefore < Lucky::Action
+class Callbacks::HaltedBefore < TestAction
   before redirect_me
   before should_not_be_reached
 
@@ -76,7 +76,7 @@ class Callbacks::HaltedBefore < Lucky::Action
   end
 end
 
-class Callbacks::HaltedAfter < Lucky::Action
+class Callbacks::HaltedAfter < TestAction
   after redirect_me
   after should_not_be_reached
 
@@ -94,7 +94,7 @@ class Callbacks::HaltedAfter < Lucky::Action
   end
 end
 
-class Callbacks::OrderDependent < Lucky::Action
+class Callbacks::OrderDependent < TestAction
   getter callback_data
   @callback_data = [] of String
 

--- a/spec/lucky/action_cookies_and_sessions_spec.cr
+++ b/spec/lucky/action_cookies_and_sessions_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 include ContextHelper
 
-class Cookies::Index < Lucky::Action
+class Cookies::Index < TestAction
   get "/cookies" do
     cookies.set :my_cookie, "cookie"
     session.set :my_session, "session"
@@ -11,13 +11,13 @@ class Cookies::Index < Lucky::Action
   end
 end
 
-class PreCookies::Index < Lucky::Action
+class PreCookies::Index < TestAction
   get "/pre_cookies" do
     plain_text "#{cookies.get?(:my_cookie)}"
   end
 end
 
-class FlashCookies::Index < Lucky::Action
+class FlashCookies::Index < TestAction
   get "/flash" do
     flash.success = "You did it!"
 

--- a/spec/lucky/action_redirect_spec.cr
+++ b/spec/lucky/action_redirect_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 include ContextHelper
 
-class RedirectAction < Lucky::Action
+class RedirectAction < TestAction
   get "/redirect_test" do
     plain_text "does not matter"
   end

--- a/spec/lucky/action_rendering_spec.cr
+++ b/spec/lucky/action_rendering_spec.cr
@@ -13,97 +13,97 @@ class Rendering::IndexPage
   end
 end
 
-class Rendering::Index < Lucky::Action
+class Rendering::Index < TestAction
   route do
     render title: "Anything", arg2: "testing multiple args"
   end
 end
 
-class Namespaced::Rendering::Index < Lucky::Action
+class Namespaced::Rendering::Index < TestAction
   route do
     render ::Rendering::IndexPage, title: "Anything", arg2: "testing multiple args"
   end
 end
 
-class Rendering::JSON::Index < Lucky::Action
+class Rendering::JSON::Index < TestAction
   route do
     json({name: "Paul"})
   end
 end
 
-class Rendering::JSON::WithStatus < Lucky::Action
+class Rendering::JSON::WithStatus < TestAction
   get "/foo" do
     json({name: "Paul"}, status: 201)
   end
 end
 
-class Rendering::JSON::WithSymbolStatus < Lucky::Action
+class Rendering::JSON::WithSymbolStatus < TestAction
   get "/foo" do
     json({name: "Paul"}, status: :created)
   end
 end
 
-class Rendering::HeadOnly < Lucky::Action
+class Rendering::HeadOnly < TestAction
   get "/foo" do
     head status: 204
   end
 end
 
-class Rendering::HeadOnly::WithSymbolStatus < Lucky::Action
+class Rendering::HeadOnly::WithSymbolStatus < TestAction
   get "/foo" do
     head status: :no_content
   end
 end
 
-class Rendering::Text::Index < Lucky::Action
+class Rendering::Text::Index < TestAction
   route do
     plain_text "Anything"
   end
 end
 
-class Rendering::Text::WithStatus < Lucky::Action
+class Rendering::Text::WithStatus < TestAction
   get "/foo" do
     plain_text "Anything", status: 201
   end
 end
 
-class Rendering::Text::WithSymbolStatus < Lucky::Action
+class Rendering::Text::WithSymbolStatus < TestAction
   get "/foo" do
     plain_text "Anything", status: :created
   end
 end
 
-class Rendering::Xml::Index < Lucky::Action
+class Rendering::Xml::Index < TestAction
   get "/foo" do
     xml "<anything />"
   end
 end
 
-class Rendering::Xml::WithStatus < Lucky::Action
+class Rendering::Xml::WithStatus < TestAction
   get "/foo" do
     xml "<anything />", status: 418
   end
 end
 
-class Rendering::Xml::WithSymbolStatus < Lucky::Action
+class Rendering::Xml::WithSymbolStatus < TestAction
   get "/foo" do
     xml "<anything />", status: :im_a_teapot
   end
 end
 
-class Rendering::File < Lucky::Action
+class Rendering::File < TestAction
   get "/file" do
     file "spec/fixtures/lucky_logo.png"
   end
 end
 
-class Rendering::File::Inline < Lucky::Action
+class Rendering::File::Inline < TestAction
   get "/foo" do
     file "spec/fixtures/lucky_logo.png", disposition: "inline"
   end
 end
 
-class Rendering::File::CustomFilename < Lucky::Action
+class Rendering::File::CustomFilename < TestAction
   get "/foo" do
     file "spec/fixtures/lucky_logo.png",
       disposition: "attachment",
@@ -111,7 +111,7 @@ class Rendering::File::CustomFilename < Lucky::Action
   end
 end
 
-class Rendering::File::CustomContentType < Lucky::Action
+class Rendering::File::CustomContentType < TestAction
   get "/foo" do
     file "spec/fixtures/plain_text",
       disposition: "attachment",
@@ -120,7 +120,7 @@ class Rendering::File::CustomContentType < Lucky::Action
   end
 end
 
-class Rendering::File::Missing < Lucky::Action
+class Rendering::File::Missing < TestAction
   get "/foo" do
     file "new_file_who_dis"
   end

--- a/spec/lucky/action_route_params_spec.cr
+++ b/spec/lucky/action_route_params_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 include ContextHelper
 
-private class TestAction < Lucky::Action
+private class TestAction < TestAction
   get "/test/:param_1/:param_2" do
     plain_text "test"
   end

--- a/spec/lucky/action_spec.cr
+++ b/spec/lucky/action_spec.cr
@@ -2,43 +2,43 @@ require "../spec_helper"
 
 include ContextHelper
 
-class CustomRoutes::Index < Lucky::Action
+class CustomRoutes::Index < TestAction
   get "/so_custom" do
     plain_text "test"
   end
 end
 
-class CustomRoutes::Put < Lucky::Action
+class CustomRoutes::Put < TestAction
   put "/so_custom" do
     plain_text "test"
   end
 end
 
-class CustomRoutes::Post < Lucky::Action
+class CustomRoutes::Post < TestAction
   post "/so_custom" do
     plain_text "test"
   end
 end
 
-class CustomRoutes::Patch < Lucky::Action
+class CustomRoutes::Patch < TestAction
   patch "/so_custom" do
     plain_text "test"
   end
 end
 
-class CustomRoutes::Trace < Lucky::Action
+class CustomRoutes::Trace < TestAction
   trace "/so_custom" do
     plain_text "test"
   end
 end
 
-class CustomRoutes::Delete < Lucky::Action
+class CustomRoutes::Delete < TestAction
   delete "/so_custom" do
     plain_text "test"
   end
 end
 
-class CustomRoutes::Match < Lucky::Action
+class CustomRoutes::Match < TestAction
   match :options, "/so_custom" do
     plain_text "test"
   end
@@ -52,55 +52,55 @@ class Tests::IndexPage
   end
 end
 
-class Tests::Index < Lucky::Action
+class Tests::Index < TestAction
   route do
     render
   end
 end
 
-class Tests::New < Lucky::Action
+class Tests::New < TestAction
   route do
     plain_text "test"
   end
 end
 
-class Tests::Edit < Lucky::Action
+class Tests::Edit < TestAction
   route do
     plain_text "test"
   end
 end
 
-class Tests::Show < Lucky::Action
+class Tests::Show < TestAction
   route do
     plain_text "test"
   end
 end
 
-class Tests::Delete < Lucky::Action
+class Tests::Delete < TestAction
   route do
     plain_text "test"
   end
 end
 
-class Tests::Update < Lucky::Action
+class Tests::Update < TestAction
   route do
     plain_text "test"
   end
 end
 
-class Tests::Create < Lucky::Action
+class Tests::Create < TestAction
   route do
     plain_text "test"
   end
 end
 
-class PlainText::Index < Lucky::Action
+class PlainText::Index < TestAction
   route do
     plain_text "plain"
   end
 end
 
-class RequiredParams::Index < Lucky::Action
+class RequiredParams::Index < TestAction
   param required_page : Int32
 
   route do
@@ -108,7 +108,7 @@ class RequiredParams::Index < Lucky::Action
   end
 end
 
-abstract class BaseActionWithParams < Lucky::Action
+abstract class BaseActionWithParams < TestAction
   param inherit_me : String
 end
 
@@ -118,7 +118,7 @@ class InheritedParams::Index < BaseActionWithParams
   end
 end
 
-class OptionalParams::Index < Lucky::Action
+class OptionalParams::Index < TestAction
   param page : Int32?
   param with_default : String? = "default"
   param with_int_default : Int32? = 1
@@ -133,7 +133,7 @@ class OptionalParams::Index < Lucky::Action
   end
 end
 
-class ParamsWithDefaultParamsLast < Lucky::Action
+class ParamsWithDefaultParamsLast < TestAction
   param has_default : String = "default"
   param has_nil_default : String?
   param no_default : String

--- a/spec/lucky/expose_spec.cr
+++ b/spec/lucky/expose_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 include ContextHelper
 
-class OnlyExpose < Lucky::Action
+class OnlyExpose < TestAction
   expose :name
 
   get "/expose" do
@@ -24,7 +24,7 @@ class OnlyExposePage
   end
 end
 
-abstract class BaseExposureAction < Lucky::Action
+abstract class BaseExposureAction < TestAction
   expose :expose_one
 
   def expose_one

--- a/spec/lucky/fallback_action_spec.cr
+++ b/spec/lucky/fallback_action_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 include ContextHelper
 
-class Rendering::FallbackRoute < Lucky::Action
+class Rendering::FallbackRoute < TestAction
   fallback do
     plain_text "Hey, you found me!"
   end

--- a/spec/lucky/form_helpers_spec.cr
+++ b/spec/lucky/form_helpers_spec.cr
@@ -1,14 +1,14 @@
 require "../spec_helper"
 
-class FormHelpers::Index < Lucky::Action
+class FormHelpers::Index < TestAction
   route { plain_text "foo " }
 end
 
-class FormHelpers::Update < Lucky::Action
+class FormHelpers::Update < TestAction
   route { plain_text "foo " }
 end
 
-class FormHelpers::Create < Lucky::Action
+class FormHelpers::Create < TestAction
   route { plain_text "foo" }
 end
 

--- a/spec/lucky/infer_page_spec.cr
+++ b/spec/lucky/infer_page_spec.cr
@@ -11,13 +11,13 @@ class Rendering::CustomPage
   end
 end
 
-class Rendering::Foo < Lucky::Action
+class Rendering::Foo < TestAction
   get "/foo" do
     render Rendering::CustomPage, title: "EditPage", arg2: "testing_multiple_args"
   end
 end
 
-class Rendering::WithinSameNameSpace < Lucky::Action
+class Rendering::WithinSameNameSpace < TestAction
   get "/in-namespace" do
     render CustomPage, title: "WithinSameNameSpace", arg2: "testing_multiple_args"
   end

--- a/spec/lucky/link_helpers_spec.cr
+++ b/spec/lucky/link_helpers_spec.cr
@@ -1,10 +1,10 @@
 require "../spec_helper"
 
-class LinkHelpers::Index < Lucky::Action
+class LinkHelpers::Index < TestAction
   route { plain_text "foo" }
 end
 
-class LinkHelpers::Create < Lucky::Action
+class LinkHelpers::Create < TestAction
   route { plain_text "foo" }
 end
 

--- a/spec/lucky/mime_type_spec.cr
+++ b/spec/lucky/mime_type_spec.cr
@@ -1,0 +1,62 @@
+require "../spec_helper"
+
+include ContextHelper
+
+describe Lucky::MimeType do
+  describe "known_formats" do
+    it "returns :html even though there is no mapping" do
+      Lucky::MimeType.known_formats.should contain(:html)
+    end
+  end
+
+  describe "determine_clients_desired_format" do
+    it "returns the format for the 'Accept' header if it is an AJAX request" do
+      format = determine_format("accept": "application/json", "X-Requested-With": "XmlHttpRequest")
+      format.should eq(:json)
+    end
+
+    it "returns the format for the 'Accept' header if it is not the default browser header " do
+      format = determine_format("accept": "application/json")
+      format.should eq(:json)
+    end
+
+    it "returns :ajax if it is an AJAX request and no 'Accept' header is given" do
+      format = determine_format("X-Requested-With": "XmlHttpRequest")
+      format.should eq(:ajax)
+    end
+
+    describe "when the 'Accept' header is the default browser header, and it is not an AJAX request" do
+      it "returns :html if :html is an accepted format" do
+        default_browser_header = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+        format = determine_format(default_format: :csv, headers: {"accept": default_browser_header}, accepted_formats: [:html, :csv])
+        format.should eq(:html)
+      end
+
+      it "returns the 'default_format' if :html is NOT an accepted format" do
+        default_browser_header = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+        format = determine_format(default_format: :csv, "accept": default_browser_header)
+        format.should eq(:csv)
+      end
+    end
+
+    it "falls back to 'default_format' if no accept header and not AJAX" do
+      format = determine_format(default_format: :csv)
+      format.should eq(:csv)
+    end
+  end
+end
+
+private def determine_format(default_format = :ics, **headers)
+  determine_format(default_format, headers, accepted_formats: [] of Symbol)
+end
+
+private def determine_format(default_format, headers, accepted_formats)
+  headers = headers.to_h.transform_keys(&.to_s.as(String))
+  request = build_request
+  request.headers.merge!(headers)
+  Lucky::MimeType.determine_clients_desired_format(
+    request,
+    default_format: default_format,
+    accepted_formats: accepted_formats
+  )
+end

--- a/spec/lucky/namespaced_action_spec.cr
+++ b/spec/lucky/namespaced_action_spec.cr
@@ -1,6 +1,6 @@
 require "../spec_helper"
 
-class Admin::MultiWord::Users::Show < Lucky::Action
+class Admin::MultiWord::Users::Show < TestAction
   route do
     plain_text "plain"
   end

--- a/spec/lucky/nested_resource_action_spec.cr
+++ b/spec/lucky/nested_resource_action_spec.cr
@@ -1,12 +1,12 @@
 require "../spec_helper"
 
-class Projects::Tasks::Show < Lucky::Action
+class Projects::Tasks::Show < TestAction
   nested_route do
     plain_text "plain"
   end
 end
 
-class Admin::Projects::Tasks::Show < Lucky::Action
+class Admin::Projects::Tasks::Show < TestAction
   nested_route do
     plain_text "plain"
   end

--- a/spec/lucky/protect_from_forgery_spec.cr
+++ b/spec/lucky/protect_from_forgery_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 include ContextHelper
 
-class ProtectedAction::Index < Lucky::Action
+class ProtectedAction::Index < TestAction
   include Lucky::ProtectFromForgery
 
   route { plain_text "Passed" }

--- a/spec/lucky/root_spec.cr
+++ b/spec/lucky/root_spec.cr
@@ -1,6 +1,6 @@
 require "../spec_helper"
 
-class RootAction < Lucky::Action
+class RootAction < TestAction
   get "/" do
     plain_text "Hello there"
   end

--- a/spec/lucky/route_not_found_handler_spec.cr
+++ b/spec/lucky/route_not_found_handler_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 include ContextHelper
 
-class SampleFallbackAction::Index < Lucky::Action
+class SampleFallbackAction::Index < TestAction
   fallback do
     plain_text "Last chance"
   end

--- a/spec/lucky/secure_headers_spec.cr
+++ b/spec/lucky/secure_headers_spec.cr
@@ -2,7 +2,7 @@ require "../spec_helper"
 
 include ContextHelper
 
-class FrameGuardRoutes::WithSameorigin < Lucky::Action
+class FrameGuardRoutes::WithSameorigin < TestAction
   include Lucky::SecureHeaders::SetFrameGuard
 
   get "/so_custom" do
@@ -14,7 +14,7 @@ class FrameGuardRoutes::WithSameorigin < Lucky::Action
   end
 end
 
-class FrameGuardRoutes::WithDeny < Lucky::Action
+class FrameGuardRoutes::WithDeny < TestAction
   include Lucky::SecureHeaders::SetFrameGuard
 
   get "/so_custom" do
@@ -26,7 +26,7 @@ class FrameGuardRoutes::WithDeny < Lucky::Action
   end
 end
 
-class FrameGuardRoutes::WithURL < Lucky::Action
+class FrameGuardRoutes::WithURL < TestAction
   include Lucky::SecureHeaders::SetFrameGuard
 
   get "/so_custom" do
@@ -38,7 +38,7 @@ class FrameGuardRoutes::WithURL < Lucky::Action
   end
 end
 
-class FrameGuardRoutes::WithBadValue < Lucky::Action
+class FrameGuardRoutes::WithBadValue < TestAction
   include Lucky::SecureHeaders::SetFrameGuard
 
   get "/so_custom" do
@@ -50,7 +50,7 @@ class FrameGuardRoutes::WithBadValue < Lucky::Action
   end
 end
 
-class XSSGuardRoutes::Index < Lucky::Action
+class XSSGuardRoutes::Index < TestAction
   include Lucky::SecureHeaders::SetXSSGuard
 
   get "/so_custom" do
@@ -58,7 +58,7 @@ class XSSGuardRoutes::Index < Lucky::Action
   end
 end
 
-class SniffGuardRoutes::Index < Lucky::Action
+class SniffGuardRoutes::Index < TestAction
   include Lucky::SecureHeaders::SetSniffGuard
 
   get "/so_custom" do

--- a/spec/lucky/verify_accepts_format_spec.cr
+++ b/spec/lucky/verify_accepts_format_spec.cr
@@ -1,0 +1,78 @@
+require "../spec_helper"
+
+include ContextHelper
+
+private class ActionThatAcceptsHtml < Lucky::Action
+  accepted_formats [:html], default: :html
+
+  get "/test" do
+    plain_text "yay"
+  end
+
+  property clients_desired_format : Symbol = :foo
+end
+
+# Test that the default is the first format if there is just one format.
+private class ActionWithImplicitDefault < Lucky::Action
+  accepted_formats [:html]
+
+  get "/test" do
+    plain_text "yay"
+  end
+
+  property clients_desired_format : Symbol = :foo
+end
+
+private class ActionThatAcceptsAnyFormat < Lucky::Action
+  get "/test" do
+    plain_text "yay"
+  end
+
+  property clients_desired_format : Symbol = :foo
+end
+
+private class ActionWithUnrecognizedFormat < Lucky::Action
+  accepted_formats [:wut_is_this]
+
+  get "/test" do
+    plain_text "not yay"
+  end
+
+  property clients_desired_format : Symbol = :foo
+end
+
+describe Lucky::VerifyAcceptsFormat do
+  it "lets the request through if the format is accepted" do
+    override_format ActionThatAcceptsHtml, :html do |action|
+      action.call.body.should eq("yay")
+    end
+  end
+
+  it "raises an error if the format is not accepted" do
+    expect_raises Lucky::NotAcceptableError do
+      override_format ActionThatAcceptsHtml, :not_accepted do |action|
+        action.call
+      end
+    end
+  end
+
+  it "lets any format through if accepted_formats is not set" do
+    override_format ActionThatAcceptsAnyFormat, :will_accept_anything do |action|
+      action.call.body.should eq("yay")
+    end
+  end
+
+  it "raises if given a format that Lucky doesn't recognize" do
+    expect_raises Exception, ":wut_is_this" do
+      override_format ActionWithUnrecognizedFormat, :not_used do |action|
+        action.call
+      end
+    end
+  end
+end
+
+private def override_format(action, format : Symbol)
+  action = action.new(build_context, params)
+  action.clients_desired_format = format
+  yield action
+end

--- a/spec/support/context_helper.cr
+++ b/spec/support/context_helper.cr
@@ -1,11 +1,13 @@
 module ContextHelper
-  private def build_request(method = "GET", body = "", content_type = "")
+  extend self
+
+  private def build_request(method = "GET", body = "", content_type = "") : HTTP::Request
     headers = HTTP::Headers.new
     headers.add("Content-Type", content_type)
     HTTP::Request.new(method, "/", body: body, headers: headers)
   end
 
-  private def build_context(path = "/", request = nil) : HTTP::Server::Context
+  def build_context(path = "/", request = nil) : HTTP::Server::Context
     build_context_with_io(IO::Memory.new, path: path, request: request)
   end
 

--- a/spec/support/test_action.cr
+++ b/spec/support/test_action.cr
@@ -1,0 +1,3 @@
+abstract class TestAction < Lucky::Action
+  accepted_formats [:html], default: :html
+end

--- a/src/lucky/action.cr
+++ b/src/lucky/action.cr
@@ -17,4 +17,5 @@ abstract class Lucky::Action
   include Lucky::ParamHelpers
   include Lucky::ActionCallbacks
   include Lucky::Redirectable
+  include Lucky::VerifyAcceptsFormat
 end

--- a/src/lucky/context_extensions.cr
+++ b/src/lucky/context_extensions.cr
@@ -1,4 +1,12 @@
 class HTTP::Server::Context
+  # :nodoc:
+  #
+  # This is used to store the client's accepted/desired format
+  # That way if there is an error, the Errors::Show action will
+  # use the same format that the Action used without trying
+  # to figure it out again.
+  property _clients_desired_format : Symbol? = nil
+
   @_cookies : Lucky::CookieJar?
 
   def cookies : Lucky::CookieJar

--- a/src/lucky/error_action.cr
+++ b/src/lucky/error_action.cr
@@ -12,6 +12,10 @@ abstract class Lucky::ErrorAction
   def initialize(@context : HTTP::Server::Context)
   end
 
+  # :nodoc:
+  # Accept all formats. ErrorAction should *always* work
+  class_getter _accepted_formats = [] of Symbol
+
   abstract def handle_error(error : Exception) : Lucky::Response
 
   def perform_action(error : Exception)

--- a/src/lucky/errors.cr
+++ b/src/lucky/errors.cr
@@ -13,4 +13,47 @@ module Lucky
       super "Could not find route matching #{@context.request.method} #{@context.request.path}"
     end
   end
+
+  class UnknownAcceptHeaderError < Error
+    getter request
+
+    def initialize(@request : HTTP::Request)
+      accept_header = request.headers["accept"]?
+      super <<-TEXT
+      Lucky couldn't figure out what format the client accepts.
+
+          The client's Accept header: '#{accept_header}'
+
+      You can teach Lucky how to handle this header:
+
+          # Add this in config/mime_types.cr
+          Lucky::MimeType.register "#{accept_header}", :custom_format
+
+      Or use one of these headers Lucky knows about:
+
+          #{Lucky::MimeType.known_accept_headers.join(", ")}
+
+
+      TEXT
+    end
+  end
+
+  class NotAcceptableError < Error
+    getter request
+
+    def initialize(action_name : String, format : Symbol, accepted_formats : Array(Symbol))
+      super <<-TEXT
+      The request wants :#{format}, but #{action_name} does not accept it.
+
+      Accepted formats: #{accepted_formats.map(&.to_s).join(", ")}
+
+      Try this...
+
+        ▸ Add :#{format} to 'accepted_formats' in #{action_name}.
+        ▸ Make your request is using one of the accepted formats.
+
+
+      TEXT
+    end
+  end
 end

--- a/src/lucky/mime_type.cr
+++ b/src/lucky/mime_type.cr
@@ -1,0 +1,101 @@
+# :nodoc:
+class Lucky::MimeType
+  alias Format = Symbol
+  alias AcceptHeaderSubstring = String
+  class_getter accept_header_formats = {} of AcceptHeaderSubstring => Format
+
+  register "application/json", :json
+  register "text/json", :json
+  register "application/jsonrequest", :json
+  register "text/javascript", :js
+  register "application/xml", :xml
+  register "application/rss+xml", :rss
+  register "application/atom+xml", :atom
+  register "application/x-yaml", :yaml
+  register "text/yaml", :yaml
+  register "text/csv", :csv
+  register "text/css", :css
+  register "text/calendar", :ics
+  register "text/plain", :plain_text
+  register "multipart/form-data", :multipart_form
+  register "application/x-www-form-urlencoded", :url_encoded_form
+
+  def self.known_accept_headers : Array(String)
+    accept_header_formats.keys
+  end
+
+  def self.known_formats : Array(Symbol)
+    (accept_header_formats.values + [:html]).uniq
+  end
+
+  def self.registered?(format : Symbol) : Bool
+    known_formats.includes?(format)
+  end
+
+  def self.register(accept_header_substring : AcceptHeaderSubstring, format : Format) : Nil
+    accept_header_formats[accept_header_substring] = format
+  end
+
+  # :nodoc:
+  def self.determine_clients_desired_format(request, default_format : Symbol, accepted_formats : Array(Symbol))
+    DetermineClientsDesiredFormat.new(request, default_format, accepted_formats).call
+  end
+
+  private class DetermineClientsDesiredFormat
+    private getter request, default_format, accepted_formats
+
+    def initialize(@request : HTTP::Request, @default_format : Symbol, @accepted_formats : Array(Symbol))
+    end
+
+    def call : Symbol?
+      accept = accept_header
+
+      if usable_accept_header? && accept
+        from_accept_header(accept)
+      elsif ajax?
+        :ajax
+      elsif accepts_html? && default_accept_header_that_browsers_send?
+        :html
+      else
+        default_format
+      end
+    end
+
+    private def accepts_html? : Bool
+      @accepted_formats.includes? :html
+    end
+
+    private def from_accept_header(accept : String) : Symbol?
+      Lucky::MimeType.accept_header_formats.find do |accept_header_substring, format|
+        accept.includes?(accept_header_substring)
+      end.try(&.[1])
+    end
+
+    private def usable_accept_header? : Bool
+      !!(accept_header && !default_accept_header_that_browsers_send?) ||
+        # If an Ajax request, it should still be possible to accept a different format
+        !!(accept_header && ajax?)
+    end
+
+    private def accept_header : String?
+      accept = request.headers["Accept"]?
+
+      if accept && !accept.empty?
+        accept
+      end
+    end
+
+    # Browser typically send */* in their accept header
+    # This method checks for that so we can figure out if a browser is
+    # making the request.
+    private def default_accept_header_that_browsers_send? : Bool
+      accept = accept_header
+
+      !!accept && !!(accept =~ /,\s*\*\/\*|\*\/\*\s*,/)
+    end
+
+    private def ajax? : Bool
+      request.headers["X-Requested-With"]?.try(&.downcase) == "xmlhttprequest"
+    end
+  end
+end

--- a/src/lucky/protect_from_forgery.cr
+++ b/src/lucky/protect_from_forgery.cr
@@ -39,7 +39,7 @@ module Lucky::ProtectFromForgery
   end
 
   private def user_provided_token : String?
-    params.get?(PARAM_KEY) || headers[SESSION_KEY]?
+    params.get?(PARAM_KEY) || request.headers[SESSION_KEY]?
   end
 
   def forbid_access_because_of_bad_token : Lucky::Response

--- a/src/lucky/request_type_helpers.cr
+++ b/src/lucky/request_type_helpers.cr
@@ -1,57 +1,100 @@
-# These helpers check HTTP headers to determine "request type".
-# Generally the `Content-Type` header is checked, followed by
-# the `Accept` header, but some check other headers, such as `X-Requested-With`.
+# These helpers check HTTP headers to determine "request MIME type".
+#
+# Generally the `Accept` header is checked, but some check other headers, such as `X-Requested-With`.
 module Lucky::RequestTypeHelpers
-  abstract def request_type : String
-  abstract def headers : HTTP::Headers
+  include Lucky::Memoizable
+
+  private def default_format
+    {% raise <<-TEXT
+    Must set 'accepted_formats' or 'default_format' in #{@type} (or its parent class).
+
+    Example of 'accepted_formats' (recommended):
+
+      abstract class BrowserAction < Lucky::Action
+        accepted_formats [:html, :json], default: :html
+      end
+
+    Example of 'default_format':
+
+      class Errors::Show < Lucky::ErrorAction
+        default_format :html
+      end
+
+
+    TEXT
+    %}
+  end
+
+  # If Lucky doesn't find a format then default to the given format
+  #
+  # ```
+  # default_format :html
+  # ```
+  macro default_format(format)
+    {% unless format.is_a?(SymbolLiteral) %}
+      {% raise "The default format in #{@type} must be a Symbol. Instead got #{format}" %}
+    {% end %}
+
+    private def default_format : Symbol
+      {{ format }}
+    end
+  end
+
+  private def clients_desired_format : Symbol
+    context._clients_desired_format ||= determine_clients_desired_format
+  end
+
+  private def determine_clients_desired_format : Symbol
+    Lucky::MimeType.determine_clients_desired_format(request, default_format, self.class._accepted_formats) ||
+      raise Lucky::UnknownAcceptHeaderError.new(request)
+  end
+
+  # Check whether the request wants the passed in format
+  def accepts?(format : Symbol) : Bool
+    clients_desired_format == format
+  end
 
   # Check if the request is JSON
   #
   # This tests if the request type is `application/json`
   def json? : Bool
-    request_type == "application/json"
+    accepts?(:json)
   end
 
   # Check if the request is AJAX
   #
-  # This tests if the X-Requested-With header is `XMLHttpRequest`
+  # This tests if the `X-Requested-With` header is `XMLHttpRequest`
   def ajax? : Bool
-    headers["X-Requested-With"]? == "XMLHttpRequest"
+    accepts?(:ajax)
   end
 
   # Check if the request is HTML
   #
-  # This tests if the request type is `text/html`
+  # Browsers typically send vague Accept headers. Because of that this will return `true` when:
+  #
+  #  * The `accepted_formats` includes `:html`
+  #  * And the `Accept` header is the browser default. For example `text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
   def html? : Bool
-    request_type.starts_with? "text/html"
+    accepts?(:html)
   end
 
   # Check if the request is XML
   #
-  # This tests if the request type is `application/xml`,
-  # `application/xhtml+xml`
+  # This tests if the request type is `application/xml`
   def xml? : Bool
-    !!(request_type =~ /application\/(xhtml\+)?xml/)
+    accepts?(:xml)
   end
 
   # Check if the request is plain text
   #
-  # This tests if the request type is `text/plain` or
+  # This tests if the `Accept` header type is `text/plain` or
   # with the optional character set per W3 RFC1341 7.1
-  def plain? : Bool
-    request_type == "text/plain" || request_type.downcase.starts_with?("text/plain; charset=")
+  def plain_text? : Bool
+    accepts?(:plain_text)
   end
 
-  private def request_type : String
-    has_content_type = !(headers["Content-Type"]?.nil? || headers["Content-Type"]?.try(&.empty?))
-    has_accept = !(headers["Accept"]?.nil? || headers["Accept"]?.try(&.empty?))
-
-    return headers["Content-Type"] if has_content_type
-    return headers["Accept"] if has_accept
-    ""
-  end
-
-  private def headers : HTTP::Headers
-    request.headers
+  # :nodoc:
+  def plain?
+    {% raise "This method has been renamed to 'plain_text?'" %}
   end
 end

--- a/src/lucky/verify_accepts_format.cr
+++ b/src/lucky/verify_accepts_format.cr
@@ -1,0 +1,107 @@
+# Configure what types of formats your action responds to
+module Lucky::VerifyAcceptsFormat
+  abstract def clients_desired_format : Symbol
+
+  macro included
+    class_property _accepted_formats = [] of Symbol
+    before verify_accepted_format
+  end
+
+  # Set what formats the Action accepts.
+  #
+  # Same as `accepted_formats` but this one only accepts one format and no
+  # default. If you pass less an empty array or more than one format, you must
+  # use the other `accepted_formats` so you can tell Lucky what the `default`
+  # format should be.
+  #
+  # If something other than the accepts formats are request, Lucky will raise
+  # a `Lucky::NotAcceptableError` error.
+  #
+  # ```
+  # # Defaults is set to :html since there is just one format
+  # accepted_formats [:html]
+  #
+  # # Raises at compile time because Lucky needs to know which format is the default
+  # accepted_formats [:html, :json]
+  #
+  # # Give Lucky the default if ore than one format is accepted
+  # accepted_formats [:html, :json], default: :html
+  # ```
+  macro accepted_formats(formats)
+    {% if !formats.is_a?(ArrayLiteral) %}
+      {% raise "#{@type} 'accepted_formats' should be an array of Symbols. Example: [:html, :json]" %}
+    {% end %}
+
+    {% if formats.size == 1 %}
+      accepted_formats {{ formats }}, default: {{ formats.first }}
+    {% else %}
+      {% formats.raise "#{@type} must pass a default to 'accepted_formats'. Example: accepted_formats [:html, :json], default: :html" %}
+    {% end %}
+  end
+
+  # Set what formats the Action accepts.
+  #
+  # If something other than the accepts formats are request, Lucky will raise
+  # a `Lucky::NotAcceptableError` error.
+  #
+  # ```
+  # accepted_formats [:html, :json], default: :json
+  # ```
+  macro accepted_formats(formats, default)
+    {% if !formats.is_a?(ArrayLiteral) %}
+      {% formats.raise "#{@type} 'accepted_formats' should be an array of Symbols. Example: [:html, :json]" %}
+    {% end %}
+
+    {% if !default.is_a?(SymbolLiteral) %}
+      {% formats.raise "#{@type} default format should be a symbol. Example: :html" %}
+    {% end %}
+
+    self._accepted_formats = {{ formats }}
+    default_format {{ default }}
+  end
+
+  private def verify_accepted_format
+    verify_all_formats_recognized!
+
+    if all_formats_allowed? || self.class._accepted_formats.includes?(clients_desired_format)
+      continue
+    else
+      raise Lucky::NotAcceptableError.new(
+        action_name: self.class.name,
+        format: clients_desired_format,
+        accepted_formats: self.class._accepted_formats
+      )
+    end
+  end
+
+  private def verify_all_formats_recognized! : Nil
+    find_unrecognized_format.try do |unrecognized_format|
+      raise <<-TEXT
+      #{self.class.name} accepts an unrecognized format :#{unrecognized_format}
+
+      You can teach Lucky how to handle this format:
+
+          # Add this in config/mime_types.cr
+          Lucky::MimeType.register "text/custom", :#{unrecognized_format}
+
+      Or use one of these formats Lucky knows about:
+
+          #{Lucky::MimeType.known_formats.join(", ")}
+
+
+      TEXT
+    end
+  end
+
+  @_find_unrecognized_format : Symbol?
+
+  private def find_unrecognized_format : Symbol?
+    @_find_unrecognized_format ||= self.class._accepted_formats.find do |format|
+      !Lucky::MimeType.registered?(format)
+    end
+  end
+
+  private def all_formats_allowed? : Bool
+    self.class._accepted_formats.empty?
+  end
+end


### PR DESCRIPTION
**Merge AFTER v0.17.0 is out**. We already have a big release. Let's not add one more thing at the last minute :P

Closes #822 

A lot of the info is in #822, but the gist is that Lucky was incorrectly checking the content-type header when it should have checked the accept header.

This goes a bit further:

* Allows verifying that the action accept the given format
* Sets a default format if none is provided
* Lots of (hopefully) helpful errors.

Once this is merged we'll need to add 'accepted_formats' in LuckyCLI's `BrowserAction` and `ApiAction`