### PR TITLE
Added support for date and time input fields. 

### DIFF
--- a/spec/lucky/input_helpers_spec.cr
+++ b/spec/lucky/input_helpers_spec.cr
@@ -35,6 +35,15 @@ class InputTestForm
       param_key: "user"
     )
   end
+
+  def joined_at
+    Avram::PermittedAttribute(Time?).new(
+      name: :joined_at,
+      param: nil,
+      value: nil,
+      param_key: "user"
+    )
+  end
 end
 
 private class TestPage
@@ -222,6 +231,26 @@ describe Lucky::InputHelpers do
 
     view.textarea(form.first_name, rows: 5, cols: 15).to_s.should contain <<-HTML
     <textarea id="user_first_name" name="user:first_name" rows="5" cols="15">My name</textarea>
+    HTML
+  end
+
+  it "renders time inputs" do
+    view.time_input(form.joined_at).to_s.should contain <<-HTML
+    <input type="time" id="user_joined_at" name="user:joined_at" value="">
+    HTML
+
+    view.time_input(form.joined_at, min: "09:00", max: "18:00").to_s.should contain <<-HTML
+    <input type="time" id="user_joined_at" name="user:joined_at" value="" min="09:00" max="18:00">
+    HTML
+  end
+
+  it "renders date inputs" do
+    view.date_input(form.joined_at).to_s.should contain <<-HTML
+    <input type="date" id="user_joined_at" name="user:joined_at" value="">
+    HTML
+
+    view.date_input(form.joined_at, min: "2019-01-01", max: "2019-12-31").to_s.should contain <<-HTML
+    <input type="date" id="user_joined_at" name="user:joined_at" value="" min="2019-01-01" max="2019-12-31">
     HTML
   end
 end

--- a/src/lucky/tags/input_helpers.cr
+++ b/src/lucky/tags/input_helpers.cr
@@ -61,7 +61,7 @@ module Lucky::InputHelpers
 
   generate_helpful_error_for checkbox
 
-  {% for input_type in ["text", "email", "file", "color", "hidden", "number", "url", "search", "range"] %}
+  {% for input_type in ["text", "email", "file", "color", "hidden", "number", "url", "search", "range", "time", "date"] %}
     generate_helpful_error_for {{input_type.id}}_input
 
     def {{input_type.id}}_input(field : Avram::PermittedAttribute, **html_options)


### PR DESCRIPTION
## Purpose
Fixes #802

## Description
This PR adds support for [date field](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/date) and [time field](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/time)

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
