### PR TITLE
attempt to fix tests in ci

### DIFF
--- a/spec/lucky/fallback_action_spec.cr
+++ b/spec/lucky/fallback_action_spec.cr
@@ -2,24 +2,18 @@ require "../spec_helper"
 
 include ContextHelper
 
-class Rendering::FallbackRoute < TestAction
-  fallback do
-    plain_text "Hey, you found me!"
-  end
-end
-
 describe "fallback routing" do
   it "renders from a fallback" do
-    response = Rendering::FallbackRoute.new(build_context, params).call
-    response.body.should eq "Hey, you found me!"
+    response = TestFallbackAction::Index.new(build_context, params).call
+    response.body.should eq "You found me"
     response.status.should eq 200
   end
 
   it "does not generate route helpers" do
-    Rendering::FallbackRoute.responds_to?(:route).should be_false
-    Rendering::FallbackRoute.responds_to?(:with).should be_false
-    Rendering::FallbackRoute.responds_to?(:url).should be_false
-    Rendering::FallbackRoute.responds_to?(:path).should be_false
-    Rendering::FallbackRoute.responds_to?(:url_without_query_params).should be_false
+    TestFallbackAction::Index.responds_to?(:route).should be_false
+    TestFallbackAction::Index.responds_to?(:with).should be_false
+    TestFallbackAction::Index.responds_to?(:url).should be_false
+    TestFallbackAction::Index.responds_to?(:path).should be_false
+    TestFallbackAction::Index.responds_to?(:url_without_query_params).should be_false
   end
 end

--- a/spec/lucky/fallback_action_spec.cr
+++ b/spec/lucky/fallback_action_spec.cr
@@ -2,6 +2,8 @@ require "../spec_helper"
 
 include ContextHelper
 
+# TestFallbackAction::Index is defined in spec/support/test_fallback_action.cr
+# so that it can be used in other tests without causing conflicts.
 describe "fallback routing" do
   it "renders from a fallback" do
     response = TestFallbackAction::Index.new(build_context, params).call

--- a/spec/lucky/route_not_found_handler_spec.cr
+++ b/spec/lucky/route_not_found_handler_spec.cr
@@ -2,6 +2,8 @@ require "../spec_helper"
 
 include ContextHelper
 
+# TestFallbackAction::Index is defined in spec/support/test_fallback_action.cr
+# so that it can be used in other tests without causing conflicts.
 describe Lucky::RouteNotFoundHandler do
   it "raises a Lucky::RouteNotFoundError" do
     context = build_context(path: "/foo/bar")

--- a/spec/lucky/route_not_found_handler_spec.cr
+++ b/spec/lucky/route_not_found_handler_spec.cr
@@ -2,12 +2,6 @@ require "../spec_helper"
 
 include ContextHelper
 
-class SampleFallbackAction::Index < TestAction
-  fallback do
-    plain_text "Last chance"
-  end
-end
-
 describe Lucky::RouteNotFoundHandler do
   it "raises a Lucky::RouteNotFoundError" do
     context = build_context(path: "/foo/bar")
@@ -21,7 +15,7 @@ describe Lucky::RouteNotFoundHandler do
   end
 
   it "has the fallback_action set from a fallback route" do
-    Lucky::RouteNotFoundHandler.fallback_action.should eq SampleFallbackAction::Index
+    Lucky::RouteNotFoundHandler.fallback_action.should eq TestFallbackAction::Index
   end
 
   it "responds with a fallback action" do
@@ -34,7 +28,7 @@ describe Lucky::RouteNotFoundHandler do
     handler.call(context)
 
     context.response.close
-    output.to_s.should contain "Last chance"
+    output.to_s.should contain "You found me"
   end
 
   it "still raises a Lucky::RouteNotFoundError for non GET requests" do

--- a/spec/support/test_fallback_action.cr
+++ b/spec/support/test_fallback_action.cr
@@ -1,0 +1,5 @@
+class TestFallbackAction::Index < TestAction
+  fallback do
+    plain_text "You found me"
+  end
+end

--- a/spec/support/test_fallback_action.cr
+++ b/spec/support/test_fallback_action.cr
@@ -1,3 +1,5 @@
+# This file depends on spec/test_action.cr being available first, so the name matters.
+# If the name changes you may need to require ./spec/test_action.cr
 class TestFallbackAction::Index < TestAction
   fallback do
     plain_text "You found me"


### PR DESCRIPTION
## Purpose
route_not_found_handler_spec fails in CI #973 

## Description
#973 

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
