### PR TITLE
debug error page in development was receiving reset context

### DIFF
--- a/src/lucky/error_action.cr
+++ b/src/lucky/error_action.cr
@@ -78,7 +78,6 @@ abstract class Lucky::ErrorAction
   end
 
   def render_exception_page(error : Exception, status : Int) : Lucky::Response
-    context.response.reset
     Lucky::TextResponse.new(
       context: context,
       status: status,


### PR DESCRIPTION
## Purpose
Fix debug error page

## Description
This fixes the following issue: https://github.com/luckyframework/lucky/issues/933

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
