### PR TITLE
Allow for spaces in pwd output in precompile_tasks

### DIFF
--- a/script/precompile_tasks
+++ b/script/precompile_tasks
@@ -5,5 +5,5 @@
 if [ "$LUCKY_ENV" != "production" ] && [ -z "$CI" ] && [ -z "$SKIP_LUCKY_TASK_PRECOMPILATION" ]; then
     shards build
     mkdir -p ../../bin
-    cp -r $PWD/bin $PWD/../..
+    cp -r "$PWD/bin" "$PWD/../.."
 fi


### PR DESCRIPTION
Closes #865

## Purpose
Fixing the issue outlined in the issue by applying the same fix that was applied to Avram.

## Description
n/a, too trivial

## Checklist
* [X] - An issue already exists detailing the issue/or feature request that this PR fixes
* [X] - All specs are formatted with `crystal tool format spec src`
* [X] - Inline documentation has been added and/or updated
* [X] - Lucky builds on docker with `./script/setup`
* [X] - All builds and specs pass on docker with `./script/test`
