### PR TITLE
Fully support PATCH like PUT and DELETE.

### DIFF
--- a/spec/http_method_override_handler_spec.cr
+++ b/spec/http_method_override_handler_spec.cr
@@ -9,7 +9,8 @@ describe Lucky::HttpMethodOverrideHandler do
       should_handle "POST", overridden_method: "", and_return: "POST"
     end
 
-    it "overrides when POST with overridden PUT or DELETE" do
+    it "overrides when POST with overridden PATCH, PUT or DELETE" do
+      should_handle "POST", overridden_method: "patch", and_return: "PATCH"
       should_handle "POST", overridden_method: "put", and_return: "PUT"
       should_handle "POST", overridden_method: "delete", and_return: "DELETE"
     end

--- a/src/lucky/http_method_override_handler.cr
+++ b/src/lucky/http_method_override_handler.cr
@@ -12,7 +12,7 @@ class Lucky::HttpMethodOverrideHandler
   end
 
   private def override_allowed?(context, http_method) : Bool
-    ["POST"].includes?(context.request.method) && ["PUT", "DELETE"].includes?(http_method)
+    ["POST"].includes?(context.request.method) && ["PATCH", "PUT", "DELETE"].includes?(http_method)
   end
 
   private def overridden_http_method(context) : String?


### PR DESCRIPTION
## Purpose

Full support for HTTP PATCH along the lines of PUT and DELETE as described in #884

## Description

This adds the missing piece for PATCH to be treated just like PUT and DELETE. It can now be parsed from the special parameter `_method` that Rails-UJS sets on the specially crafted links (that lucky already generates correctly).
 
## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation status has not gotten worse :wink:
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
