### PR TITLE
Add link to migration guide as comment to generated migrations

### DIFF
--- a/tasks/gen/model.cr
+++ b/tasks/gen/model.cr
@@ -38,6 +38,8 @@ class Gen::Model < LuckyCli::Task
 
   private def migrate_contents
     String.build do |string|
+      string << "# Learn about migrations at: https://luckyframework.org/guides/database/migrations"
+      string << "\n"
       string << "create table_for(#{model_name}) do\n"
       string << "  primary_key id : Int64\n"
       string << "  add_timestamps\n"


### PR DESCRIPTION
## Purpose
Closes #915

## Description
Adds a link to the migration guide as comment of the beginning of each generated migration. Copy could potentially be improved, open to suggestions.

## Checklist
* [X] - An issue already exists detailing the issue/or feature request that this PR fixes
* [X] - All specs are formatted with `crystal tool format spec src`
* [X] - Inline documentation has been added and/or updated
* [X] - Lucky builds on docker with `./script/setup`
* [X] - All builds and specs pass on docker with `./script/test`
