### PR TITLE
API Documentation link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ Feel free to say hi or ask questions on our
 
 Keep up to date by following [@luckyframework](https://twitter.com/luckyframework) on Twitter.
 
+## Documentation
+[API (master)](https://luckyframework.github.io/lucky/)
+
 ## What's it look like?
 
 ### JSON endpoint:


### PR DESCRIPTION
## Description
Adds a link in readme for deployed api documentation.

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
