### PR TITLE
Fixes with_defaults for tags that have content.

### DIFF
--- a/spec/lucky/with_defaults_spec.cr
+++ b/spec/lucky/with_defaults_spec.cr
@@ -33,6 +33,17 @@ private class TestWithDefaultsPage
       html.text_input replace_class: "replaced-without-default"
     end
 
+    # tags that have content
+    with_defaults class: "default" do |html|
+      html.div "text content"
+    end
+
+    with_defaults class: "default" do |html|
+      html.div do
+        text "block content"
+      end
+    end
+
     view
   end
 end
@@ -55,6 +66,10 @@ describe "with_defaults" do
       .should contain %(<input type="text" id="user_name" name="user:name" value="" class="appended-without-default">)
     contents
       .should contain %(<input type="text" id="user_name" name="user:name" value="" class="replaced-without-default">)
+    contents
+      .should contain %(<div class="default">text content</div>)
+    contents
+      .should contain %(<div class="default">block content</div>)
   end
 end
 

--- a/src/lucky/tags/with_defaults.cr
+++ b/src/lucky/tags/with_defaults.cr
@@ -31,7 +31,6 @@ module Lucky::WithDefaults
     macro method_missing(call)
       overridden_html_class = nil
 
-      {% args = call.args %}
       {% named_args = call.named_args %}
       {% if named_args %}
         {% if call.named_args.any? { |arg| arg.name == :class } %}
@@ -103,8 +102,8 @@ module Lucky::WithDefaults
       end
       {% end %}
 
-      args = Tuple.new({% if args %}
-        {% for arg in args %}
+      args = Tuple.new({% if call.args %}
+        {% for arg in call.args %}
           {{ arg }},
         {% end %}
       {% end %})


### PR DESCRIPTION
## Purpose
There were some bugs in `with_defaults`. See #971 

## Description
`with_defaults` did not work with html tags that had content.
See #971 

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
