### PR TITLE
Accept every integer type on the #pluralize method

### DIFF
--- a/spec/lucky/text_helpers/pluralize_spec.cr
+++ b/spec/lucky/text_helpers/pluralize_spec.cr
@@ -5,6 +5,7 @@ describe Lucky::TextHelpers do
     it "pluralizes words" do
       view.pluralize(1, "count").should eq "1 count"
       view.pluralize(2, "count").should eq "2 counts"
+      view.pluralize(1000000000000, "count").should eq "1000000000000 counts"
       view.pluralize("1", "count").should eq "1 count"
       view.pluralize("2", "count").should eq "2 counts"
       view.pluralize("1,066", "count").should eq "1,066 counts"

--- a/src/lucky/page_helpers/text_helpers.cr
+++ b/src/lucky/page_helpers/text_helpers.cr
@@ -86,7 +86,7 @@ module Lucky::TextHelpers
 
   # It pluralizes `singular` unless `count` is 1. You can specify the `plural` option
   # to override the chosen plural word.
-  def pluralize(count : Int32 | String | Nil, singular : String, plural = nil) : String
+  def pluralize(count : Int | String | Nil, singular : String, plural = nil) : String
     word = if (count == 1 || count =~ /^1(\.0+)?$/)
              singular
            else


### PR DESCRIPTION
## Purpose
This PR makes the `#pluralize` method to accept every integer subtype (BigInt, Int16, Int32, Int64, Int8, UInt16, UInt32, UInt64, UInt8).

## Description
This changes the `#pluralize` method signature to `Int`.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`

Closes #887 