### PR TITLE
changed defaults for lucky exec to make it work more like a repl

### DIFF
--- a/spec/tasks/exec_spec.cr
+++ b/spec/tasks/exec_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 describe Lucky::Exec do
   it "runs the editor" do
     with_test_template do
-      Lucky::Exec.new.call(["-e", %(echo '5 + 5' >)])
+      Lucky::Exec.new.call(["-o", "-e", %(echo '5 + 5' >)])
 
       newest_code.should eq <<-CODE
       5 + 5

--- a/spec/tasks/exec_spec.cr
+++ b/spec/tasks/exec_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 describe Lucky::Exec do
   it "runs the editor" do
     with_test_template do
-      Lucky::Exec.new.call(["-o", "-e", %(echo '5 + 5' >)])
+      Lucky::Exec.new.call(["--once", "--editor", %(echo '5 + 5' >)])
 
       newest_code.should eq <<-CODE
       5 + 5

--- a/tasks/exec.cr
+++ b/tasks/exec.cr
@@ -12,10 +12,14 @@ class Lucky::Exec < LuckyCli::Task
     setting template_path : String = "#{__DIR__}/exec_template.cr.template"
   end
 
+  def print_help_or_call(args : Array(String), io : IO = STDERR)
+    call(args)
+  end
+
   def call(args = ARGV)
     editor = settings.editor
-    repeat = false
-    back = 0
+    repeat = true
+    back = 1
 
     OptionParser.parse(args) do |parser|
       parser.banner = "Usage: lucky exec [arguments]"
@@ -23,10 +27,10 @@ class Lucky::Exec < LuckyCli::Task
       parser.on("-e EDITOR", "--editor EDITOR", "Which editor to use") do |e|
         editor = e
       end
-      parser.on("-r", "--repeat", "Keep editing in a loop") do
-        repeat = true
+      parser.on("-o", "--once", "Don't loop") do
+        repeat = false
       end
-      parser.on("-b BACK", "--back BACK", "Keep editing in a loop") do |b|
+      parser.on("-b BACK", "--back BACK", "Load code from this many sessions back. Default is 1.") do |b|
         back = b.to_i
       end
       parser.invalid_option do |flag|

--- a/tasks/exec.cr
+++ b/tasks/exec.cr
@@ -12,6 +12,7 @@ class Lucky::Exec < LuckyCli::Task
     setting template_path : String = "#{__DIR__}/exec_template.cr.template"
   end
 
+  # Override parent class (LuckyCli::Task) because this method hijacks the following args: "--help", "-h", "help"
   def print_help_or_call(args : Array(String), io : IO = STDERR)
     call(args)
   end


### PR DESCRIPTION
## Purpose
To make lucky exec work more like a repl by changing the default options.

## Description
Addresses #937.

Note: the print_help_or_call method is overridden because because it hijacks the help message.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
