### PR TITLE
Make shell scripts POSIX-compliant

### DIFF
--- a/script/precompile_tasks
+++ b/script/precompile_tasks
@@ -1,13 +1,9 @@
-#! /bin/bash
-
-# Exit if any subcommand fails
-set -e
-set -o pipefail
+#!/bin/sh -e
 
 # Precompile tasks if not in production and not in CI
 # Also allow skipping precompilation with an ENV var
 if [ "$LUCKY_ENV" != "production" ] && [ -z "$CI" ] && [ -z "$SKIP_LUCKY_TASK_PRECOMPILATION" ]; then
-    shards build && \
-    mkdir -p ../../bin && \
-    cp -r $(pwd)/bin $(pwd)/../..
+    shards build
+    mkdir -p ../../bin
+    cp -r $PWD/bin $PWD/../..
 fi

--- a/script/setup
+++ b/script/setup
@@ -1,8 +1,4 @@
-#! /bin/bash
-
-# Exit if any subcommand fails
-set -e
-set -o pipefail
+#!/bin/sh -eu
 
 if ! command -v docker-compose > /dev/null; then
     printf 'Docker and docker-compose are not installed.\n'

--- a/script/test
+++ b/script/test
@@ -1,16 +1,12 @@
-#! /bin/bash
+#!/bin/sh -eu
 
-# Exit if any subcommand fails
-set -e
-set -o pipefail
 
 COMPOSE="docker-compose run --rm app"
 
 printf "\nrunning specs with 'crystal spec'\n\n"
 $COMPOSE crystal spec "$@"
 
-if [ $# -eq 0 ]
-then
+if [ $# = 0 ]; then
     printf "\nChecking that tasks build correctly\n\n"
     $COMPOSE shards build
     


### PR DESCRIPTION
## Purpose
Fixes https://github.com/luckyframework/lucky/issues/878
It converts bash scripts to POSIX compliant ones, in order to run them in any other OS without bash like Alpine (even if we can install it).

## Description
Bashisms were removed or converted to POSIX-compliant syntax.
I have also added minor improvements, mainly stylistic (but not opinionated). I can explain if there are questions about them.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
