### PR TITLE
Sorting the type declarations from needs so the nillable ones are las…

### DIFF
--- a/spec/lucky/assignable_spec.cr
+++ b/spec/lucky/assignable_spec.cr
@@ -45,6 +45,7 @@ end
 
 class PageWithDefaultsFirst
   include Lucky::HTMLPage
+  needs required : String
   needs extra_css : String?
   needs status : String = "special"
   needs title : String
@@ -60,6 +61,6 @@ describe "Assigns within multiple pages with the same name" do
     PageTwo.new build_context, title: "foo", name: "Paul"
     PageThree.new build_context, name: "Paul", admin_name: "Pablo", title: "Admin"
     PageWithQuestionMark.new(build_context, signed_in?: true).perform_render.to_s.should contain("true")
-    PageWithDefaultsFirst.new(build_context, title: "foo").perform_render.to_s.should contain("special foo")
+    PageWithDefaultsFirst.new(build_context, required: "thing", title: "foo").perform_render.to_s.should contain("special foo")
   end
 end

--- a/spec/lucky/assignable_spec.cr
+++ b/spec/lucky/assignable_spec.cr
@@ -1,5 +1,7 @@
 require "../spec_helper"
 
+include ContextHelper
+
 class BasePage
   include Lucky::HTMLPage
 
@@ -41,11 +43,23 @@ class PageWithQuestionMark
   end
 end
 
+class PageWithDefaultsFirst
+  include Lucky::HTMLPage
+  needs extra_css : String?
+  needs status : String = "special"
+  needs title : String
+
+  def render
+    text "#{@status} #{@title}"
+  end
+end
+
 describe "Assigns within multiple pages with the same name" do
   it "should only appear once in the initializer" do
     PageOne.new build_context, title: "foo", name: "Paul", second: "second"
     PageTwo.new build_context, title: "foo", name: "Paul"
     PageThree.new build_context, name: "Paul", admin_name: "Pablo", title: "Admin"
     PageWithQuestionMark.new(build_context, signed_in?: true).perform_render.to_s.should contain("true")
+    PageWithDefaultsFirst.new(build_context, title: "foo").perform_render.to_s.should contain("special foo")
   end
 end

--- a/spec/lucky/assignable_spec.cr
+++ b/spec/lucky/assignable_spec.cr
@@ -46,7 +46,9 @@ end
 class PageWithDefaultsFirst
   include Lucky::HTMLPage
   needs required : String
+  needs nothing : Bool = false
   needs extra_css : String?
+  needs extra_html : String? = nil
   needs status : String = "special"
   needs title : String
 

--- a/spec/lucky/component_spec.cr
+++ b/spec/lucky/component_spec.cr
@@ -9,7 +9,6 @@ private class TestComponent < Lucky::BaseComponent
 end
 
 private class ComplexTestComponent < Lucky::BaseComponent
-  needs extra_css : String?
   needs title : String
 
   def render

--- a/spec/lucky/component_spec.cr
+++ b/spec/lucky/component_spec.cr
@@ -9,6 +9,7 @@ private class TestComponent < Lucky::BaseComponent
 end
 
 private class ComplexTestComponent < Lucky::BaseComponent
+  needs extra_css : String?
   needs title : String
 
   def render

--- a/src/lucky/html_builder.cr
+++ b/src/lucky/html_builder.cr
@@ -45,7 +45,9 @@ module Lucky::HTMLBuilder
 
   macro generate_needy_initializer
     {% if !@type.abstract? %}
-      {% sorted_assigns = ASSIGNS.sort_by { |dec| dec.type.resolve.nilable? || dec.value ? 1 : 0 } %}
+      {% sorted_assigns = ASSIGNS.sort_by { |dec|
+           dec.type.resolve.nilable? || dec.value || dec.value == nil || dec.value == false ? 1 : 0
+         } %}
       def initialize(
         {% for declaration in sorted_assigns %}
           {% var = declaration.var %}

--- a/src/lucky/html_builder.cr
+++ b/src/lucky/html_builder.cr
@@ -45,8 +45,9 @@ module Lucky::HTMLBuilder
 
   macro generate_needy_initializer
     {% if !@type.abstract? %}
+      {% sorted_assigns = ASSIGNS.sort_by { |dec| dec.type.resolve.nilable? ? 1 : 0 } %}
       def initialize(
-        {% for declaration in ASSIGNS %}
+        {% for declaration in sorted_assigns %}
           {% var = declaration.var %}
           {% type = declaration.type %}
           {% value = declaration.value %}

--- a/src/lucky/html_builder.cr
+++ b/src/lucky/html_builder.cr
@@ -45,7 +45,7 @@ module Lucky::HTMLBuilder
 
   macro generate_needy_initializer
     {% if !@type.abstract? %}
-      {% sorted_assigns = ASSIGNS.sort_by { |dec| dec.type.resolve.nilable? ? 1 : 0 } %}
+      {% sorted_assigns = ASSIGNS.sort_by { |dec| dec.type.resolve.nilable? || dec.value ? 1 : 0 } %}
       def initialize(
         {% for declaration in sorted_assigns %}
           {% var = declaration.var %}


### PR DESCRIPTION
## Purpose
Fixes #992

## Description
When you use `needs` that have both nilable and required values, the nilable ones had to come last otherwise there was a crystal compile error. This PR sorts the assignable type declarations putting the nilable ones last for the initialize method.

cc. @bdtomlin @wezm 

It'd be great if y'all could look over this and see if there's any other cases this solution doesn't cover. 

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
