### PR TITLE
add inferred nil to html_builder when type ends with ?

### DIFF
--- a/spec/lucky/html_page_spec.cr
+++ b/spec/lucky/html_page_spec.cr
@@ -66,6 +66,7 @@ class LessNeedyDefaultsPage < MainLayout
   needs a_string : String = "string default"
   needs bool : Bool = false
   needs nil_default : String? = nil
+  needs inferred_nil_default : String?
 
   def inner
     div @a_string
@@ -74,6 +75,9 @@ class LessNeedyDefaultsPage < MainLayout
     end
     if @nil_default.nil?
       div "nil default"
+    end
+    if @inferred_nil_default.nil?
+      div "inferred nil default"
     end
   end
 
@@ -144,6 +148,10 @@ describe Lucky::HTMLPage do
 
     it "allows nil as default value to needs" do
       LessNeedyDefaultsPage.new(build_context).render.to_s.should contain %(<div>nil default</div>)
+    end
+
+    it "infers the default value from nilable needs" do
+      LessNeedyDefaultsPage.new(build_context).render.to_s.should contain %(<div>inferred nil default</div>)
     end
   end
 

--- a/spec/lucky/html_page_spec.cr
+++ b/spec/lucky/html_page_spec.cr
@@ -67,18 +67,14 @@ class LessNeedyDefaultsPage < MainLayout
   needs bool : Bool = false
   needs nil_default : String? = nil
   needs inferred_nil_default : String?
+  needs inferred_nil_default2 : String | Nil
 
   def inner
     div @a_string
-    if @bool == false
-      div "bool default"
-    end
-    if @nil_default.nil?
-      div "nil default"
-    end
-    if @inferred_nil_default.nil?
-      div "inferred nil default"
-    end
+    div("bool default") if @bool == false
+    div("nil default") if @nil_default.nil?
+    div("inferred nil default") if @inferred_nil_default.nil?
+    div("inferred nil default 2") if @inferred_nil_default2.nil?
   end
 
   def page_title
@@ -152,6 +148,10 @@ describe Lucky::HTMLPage do
 
     it "infers the default value from nilable needs" do
       LessNeedyDefaultsPage.new(build_context).render.to_s.should contain %(<div>inferred nil default</div>)
+    end
+
+    it "infers the default value from nilable needs" do
+      LessNeedyDefaultsPage.new(build_context).render.to_s.should contain %(<div>inferred nil default 2</div>)
     end
   end
 

--- a/src/lucky/html_builder.cr
+++ b/src/lucky/html_builder.cr
@@ -49,8 +49,10 @@ module Lucky::HTMLBuilder
         {% for declaration in ASSIGNS %}
           {% var = declaration.var %}
           {% type = declaration.type %}
-          {% has_default = declaration.value || declaration.value == false || declaration.value == nil %}
-          {% if var.stringify.ends_with?("?") %}{{ var }}{% end %} @{{ var.stringify.gsub(/\?/, "").id }} : {{ type }}{% if has_default %} = {{ declaration.value }}{% end %},
+          {% value = declaration.value %}
+          {% value = nil if type.stringify.ends_with?("::Nil") && !value %}
+          {% has_default = value || value == false || value == nil %}
+          {% if false || var.stringify.ends_with?("?") %}{{ var }}{% end %} @{{ var.stringify.gsub(/\?/, "").id }} : {{ type }}{% if has_default %} = {{ value }}{% end %},
         {% end %}
         **unused_exposures
         )

--- a/src/lucky/html_builder.cr
+++ b/src/lucky/html_builder.cr
@@ -50,7 +50,7 @@ module Lucky::HTMLBuilder
           {% var = declaration.var %}
           {% type = declaration.type %}
           {% value = declaration.value %}
-          {% value = nil if type.stringify.ends_with?("::Nil") && !value %}
+          {% value = nil if type.stringify.ends_with?("Nil") && !value %}
           {% has_default = value || value == false || value == nil %}
           {% if false || var.stringify.ends_with?("?") %}{{ var }}{% end %} @{{ var.stringify.gsub(/\?/, "").id }} : {{ type }}{% if has_default %} = {{ value }}{% end %},
         {% end %}


### PR DESCRIPTION
## Purpose
Allow the more intuitive way to specify optional "needs" in html builder. #804 

## Description
Instead of
```crystal
needs user : User? = nil
```
you can now just specify
```crystal
needs user : User?
```
## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
