### PR TITLE
Update to Crystal 0.31.0

### DIFF
--- a/spec/lucky/base_http_client_spec.cr
+++ b/spec/lucky/base_http_client_spec.cr
@@ -128,6 +128,33 @@ private def test_server_port
   6226
 end
 
-at_exit do
-  server.close
-end
+# There is no hook for after the specs.
+# As a workaround we can just let the server be closed when the program finished
+# or monkey match Spec.run
+#
+# at_exit do
+#   server.close
+# end
+
+# monkey patch that requires renaminc server variable to SERVER constant
+#
+# private def spec_after_all
+#   puts "spec_after_all"
+#   SERVER.close
+# end
+
+# module Spec
+#   def self.run
+#     start_time = Time.monotonic
+
+#     at_exit do
+#       run_filters
+#       root_context.run
+#     ensure
+#       spec_after_all
+#       elapsed_time = Time.monotonic - start_time
+#       root_context.finish(elapsed_time, @@aborted)
+#       exit 1 unless root_context.succeeded && !@@aborted
+#     end
+#   end
+# end

--- a/spec/lucky/error_handling_spec.cr
+++ b/spec/lucky/error_handling_spec.cr
@@ -28,7 +28,7 @@ class FakeErrorAction < Lucky::ErrorAction
     plain_text "This is not a debug page", status: 500
   end
 
-  def report(error : Exception)
+  def report(error : Exception) : Nil
     settings.output.print("Reported: #{error.class.name}")
   end
 end

--- a/src/lucky/avram_error_extensions.cr
+++ b/src/lucky/avram_error_extensions.cr
@@ -1,7 +1,7 @@
 class Avram::InvalidOperationError
   include Lucky::RenderableError
 
-  def renderable_status
+  def renderable_status : Int32
     400
   end
 

--- a/src/lucky/errors.cr
+++ b/src/lucky/errors.cr
@@ -23,11 +23,11 @@ module Lucky
       super "Failed to parse the request parameters."
     end
 
-    def renderable_status
+    def renderable_status : Int32
       400
     end
 
-    def renderable_message
+    def renderable_message : String
       "There was a problem parsing the JSON params. Please check that it is formed correctly."
     end
   end
@@ -57,11 +57,11 @@ module Lucky
       TEXT
     end
 
-    def renderable_status
+    def renderable_status : Int32
       406
     end
 
-    def renderable_message
+    def renderable_message : String
       "Unrecognized Accept header '#{request.headers["Accept"]?}'."
     end
   end
@@ -86,11 +86,11 @@ module Lucky
       TEXT
     end
 
-    def renderable_status
+    def renderable_status : Int32
       406
     end
 
-    def renderable_message
+    def renderable_message : String
       "Accept header '#{request.headers["Accept"]?}' is not accepted."
     end
   end
@@ -121,7 +121,7 @@ module Lucky
       HTTP::Status::UNPROCESSABLE_ENTITY.value
     end
 
-    def renderable_message
+    def renderable_message : String
       message
     end
   end
@@ -138,11 +138,11 @@ module Lucky
       "Missing parameter: '#{param_name}''"
     end
 
-    def renderable_status
+    def renderable_status : Int32
       400
     end
 
-    def renderable_message
+    def renderable_message : String
       message
     end
   end
@@ -159,11 +159,11 @@ module Lucky
       "Missing param key: '#{nested_key}'"
     end
 
-    def renderable_status
+    def renderable_status : Int32
       400
     end
 
-    def renderable_message
+    def renderable_message : String
       message
     end
   end

--- a/src/lucky/file_response.cr
+++ b/src/lucky/file_response.cr
@@ -60,7 +60,7 @@ class Lucky::FileResponse < Lucky::Response
     File.open(full_path) { |file| IO.copy(file, context.response) }
   end
 
-  def status
+  def status : Int
     @status || context.response.status_code || DEFAULT_STATUS
   end
 

--- a/src/lucky/text_response.cr
+++ b/src/lucky/text_response.cr
@@ -16,7 +16,7 @@ class Lucky::TextResponse < Lucky::Response
     context.response.print body
   end
 
-  def status
+  def status : Int
     @status || context.response.status_code || DEFAULT_STATUS
   end
 end

--- a/tasks/watch.cr
+++ b/tasks/watch.cr
@@ -227,15 +227,28 @@ class Watch < LuckyCli::Task
   end
 
   private def parse_options
-    OptionParser.parse! do |parser|
-      parser.banner = "Usage: lucky watch [arguments]"
-      parser.on("-r", "--reload-browser", "Reloads browser on changes using browser-sync") {
-        @reload_browser = true
-      }
-      parser.on("-h", "--help", "Help here") {
-        puts parser
-        exit(0)
-      }
-    end
+    {% if compare_versions(Crystal::VERSION, "0.31.0-0") >= 0 %}
+      OptionParser.parse do |parser|
+        parser.banner = "Usage: lucky watch [arguments]"
+        parser.on("-r", "--reload-browser", "Reloads browser on changes using browser-sync") {
+          @reload_browser = true
+        }
+        parser.on("-h", "--help", "Help here") {
+          puts parser
+          exit(0)
+        }
+      end
+    {% else %}
+      OptionParser.parse! do |parser|
+        parser.banner = "Usage: lucky watch [arguments]"
+        parser.on("-r", "--reload-browser", "Reloads browser on changes using browser-sync") {
+          @reload_browser = true
+        }
+        parser.on("-h", "--help", "Help here") {
+          puts parser
+          exit(0)
+        }
+      end
+    {% end %}
   end
 end


### PR DESCRIPTION
Commits are self-descriptive.
The changes are compatible with Crystal 0.30.0 and 0.31.0.

The workaround for the http server lifecycle is a compromise. I would suggest to handle the lifecycle of the server in a different way. There are changes in how specs are run in Crystal 0.31.0 that prevent the former `at_exit` to work as it used to. Ref: https://github.com/crystal-lang/crystal/pull/8125#issuecomment-533296357
