### PR TITLE
allow false as default arg to html page

### DIFF
--- a/spec/lucky/html_page_spec.cr
+++ b/spec/lucky/html_page_spec.cr
@@ -62,6 +62,26 @@ class InnerPage < MainLayout
   end
 end
 
+class LessNeedyDefaultsPage < MainLayout
+  needs a_string : String = "string default"
+  needs bool : Bool = false
+  needs nil_default : String? = nil
+
+  def inner
+    div @a_string
+    if @bool == false
+      div "bool default"
+    end
+    if @nil_default.nil?
+      div "nil default"
+    end
+  end
+
+  def page_title
+    "Boolean Default"
+  end
+end
+
 describe Lucky::HTMLPage do
   describe "tags that contain contents" do
     it "can be called with various arguments" do
@@ -110,6 +130,20 @@ describe Lucky::HTMLPage do
     it "renders layouts and needs" do
       InnerPage.new(build_context, foo: "bar").render.to_s.should contain %(<title>A great title</title>)
       InnerPage.new(build_context, foo: "bar").render.to_s.should contain %(<body>Inner textbar</body>)
+    end
+  end
+
+  describe "needs with defaults" do
+    it "allows default values to needs" do
+      LessNeedyDefaultsPage.new(build_context).render.to_s.should contain %(<div>string default</div>)
+    end
+
+    it "allows false as default value to needs" do
+      LessNeedyDefaultsPage.new(build_context).render.to_s.should contain %(<div>bool default</div>)
+    end
+
+    it "allows nil as default value to needs" do
+      LessNeedyDefaultsPage.new(build_context).render.to_s.should contain %(<div>nil default</div>)
     end
   end
 

--- a/src/lucky/html_builder.cr
+++ b/src/lucky/html_builder.cr
@@ -49,7 +49,7 @@ module Lucky::HTMLBuilder
         {% for declaration in ASSIGNS %}
           {% var = declaration.var %}
           {% type = declaration.type %}
-          {% has_default = declaration.value || declaration.value == nil %}
+          {% has_default = declaration.value || declaration.value == false || declaration.value == nil %}
           {% if var.stringify.ends_with?("?") %}{{ var }}{% end %} @{{ var.stringify.gsub(/\?/, "").id }} : {{ type }}{% if has_default %} = {{ declaration.value }}{% end %},
         {% end %}
         **unused_exposures


### PR DESCRIPTION
## Purpose
Bug when using needs macro with boolean and false default value #978 
Also added a few tests to keep things honest down the road.

## Description
The source of the problem: https://github.com/luckyframework/lucky/blob/33606a60927df013f997f19dca3dc88439cf46e9/src/lucky/html_builder.cr#L52
This line accounts for nil, but not for false.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
