### PR TITLE
Improve BaseHTTPClient

### DIFF
--- a/spec/support/test_server.cr
+++ b/spec/support/test_server.cr
@@ -6,9 +6,10 @@ class TestServer
 
   class_property routes : Hash(String, String) = {} of String => String
 
-  property last_request : HTTP::Request?
+  property! last_request : HTTP::Request?
+  getter port
 
-  def initialize(port : Int32)
+  def initialize(@port : Int32)
     @server = HTTP::Server.new do |context|
       last_request = context.request.dup
       last_request.body = last_request.body.try(&.peek)

--- a/src/lucky/base_http_client.cr
+++ b/src/lucky/base_http_client.cr
@@ -1,28 +1,102 @@
 require "http/client"
 
-class Lucky::BaseHTTPClient
+# A client for making HTTP requests
+#
+# Makes it easy to pass params, use Lucky route helpers, and chain header methods.
+abstract class Lucky::BaseHTTPClient
+  private getter client
+
   @client : HTTP::Client
 
   def initialize(host = Lucky::Server.settings.host, port = Lucky::Server.settings.port)
     @client = HTTP::Client.new(host, port: port)
   end
 
-  def get(path : String, headers : HTTP::Headers? = nil, params : HTTP::Params? = nil)
-    if params
-      path = path + "?#{params}"
+  {% for method in [:get, :put, :patch, :post] %}
+    def self.{{ method.id }}(*args, **named_args)
+      new.{{ method.id }}(*args, **named_args)
     end
-    @client.get(path, headers: headers)
-  end
-
-  {% for method in [:put, :patch, :post] %}
-
-    def {{method.id}}(path : String, body : Hash(String, String), headers : HTTP::Headers? = nil)
-      @client.{{method.id}}(path, headers: headers, form: body)
-    end
-
   {% end %}
 
-  def delete(path : String, headers : HTTP::Headers? = nil)
-    @client.delete(path, headers: headers)
+  # Set headers for requests
+  #
+  # ```
+  # # `content_type` will be normalized to `content-type`
+  # AppClient.new.headers(content_type: "application/json")
+  #
+  # # You can also use string keys if you want
+  # AppClient.new.headers("Content-Type": "application/json")
+  # ```
+
+  # The header call is chainable and returns the client:
+  #
+  # ```
+  # # content_type will be normalized to `content-type`
+  # AppClient.new
+  #   .headers(content_type: "application/json")
+  #   .headers(accept: "text/plain")
+  #   .get("/some-path")
+  # ```
+  #
+  # You can also set up headers in `initialize` or in instance methods:
+  #
+  # ```
+  # class AppClient < Lucky::BaseHTTPClient
+  #   def initialize
+  #     headers(content_type: "application/json")
+  #   end
+  #
+  #   def accept_plain_text
+  #     headers(accept: "text/plain")
+  #   end
+  # end
+  #
+  # AppClient.new
+  #   .accept_plain_text
+  #   .get("/some-path")
+  # ```
+  def headers(**header_values)
+    @client.before_request do |request|
+      header_values.each do |key, value|
+        request.headers[key.to_s.gsub("-", "_")] = value.to_s
+      end
+    end
+    self
   end
+
+  # Sends a request with the path and method from a Lucky::Action
+  #
+  # ```
+  # # Make a request without body params
+  # AppClient.new.exec Users::Index
+  #
+  # # Make a request with body params
+  # AppClient.new.exec Users::Create, user: {email: "paul@example.com"}
+  #
+  # # Actions that require path params work like normal
+  # AppClient.new.exec Users::Show.with(user.id)
+  # ```
+  def exec(action : Lucky::Action.class, **params) : HTTP::Client::Response
+    exec(action.route, params)
+  end
+
+  # See docs for `exec`
+  def exec(route_helper : Lucky::RouteHelper, **params) : HTTP::Client::Response
+    exec(route_helper, params)
+  end
+
+  # See docs for `exec`
+  def exec(route_helper : Lucky::RouteHelper, params : NamedTuple) : HTTP::Client::Response
+    @client.exec(method: route_helper.method.to_s.upcase, path: route_helper.path, body: params.to_json)
+  end
+
+  {% for method in [:put, :patch, :post, :delete, :get] %}
+    def {{ method.id }}(path : String, **params) : HTTP::Client::Response
+      {{ method.id }}(path, params)
+    end
+
+    def {{ method.id }}(path : String, params : NamedTuple) : HTTP::Client::Response
+      @client.{{ method.id }}(path, form: params.to_json)
+    end
+  {% end %}
 end


### PR DESCRIPTION
This can be used for request specs. This will be used for the default auth specs when generating an API app with Auth. 

I imagine this could be used for other HTTP Clients as well, but for now the main purpose is for testing Lucky apps