### PR TITLE
Adding friendly error for when needs misses a type declaration

### DIFF
--- a/src/lucky/assignable.cr
+++ b/src/lucky/assignable.cr
@@ -1,6 +1,9 @@
 module Lucky::Assignable
   macro needs(*type_declarations)
     {% for declaration in type_declarations %}
+      {% unless declaration.is_a?(TypeDeclaration) %}
+        {% raise "needs expected a type declaration like 'name : String', instead got: '#{declaration}'" %}
+      {% end %}
       {% ASSIGNS << declaration %}
     {% end %}
   end


### PR DESCRIPTION
## Purpose
fixes #864 

## Description
This will now throw a compile-time error if you use `needs` without a proper type declaration like `needs title : String`. 

Here's an example of what it looks like.
<img width="1008" alt="Screen Shot 2019-09-17 at 11 29 51 AM" src="https://user-images.githubusercontent.com/2391/65069039-b6d31f80-d93e-11e9-9ad0-0090180ea331.png">
 
## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
