### PR TITLE
Add more context to resource generator

### DIFF
--- a/tasks/gen/templates/resource/pages/{{folder_name}}/edit_page.cr.ecr
+++ b/tasks/gen/templates/resource/pages/{{folder_name}}/edit_page.cr.ecr
@@ -1,10 +1,11 @@
 class <%= pluralized_resource %>::EditPage < MainLayout
   needs operation : <%= operation_class %>
   needs <%= underscored_resource %> : <%= resource %>
-  quick_def page_title, "Edit"
+  quick_def page_title, "Edit <%= resource %> with id: #{@<%= underscored_resource %>.id}"
 
   def content
-    h1 "Edit"
+    link "Back to all <%= pluralized_resource %>", <%= pluralized_resource %>::Index
+    h1 "Edit <%= resource %> with id: #{@<%= underscored_resource %>.id}"
     render_<%= underscored_resource %>_form(@operation)
   end
 

--- a/tasks/gen/templates/resource/pages/{{folder_name}}/index_page.cr.ecr
+++ b/tasks/gen/templates/resource/pages/{{folder_name}}/index_page.cr.ecr
@@ -1,6 +1,6 @@
 class <%= pluralized_resource %>::IndexPage < MainLayout
   needs <%= pluralized_resource.underscore %> : <%= query_class %>
-  quick_def page_title, "All"
+  quick_def page_title, "All <%= pluralized_resource %>"
 
   def content
     h1 "All <%= pluralized_resource %>"

--- a/tasks/gen/templates/resource/pages/{{folder_name}}/new_page.cr.ecr
+++ b/tasks/gen/templates/resource/pages/{{folder_name}}/new_page.cr.ecr
@@ -1,9 +1,9 @@
 class <%= pluralized_resource %>::NewPage < MainLayout
   needs operation : <%= operation_class %>
-  quick_def page_title, "New"
+  quick_def page_title, "New <%= pluralized_resource %>"
 
   def content
-    h1 "New"
+    h1 "New <%= pluralized_resource %>"
     render_<%= underscored_resource %>_form(@operation)
   end
 

--- a/tasks/gen/templates/resource/pages/{{folder_name}}/show_page.cr.ecr
+++ b/tasks/gen/templates/resource/pages/{{folder_name}}/show_page.cr.ecr
@@ -1,10 +1,10 @@
 class <%= pluralized_resource %>::ShowPage < MainLayout
   needs <%= underscored_resource %> : <%= resource %>
-  quick_def page_title, @<%= underscored_resource %>.<%= columns.first.name %>
+  quick_def page_title, "<%= resource %> with id: #{@<%= underscored_resource %>.id}"
 
   def content
     link "Back to all <%= pluralized_resource %>", <%= pluralized_resource %>::Index
-    h1 @<%= underscored_resource %>.<%= columns.first.name %>
+    h1 "<%= resource %> with id: #{@<%= underscored_resource %>.id}"
     render_actions
     render_<%= underscored_resource %>_fields
   end


### PR DESCRIPTION
## Purpose

Add more context to page titles and headers. Also uses id instead of the first column since the first column may not make any sense at all for a header/page title.

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
