### PR TITLE
Fix watch task -h flag override

### DIFF
--- a/tasks/watch.cr
+++ b/tasks/watch.cr
@@ -204,21 +204,9 @@ class Watch < LuckyCli::Task
   summary "Start and recompile project when files change"
   @reload_browser : Bool = false
 
-  def help_message
-    <<-TEXT
-    Starts a file watching process and runs your project.
-    When any of your project files change, this will recompile the
-    project for you.
-
-    Examples:
-
-      lucky watch
-      lucky watch --reload-browser
-
-    Options:
-
-      -r , --reload-browser     Reloads browser on changes using browser-sync
-    TEXT
+  # Override parent class (LuckyCli::Task) because this method hijacks the following args: "--help", "-h", "help"
+  def print_help_or_call(args : Array(String), io : IO = STDERR)
+    call(args)
   end
 
   def call
@@ -245,7 +233,12 @@ class Watch < LuckyCli::Task
 
   private def parse_options
     OptionParser.parse do |parser|
-      parser.banner = "Usage: lucky watch [arguments]"
+      parser.banner = <<-TEXT
+      #{summary}
+
+      Usage: lucky watch [arguments]
+      TEXT
+      parser.on("-h", "--help", "Show this help message") { puts parser; exit(0) }
       parser.on("-r", "--reload-browser", "Reloads browser on changes using browser-sync") {
         @reload_browser = true
       }

--- a/tasks/watch.cr
+++ b/tasks/watch.cr
@@ -210,8 +210,8 @@ class Watch < LuckyCli::Task
     call(args)
   end
 
-  def call
-    parse_options
+  def call(args = ARGV)
+    parse_options(args)
 
     build_commands = ["crystal build ./src/start_server.cr"]
     run_commands = ["./start_server"]
@@ -232,8 +232,8 @@ class Watch < LuckyCli::Task
     end
   end
 
-  private def parse_options
-    OptionParser.parse do |parser|
+  private def parse_options(args)
+    OptionParser.parse(args) do |parser|
       parser.banner = <<-TEXT
       #{summary}
 

--- a/tasks/watch.cr
+++ b/tasks/watch.cr
@@ -204,6 +204,23 @@ class Watch < LuckyCli::Task
   summary "Start and recompile project when files change"
   @reload_browser : Bool = false
 
+  def help_message
+    <<-TEXT
+    Starts a file watching process and runs your project.
+    When any of your project files change, this will recompile the
+    project for you.
+
+    Examples:
+
+      lucky watch
+      lucky watch --reload-browser
+
+    Options:
+
+      -r , --reload-browser     Reloads browser on changes using browser-sync
+    TEXT
+  end
+
   def call
     parse_options
 
@@ -231,10 +248,6 @@ class Watch < LuckyCli::Task
       parser.banner = "Usage: lucky watch [arguments]"
       parser.on("-r", "--reload-browser", "Reloads browser on changes using browser-sync") {
         @reload_browser = true
-      }
-      parser.on("-h", "--help", "Help here") {
-        puts parser
-        exit(0)
       }
     end
   end


### PR DESCRIPTION
## Purpose
Fixes #942 

## Description
All tasks respond to a `-h` flag by default. If a task includes the `OptionParser`, it's `-h` flag is overridden. This PR follows what the exec task did and puts focus back on the OptionParser. I also updated the help banner to include the summary just to help make it a little clearer.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
