### PR TITLE
Adding to_param on UUID extensions

### DIFF
--- a/spec/charms/uuid_spec.cr
+++ b/spec/charms/uuid_spec.cr
@@ -1,0 +1,11 @@
+require "../spec_helper"
+
+describe "UUID charm" do
+  describe "to_parm" do
+    it "gets the value as a string" do
+      uuid = UUID.new("87b3042b-9b9a-41b7-8b15-a93d3f17025e")
+      uuid.to_param.should eq "87b3042b-9b9a-41b7-8b15-a93d3f17025e"
+      uuid.to_param.class.should eq String
+    end
+  end
+end

--- a/src/charms/uuid_extensions.cr
+++ b/src/charms/uuid_extensions.cr
@@ -1,0 +1,5 @@
+struct UUID
+  def to_param : String
+    self.to_s
+  end
+end


### PR DESCRIPTION
## Purpose
This allows UUID values to be used in routes.

## Checklist
* [X] - All specs are formatted with `crystal tool format spec src`
* [X] - Lucky builds on docker with `./script/setup`
* [X] - All builds and specs pass on docker with `./script/test`
