### PR TITLE
Generate docs for CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,14 @@ install:
   - script/setup
 script:
   - script/test
+  - script/docs
 notifications:
   email: false
+deploy:
+  provider: pages
+  skip_cleanup: true
+  token: $GITHUB_TOKEN
+  project_name: lucky
+  on:
+    branch: master
+  local_dir: docs

--- a/script/docs
+++ b/script/docs
@@ -1,0 +1,6 @@
+#!/bin/sh -eu
+
+COMPOSE="docker-compose run --rm app"
+
+printf "\ngenerating docs with 'crystal docs'\n\n"
+$COMPOSE crystal docs


### PR DESCRIPTION
## Purpose
Generates docs (`crystal docs`) for Travis CI
Issue: https://github.com/luckyframework/lucky/issues/988

## Description
On any commit into `master`, this will auto-deploy documentation generated from `crystal docs` on Github Pages.

**Travis CI config needs to be updated to include GITHUB_TOKEN environment variable**
The GITHUB_TOKEN, which is a [github personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line), only needs the `public_repo` scope.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
* [ ] - Update Travis CI config to include GITHUB_TOKEN (possibly enable only for `master` branch)