### PR TITLE
Adds the boolean attributes to checkbox and textarea helper methods.

### DIFF
--- a/spec/lucky/input_helpers_spec.cr
+++ b/spec/lucky/input_helpers_spec.cr
@@ -91,7 +91,7 @@ describe Lucky::InputHelpers do
       view.checkbox(false_field).to_s.should contain <<-HTML
       <input type="hidden" id="" name="user:admin" value="false">
       HTML
-			view.checkbox(false_field, attrs: [:checked]).to_s.should contain <<-HTML
+      view.checkbox(false_field, attrs: [:checked]).to_s.should contain <<-HTML
 			<input type="checkbox" id="user_admin" name="user:admin" value="true" checked>
 			HTML
 
@@ -102,7 +102,7 @@ describe Lucky::InputHelpers do
       view.checkbox(true_field).to_s.should contain <<-HTML
       <input type="hidden" id="" name="user:admin" value="false">
       HTML
-			view.checkbox(true_field, attrs: [:required]).to_s.should contain <<-HTML
+      view.checkbox(true_field, attrs: [:required]).to_s.should contain <<-HTML
 			<input type="checkbox" id="user_admin" name="user:admin" value="true" checked="true" required>
 			HTML
     end
@@ -239,7 +239,7 @@ describe Lucky::InputHelpers do
     <textarea id="user_first_name" name="user:first_name" rows="5" cols="15">My name</textarea>
     HTML
 
-		view.textarea(form.first_name, attrs: [:required]).to_s.should contain <<-HTML
+    view.textarea(form.first_name, attrs: [:required]).to_s.should contain <<-HTML
 		<textarea id="user_first_name" name="user:first_name" required>My name</textarea>
 		HTML
   end

--- a/spec/lucky/input_helpers_spec.cr
+++ b/spec/lucky/input_helpers_spec.cr
@@ -91,6 +91,9 @@ describe Lucky::InputHelpers do
       view.checkbox(false_field).to_s.should contain <<-HTML
       <input type="hidden" id="" name="user:admin" value="false">
       HTML
+			view.checkbox(false_field, attrs: [:checked]).to_s.should contain <<-HTML
+			<input type="checkbox" id="user_admin" name="user:admin" value="true" checked>
+			HTML
 
       true_field = form.admin(true)
       view.checkbox(true_field).to_s.should contain <<-HTML
@@ -99,6 +102,9 @@ describe Lucky::InputHelpers do
       view.checkbox(true_field).to_s.should contain <<-HTML
       <input type="hidden" id="" name="user:admin" value="false">
       HTML
+			view.checkbox(true_field, attrs: [:required]).to_s.should contain <<-HTML
+			<input type="checkbox" id="user_admin" name="user:admin" value="true" checked="true" required>
+			HTML
     end
   end
 
@@ -232,6 +238,10 @@ describe Lucky::InputHelpers do
     view.textarea(form.first_name, rows: 5, cols: 15).to_s.should contain <<-HTML
     <textarea id="user_first_name" name="user:first_name" rows="5" cols="15">My name</textarea>
     HTML
+
+		view.textarea(form.first_name, attrs: [:required]).to_s.should contain <<-HTML
+		<textarea id="user_first_name" name="user:first_name" required>My name</textarea>
+		HTML
   end
 
   it "renders time inputs" do

--- a/spec/lucky/input_helpers_spec.cr
+++ b/spec/lucky/input_helpers_spec.cr
@@ -92,8 +92,8 @@ describe Lucky::InputHelpers do
       <input type="hidden" id="" name="user:admin" value="false">
       HTML
       view.checkbox(false_field, attrs: [:checked]).to_s.should contain <<-HTML
-			<input type="checkbox" id="user_admin" name="user:admin" value="true" checked>
-			HTML
+      <input type="checkbox" id="user_admin" name="user:admin" value="true" checked>
+      HTML
 
       true_field = form.admin(true)
       view.checkbox(true_field).to_s.should contain <<-HTML
@@ -103,8 +103,8 @@ describe Lucky::InputHelpers do
       <input type="hidden" id="" name="user:admin" value="false">
       HTML
       view.checkbox(true_field, attrs: [:required]).to_s.should contain <<-HTML
-			<input type="checkbox" id="user_admin" name="user:admin" value="true" checked="true" required>
-			HTML
+      <input type="checkbox" id="user_admin" name="user:admin" value="true" checked="true" required>
+      HTML
     end
   end
 
@@ -240,8 +240,8 @@ describe Lucky::InputHelpers do
     HTML
 
     view.textarea(form.first_name, attrs: [:required]).to_s.should contain <<-HTML
-		<textarea id="user_first_name" name="user:first_name" required>My name</textarea>
-		HTML
+    <textarea id="user_first_name" name="user:first_name" required>My name</textarea>
+    HTML
   end
 
   it "renders time inputs" do

--- a/src/lucky/tags/input_helpers.cr
+++ b/src/lucky/tags/input_helpers.cr
@@ -29,13 +29,13 @@ module Lucky::InputHelpers
   end
 
   generate_helpful_error_for textarea
-	
-	# Returns a textarea field.
-	#
-	# ```
-	# textarea(attribute)
-	# # => <textarea id="param_key_attribute_name" name="param_key:attribute_name"></textarea>
-	# ```
+
+  # Returns a textarea field.
+  #
+  # ```
+  # textarea(attribute)
+  # # => <textarea id="param_key_attribute_name" name="param_key:attribute_name"></textarea>
+  # ```
   def textarea(field : Avram::PermittedAttribute, **html_options)
     textarea field.param.to_s, merge_options(html_options, {
       "id"   => input_id(field),
@@ -43,13 +43,13 @@ module Lucky::InputHelpers
     })
   end
 
-	# Similar to textarea; this allows for Boolean attributes
-	# through `attrs`.
-	#
-	# ```
-	# textarea(attribute, attrs: [:required])
-	# # => <textarea id="param_key_attribute_name" name="param_key:attribute_name" required></textarea>
-	# ```
+  # Similar to textarea; this allows for Boolean attributes
+  # through `attrs`.
+  #
+  # ```
+  # textarea(attribute, attrs: [:required])
+  # # => <textarea id="param_key_attribute_name" name="param_key:attribute_name" required></textarea>
+  # ```
   def textarea(field : Avram::PermittedAttribute, attrs : Array(Symbol), **html_options)
     textarea field.param.to_s, merge_options(html_options, {
       "id"   => input_id(field),
@@ -57,7 +57,7 @@ module Lucky::InputHelpers
     }), attrs: attrs
   end
 
-	def checkbox(field : Avram::PermittedAttribute(T),
+  def checkbox(field : Avram::PermittedAttribute(T),
                unchecked_value : String,
                checked_value : String,
                **html_options) forall T
@@ -79,7 +79,7 @@ module Lucky::InputHelpers
     generate_input(field, "checkbox", html_options)
   end
 
-  def checkbox(field : Avram::PermittedAttribute(Bool?), attrs : Array(Symbol),  **html_options)
+  def checkbox(field : Avram::PermittedAttribute(Bool?), attrs : Array(Symbol), **html_options)
     unchecked_value = "false"
     if field.value
       html_options = merge_options(html_options, {"checked" => "true"})
@@ -89,7 +89,7 @@ module Lucky::InputHelpers
     generate_input(field, "checkbox", html_options, attrs: attrs)
   end
 
-	generate_helpful_error_for checkbox
+  generate_helpful_error_for checkbox
 
   {% for input_type in ["text", "email", "file", "color", "hidden", "number", "url", "search", "range"] %}
     generate_helpful_error_for {{input_type.id}}_input

--- a/src/lucky/tags/input_helpers.cr
+++ b/src/lucky/tags/input_helpers.cr
@@ -29,7 +29,13 @@ module Lucky::InputHelpers
   end
 
   generate_helpful_error_for textarea
-
+	
+	# Returns a textarea field.
+	#
+	# ```
+	# textarea(attribute)
+	# # => <textarea id="param_key_attribute_name" name="param_key:attribute_name"></textarea>
+	# ```
   def textarea(field : Avram::PermittedAttribute, **html_options)
     textarea field.param.to_s, merge_options(html_options, {
       "id"   => input_id(field),
@@ -37,7 +43,21 @@ module Lucky::InputHelpers
     })
   end
 
-  def checkbox(field : Avram::PermittedAttribute(T),
+	# Similar to textarea; this allows for Boolean attributes
+	# through `attrs`.
+	#
+	# ```
+	# textarea(attribute, attrs: [:required])
+	# # => <textarea id="param_key_attribute_name" name="param_key:attribute_name" required></textarea>
+	# ```
+  def textarea(field : Avram::PermittedAttribute, attrs : Array(Symbol), **html_options)
+    textarea field.param.to_s, merge_options(html_options, {
+      "id"   => input_id(field),
+      "name" => input_name(field),
+    }), attrs: attrs
+  end
+
+	def checkbox(field : Avram::PermittedAttribute(T),
                unchecked_value : String,
                checked_value : String,
                **html_options) forall T
@@ -59,7 +79,17 @@ module Lucky::InputHelpers
     generate_input(field, "checkbox", html_options)
   end
 
-  generate_helpful_error_for checkbox
+  def checkbox(field : Avram::PermittedAttribute(Bool?), attrs : Array(Symbol),  **html_options)
+    unchecked_value = "false"
+    if field.value
+      html_options = merge_options(html_options, {"checked" => "true"})
+    end
+    html_options = merge_options(html_options, {"value" => "true"})
+    generate_input(field, "hidden", {"id" => ""}, {"value" => unchecked_value})
+    generate_input(field, "checkbox", html_options, attrs: attrs)
+  end
+
+	generate_helpful_error_for checkbox
 
   {% for input_type in ["text", "email", "file", "color", "hidden", "number", "url", "search", "range"] %}
     generate_helpful_error_for {{input_type.id}}_input

--- a/src/lucky/tags/input_helpers.cr
+++ b/src/lucky/tags/input_helpers.cr
@@ -1,4 +1,6 @@
 module Lucky::InputHelpers
+  EMPTY_BOOLEAN_ATTRIBUTES = [] of Symbol
+
   macro error_message_for_unallowed_field
     {% raise <<-ERROR
       The attribute is not permitted.
@@ -37,10 +39,7 @@ module Lucky::InputHelpers
   # # => <textarea id="param_key_attribute_name" name="param_key:attribute_name"></textarea>
   # ```
   def textarea(field : Avram::PermittedAttribute, **html_options)
-    textarea field.param.to_s, merge_options(html_options, {
-      "id"   => input_id(field),
-      "name" => input_name(field),
-    })
+    textarea field, EMPTY_BOOLEAN_ATTRIBUTES, **html_options
   end
 
   # Similar to textarea; this allows for Boolean attributes
@@ -70,13 +69,7 @@ module Lucky::InputHelpers
   end
 
   def checkbox(field : Avram::PermittedAttribute(Bool?), **html_options)
-    unchecked_value = "false"
-    if field.value
-      html_options = merge_options(html_options, {"checked" => "true"})
-    end
-    html_options = merge_options(html_options, {"value" => "true"})
-    generate_input(field, "hidden", {"id" => ""}, {"value" => unchecked_value})
-    generate_input(field, "checkbox", html_options)
+    checkbox field, EMPTY_BOOLEAN_ATTRIBUTES, **html_options
   end
 
   def checkbox(field : Avram::PermittedAttribute(Bool?), attrs : Array(Symbol), **html_options)
@@ -101,7 +94,7 @@ module Lucky::InputHelpers
     # # => <input type="{{input_type.id}}" id="param_key_attribute_name" name="param_key:attribute_name" value="" />
     # ```
     def {{input_type.id}}_input(field : Avram::PermittedAttribute, **html_options)
-      generate_input(field, {{input_type}}, html_options)
+      {{input_type.id}}_input field, EMPTY_BOOLEAN_ATTRIBUTES, **html_options
     end
 
     # Similar to {{input_type.id}}_input; this allows for Boolean attributes
@@ -119,7 +112,7 @@ module Lucky::InputHelpers
   generate_helpful_error_for telephone_input
 
   def telephone_input(field : Avram::PermittedAttribute, **html_options)
-    generate_input(field, "tel", html_options)
+    telephone_input field, EMPTY_BOOLEAN_ATTRIBUTES, **html_options
   end
 
   def telephone_input(field : Avram::PermittedAttribute, attrs : Array(Symbol), **html_options)
@@ -129,7 +122,7 @@ module Lucky::InputHelpers
   generate_helpful_error_for password_input
 
   def password_input(field : Avram::PermittedAttribute, **html_options)
-    generate_input(field, "password", html_options, {"value" => ""})
+    password_input field, EMPTY_BOOLEAN_ATTRIBUTES, **html_options
   end
 
   def password_input(field : Avram::PermittedAttribute, attrs : Array(Symbol), **html_options)
@@ -139,8 +132,7 @@ module Lucky::InputHelpers
   generate_helpful_error_for time_input
 
   def time_input(field : Avram::PermittedAttribute, **html_options)
-    value = field.value.try(&.to_s("%H:%M:%S")) || field.param.to_s
-    generate_input(field, "time", html_options, {"value" => value})
+    time_input field, EMPTY_BOOLEAN_ATTRIBUTES, **html_options
   end
 
   def time_input(field : Avram::PermittedAttribute, attrs : Array(Symbol), **html_options)
@@ -151,8 +143,7 @@ module Lucky::InputHelpers
   generate_helpful_error_for date_input
 
   def date_input(field : Avram::PermittedAttribute, **html_options)
-    value = field.value.try(&.to_s("%Y-%m-%d")) || field.param.to_s
-    generate_input(field, "date", html_options, {"value" => value})
+    date_input field, EMPTY_BOOLEAN_ATTRIBUTES, **html_options
   end
 
   def date_input(field : Avram::PermittedAttribute, attrs : Array(Symbol), **html_options)
@@ -163,8 +154,7 @@ module Lucky::InputHelpers
   generate_helpful_error_for datetime_input
 
   def datetime_input(field : Avram::PermittedAttribute, **html_options)
-    value = field.value.try(&.to_s("%Y-%m-%dT%H:%M:%S")) || field.param.to_s
-    generate_input(field, "datetime-local", html_options, {"value" => value})
+    datetime_input field, EMPTY_BOOLEAN_ATTRIBUTES, **html_options
   end
 
   def datetime_input(field : Avram::PermittedAttribute, attrs : Array(Symbol), **html_options)


### PR DESCRIPTION
## Purpose
Fixes #952

## Description
Adds the ability to set boolean attributes `attrs: [:required]` on `textarea` and `checkbox` methods.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
