### PR TITLE
Raise custom error when parsing JSON params fails

### DIFF
--- a/spec/http_method_override_handler_spec.cr
+++ b/spec/http_method_override_handler_spec.cr
@@ -22,12 +22,12 @@ describe Lucky::HttpMethodOverrideHandler do
       should_handle "GET", overridden_method: nil, and_return: "GET"
     end
 
-    it "fails if request body contains malformed json" do
+    it "continues if request body contains malformed json" do
       request = build_request "GET", body: "{ \"bad_json\": 123", content_type: "application/json"
 
-      expect_raises(JSON::ParseException) do
-        Lucky::HttpMethodOverrideHandler.new.call(build_context(request: request))
-      end
+      Lucky::HttpMethodOverrideHandler.new.call(build_context(request: request))
+
+      request.method.should eq "GET"
     end
   end
 end

--- a/spec/lucky/params_spec.cr
+++ b/spec/lucky/params_spec.cr
@@ -40,6 +40,18 @@ describe Lucky::Params do
 
       params.get?(:from).should eq "form"
     end
+
+    it "raises an exception if parsing fails" do
+      invalid_json = "//"
+      request = build_request body: invalid_json,
+        content_type: "application/json"
+
+      params = Lucky::Params.new(request)
+
+      expect_raises Lucky::ParamParsingError do
+        params.get?(:page).should eq "1"
+      end
+    end
   end
 
   describe "when route params are passed in" do

--- a/src/lucky/errors.cr
+++ b/src/lucky/errors.cr
@@ -14,6 +14,14 @@ module Lucky
     end
   end
 
+  class ParamParsingError < Error
+    getter request
+
+    def initialize(@request : HTTP::Request)
+      super "Failed to parse the request parameters."
+    end
+  end
+
   class UnknownAcceptHeaderError < Error
     getter request
 

--- a/src/lucky/http_method_override_handler.cr
+++ b/src/lucky/http_method_override_handler.cr
@@ -17,5 +17,7 @@ class Lucky::HttpMethodOverrideHandler
 
   private def overridden_http_method(context) : String?
     Lucky::Params.new(context.request).get?(:_method).try(&.upcase)
+  rescue Lucky::ParamParsingError
+    nil
   end
 end

--- a/src/lucky/params.cr
+++ b/src/lucky/params.cr
@@ -403,6 +403,8 @@ class Lucky::Params
         JSON.parse(body)
       end
     end
+  rescue JSON::ParseException
+    raise Lucky::ParamParsingError.new(request)
   end
 
   private def body


### PR DESCRIPTION
## Purpose

This makes it easier to rescue JSON parsing only for params. This will be  useful in Errors::Show for default apps
