### PR TITLE
Rename `form` to `operation` in resource generator

### DIFF
--- a/tasks/gen/templates/resource/actions/{{folder_name}}/create.cr.ecr
+++ b/tasks/gen/templates/resource/actions/{{folder_name}}/create.cr.ecr
@@ -1,12 +1,12 @@
 class <%= pluralized_resource %>::Create < BrowserAction
   route do
-    <%= operation_class %>.create(params) do |form, <%= underscored_resource %>|
+    <%= operation_class %>.create(params) do |operation, <%= underscored_resource %>|
       if <%= underscored_resource %>
         flash.success = "The record has been saved"
         redirect Show.with(<%= underscored_resource %>.id)
       else
         flash.failure = "It looks like the form is not valid"
-        html NewPage, form: form
+        html NewPage, operation: operation
       end
     end
   end

--- a/tasks/gen/templates/resource/actions/{{folder_name}}/edit.cr.ecr
+++ b/tasks/gen/templates/resource/actions/{{folder_name}}/edit.cr.ecr
@@ -2,7 +2,7 @@ class <%= pluralized_resource %>::Edit < BrowserAction
   route do
     <%= underscored_resource %> = <%= query_class %>.find(<%= resource_id_method_name %>)
     html EditPage,
-      form: <%= operation_class %>.new(<%= underscored_resource %>),
+      operation: <%= operation_class %>.new(<%= underscored_resource %>),
       <%= underscored_resource %>: <%= underscored_resource %>
   end
 end

--- a/tasks/gen/templates/resource/actions/{{folder_name}}/new.cr.ecr
+++ b/tasks/gen/templates/resource/actions/{{folder_name}}/new.cr.ecr
@@ -1,5 +1,5 @@
 class <%= pluralized_resource %>::New < BrowserAction
   route do
-    html NewPage, form: <%= operation_class %>.new
+    html NewPage, operation: <%= operation_class %>.new
   end
 end

--- a/tasks/gen/templates/resource/actions/{{folder_name}}/update.cr.ecr
+++ b/tasks/gen/templates/resource/actions/{{folder_name}}/update.cr.ecr
@@ -1,13 +1,13 @@
 class <%= pluralized_resource %>::Update < BrowserAction
   route do
     <%= underscored_resource %> = <%= query_class %>.find(<%= resource_id_method_name %>)
-    <%= operation_class %>.update(<%= underscored_resource %>, params) do |form, <%= underscored_resource %>|
-      if form.saved?
+    <%= operation_class %>.update(<%= underscored_resource %>, params) do |operation, <%= underscored_resource %>|
+      if operation.saved?
         flash.success = "The record has been updated"
         redirect Show.with(<%= underscored_resource %>.id)
       else
         flash.failure = "It looks like the form is not valid"
-        html EditPage, form: form, <%= underscored_resource %>: <%= underscored_resource %>
+        html EditPage, operation: operation, <%= underscored_resource %>: <%= underscored_resource %>
       end
     end
   end

--- a/tasks/gen/templates/resource/pages/{{folder_name}}/edit_page.cr.ecr
+++ b/tasks/gen/templates/resource/pages/{{folder_name}}/edit_page.cr.ecr
@@ -1,11 +1,11 @@
 class <%= pluralized_resource %>::EditPage < MainLayout
-  needs form : <%= operation_class %>
+  needs operation : <%= operation_class %>
   needs <%= underscored_resource %> : <%= resource %>
   quick_def page_title, "Edit"
 
   def content
     h1 "Edit"
-    render_<%= underscored_resource %>_form(@form)
+    render_<%= underscored_resource %>_form(@operation)
   end
 
   def render_<%= underscored_resource %>_form(f)

--- a/tasks/gen/templates/resource/pages/{{folder_name}}/edit_page.cr.ecr
+++ b/tasks/gen/templates/resource/pages/{{folder_name}}/edit_page.cr.ecr
@@ -8,10 +8,10 @@ class <%= pluralized_resource %>::EditPage < MainLayout
     render_<%= underscored_resource %>_form(@operation)
   end
 
-  def render_<%= underscored_resource %>_form(f)
+  def render_<%= underscored_resource %>_form(op)
     form_for <%= pluralized_resource %>::Update.with(@<%= underscored_resource %>.id) do
       <%- columns.each_with_index do |column, index| -%>
-      mount Shared::Field.new(f.<%= column.name %>)<% if index.zero? %>, &.text_input(autofocus: "true")<% end %>
+      mount Shared::Field.new(op.<%= column.name %>)<% if index.zero? %>, &.text_input(autofocus: "true")<% end %>
       <%- end -%>
 
       submit "Update", data_disable_with: "Updating..."

--- a/tasks/gen/templates/resource/pages/{{folder_name}}/new_page.cr.ecr
+++ b/tasks/gen/templates/resource/pages/{{folder_name}}/new_page.cr.ecr
@@ -1,10 +1,10 @@
 class <%= pluralized_resource %>::NewPage < MainLayout
-  needs form : <%= operation_class %>
+  needs operation : <%= operation_class %>
   quick_def page_title, "New"
 
   def content
     h1 "New"
-    render_<%= underscored_resource %>_form(@form)
+    render_<%= underscored_resource %>_form(@operation)
   end
 
   def render_<%= underscored_resource %>_form(f)

--- a/tasks/gen/templates/resource/pages/{{folder_name}}/new_page.cr.ecr
+++ b/tasks/gen/templates/resource/pages/{{folder_name}}/new_page.cr.ecr
@@ -7,10 +7,10 @@ class <%= pluralized_resource %>::NewPage < MainLayout
     render_<%= underscored_resource %>_form(@operation)
   end
 
-  def render_<%= underscored_resource %>_form(f)
+  def render_<%= underscored_resource %>_form(op)
     form_for <%= pluralized_resource %>::Create do
       <%- columns.each_with_index do |column, index| -%>
-      mount Shared::Field.new(f.<%= column.name %>)<% if index.zero? %>, &.text_input(autofocus: "true")<% end %>
+      mount Shared::Field.new(op.<%= column.name %>)<% if index.zero? %>, &.text_input(autofocus: "true")<% end %>
       <%- end -%>
 
       submit "Save", data_disable_with: "Saving..."


### PR DESCRIPTION
Fixes #946