### PR TITLE
add #any? and #empty? to Lucky::FlashStore

### DIFF
--- a/spec/lucky/cookies/flash_store_spec.cr
+++ b/spec/lucky/cookies/flash_store_spec.cr
@@ -62,6 +62,38 @@ describe Lucky::FlashStore do
     end
   end
 
+  describe "#any?" do
+    it "returns true if there are key/value pairs" do
+      flash_store = build_flash_store(next: {
+        "some_key" => "some_value",
+      })
+
+      flash_store.any?.should be_true
+    end
+
+    it "returns false if there are no key/value pairs" do
+      flash_store = build_flash_store
+
+      flash_store.any?.should be_false
+    end
+  end
+
+  describe "#empty?" do
+    it "returns false if there are key/value pairs" do
+      flash_store = build_flash_store(next: {
+        "some_key" => "some_value",
+      })
+
+      flash_store.empty?.should be_false
+    end
+
+    it "returns true if there are no key/value pairs" do
+      flash_store = build_flash_store
+
+      flash_store.empty?.should be_true
+    end
+  end
+
   describe "#all" do
     it "prefers values from @next over @now" do
       next_hash = {"name" => "Paul"}

--- a/src/lucky/cookies/flash_store.cr
+++ b/src/lucky/cookies/flash_store.cr
@@ -2,7 +2,7 @@ class Lucky::FlashStore
   SESSION_KEY = "_flash"
   alias Key = String | Symbol
 
-  delegate each, to: all
+  delegate any?, each, empty?, to: all
 
   @now = {} of String => String
   @next = {} of String => String


### PR DESCRIPTION
## Purpose
Add a couple of missing but useful methods to the Lucky::FlashStore (any?, and empty?) #975 

## Description
Some common ways of using the flash store were missing (any?, and empty?), for example...
```crystal
# src/components/shared/flash_messages.cr
class Shared::FlashMessages < BaseComponent
  needs flash : Lucky::FlashStore

  FLASH_CSS_CLASSES = {
    "primary": "is-primary",
    "info":    "is-info",
    "link":    "is-link",
    "success": "is-success",
    "warning": "is-warning",
    "failure": "is-danger",
  }

  def render
    if @flash.any?
      div class: "flash-messages" do
        @flash.each do |flash_type, flash_message|
          div class: "notification #{class_for_flash(flash_type)}", flow_id: "flash" do
            button class: "delete"
            text flash_message
          end
        end
      end
    end
  end

  private def class_for_flash(flash_type)
    FLASH_CSS_CLASSES[flash_type]
  end
end
```

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
