### PR TITLE
Allow ErrorAction#render to return `nil`

### DIFF
--- a/spec/lucky/error_handling_spec.cr
+++ b/spec/lucky/error_handling_spec.cr
@@ -24,7 +24,7 @@ class FakeErrorAction < Lucky::ErrorAction
     head status: 404
   end
 
-  def render(error : Exception) : Lucky::Response
+  def default_render(error : Exception) : Lucky::Response
     plain_text "This is not a debug page", status: 500
   end
 
@@ -108,7 +108,7 @@ describe "Error handling" do
       end
     end
 
-    it "falls back to generic error handling if there are no custom error handlers" do
+    it "falls back to 'default_render' if there is no 'render' method for the exception" do
       handle_error(error: UnhandledError.new) do |context, output|
         output.should contain("This is not a debug page")
         context.response.headers["Content-Type"].should eq("text/plain")

--- a/spec/lucky/invalid_param_error_spec.cr
+++ b/spec/lucky/invalid_param_error_spec.cr
@@ -8,6 +8,6 @@ describe Lucky::Exceptions::InvalidParam do
       param_type: "Int32")
     error.should be_a(Lucky::RenderableError)
     error.renderable_message.should contain("couldn't be parsed")
-    error.http_status.should eq 422
+    error.renderable_status.should eq 422
   end
 end

--- a/src/lucky/error_action.cr
+++ b/src/lucky/error_action.cr
@@ -33,13 +33,13 @@ abstract class Lucky::ErrorAction
   # Accept all formats. ErrorAction should *always* work
   class_getter _accepted_formats = [] of Symbol
 
-  abstract def render(error : Exception) : Lucky::Response
+  abstract def default_render(error : Exception) : Lucky::Response
   abstract def report(error : Exception) : Nil
 
   def perform_action(error : Exception)
     # Always get the rendered error because it also includes the HTTP status.
     # We need the HTTP status to use in the debug page.
-    response = render(error)
+    response = render(error) || default_render(error)
     ensure_response_is_returned(response)
 
     if html? && Lucky::ErrorHandler.settings.show_debug_output
@@ -51,6 +51,9 @@ abstract class Lucky::ErrorAction
     if !_dont_report.includes?(error.class)
       report(error)
     end
+  end
+
+  private def render(error : Exception) : Nil
   end
 
   private def ensure_response_is_returned(response : Lucky::Response) : Lucky::Response

--- a/src/lucky/exceptions.cr
+++ b/src/lucky/exceptions.cr
@@ -24,7 +24,7 @@ module Lucky
         "Required param \"#{param_name}\" with value \"#{param_value}\" couldn't be parsed to a \"#{param_type}\""
       end
 
-      def http_status : Int32
+      def renderable_status : Int32
         HTTP::Status::UNPROCESSABLE_ENTITY.value
       end
 

--- a/src/lucky/renderable_error.cr
+++ b/src/lucky/renderable_error.cr
@@ -1,4 +1,4 @@
 module Lucky::RenderableError
-  abstract def http_status : Int32
+  abstract def renderable_status : Int32
   abstract def renderable_message : String
 end


### PR DESCRIPTION
This will make it so `render` can return `nil` if it doesn't want to
render the exception. It'll instead fall back to the `default_render`
method.

This will allow methods to only render a custom response for certain
formats:

```crystal
def render(error : Lucky::UnknownAcceptHeaderError)
  if json?
   # Custom error for JSON
  end
  # But if not JSON, just render the default
end
```
