### PR TITLE
Use default format for requests that accept anything

### DIFF
--- a/spec/lucky/mime_type_spec.cr
+++ b/spec/lucky/mime_type_spec.cr
@@ -20,7 +20,12 @@ describe Lucky::MimeType do
       format.should eq(:json)
     end
 
-    it "returns the 'default_format' if the accept header accepts anything '*/*'" do
+    it "returns 'nil' if there is a non-browser 'Accept' header, but Lucky doesn't understand it" do
+      format = determine_format("accept": "wut/is-this")
+      format.should be_nil
+    end
+
+    it "returns the 'default_format' if the 'Accept' header accepts anything '*/*'" do
       format = determine_format(default_format: :csv, "accept": "*/*")
       format.should eq(:csv)
     end

--- a/src/lucky/mime_type.cr
+++ b/src/lucky/mime_type.cr
@@ -91,9 +91,10 @@ class Lucky::MimeType
       end
     end
 
-    # Browser typically send */* in their accept header
-    # This method checks for that so we can figure out if a browser is
-    # making the request.
+    # This checks if the "Accept" header is from a browser. Browsers typically
+    # include "*/*" along with other characters in the request's "Accept" header.
+    # This method handles those intricacies and determins if the header is from
+    # a browser.
     private def default_accept_header_that_browsers_send? : Bool
       accept = accept_header
 


### PR DESCRIPTION
This is what CURL uses. We should return the default format in those
cases.

Also adds a spec for when format cannot be determined