### PR TITLE
Fixing issue on gen.resource.browser with some column types

### DIFF
--- a/spec/support/generator_helper.cr
+++ b/spec/support/generator_helper.cr
@@ -9,4 +9,10 @@ module GeneratorHelper
   private def should_generate_migration(named name : String)
     Dir.new("./db/migrations").any?(&.ends_with?(name)).should be_true
   end
+
+  private def should_generate_migration(named name : String, with content : String)
+    filename = Dir.new("./db/migrations").find(&.ends_with?(name))
+    filename.should_not be_nil
+    File.read("./db/migrations/#{filename}").should contain(content)
+  end
 end

--- a/spec/tasks/gen/resource_spec.cr
+++ b/spec/tasks/gen/resource_spec.cr
@@ -7,7 +7,7 @@ describe Gen::Action do
   it "generates actions, model, operation and query" do
     with_cleanup do
       Gen::Migration.silence_output do
-        io = generate Gen::Resource::Browser, "User", "name:String"
+        io = generate Gen::Resource::Browser, "User", "name:String", "signed_up:Time"
 
         should_create_files_with_contents io,
           "./src/actions/users/index.cr": "class Users::Index < BrowserAction",
@@ -32,28 +32,17 @@ describe Gen::Action do
           "./src/queries/user_query.cr": "class UserQuery < User::BaseQuery",
           "./src/operations/save_user.cr": "class SaveUser < User::SaveOperation"
         should_generate_migration named: "create_users.cr"
+        should_generate_migration named: "create_users.cr", with: "add signed_up : Time"
         io.to_s.should contain "at: #{"/users".colorize.green}"
       end
     end
   end
 
-  it "allows for all supported column types" do
+  it "displays an error when given a more complex type" do
     with_cleanup do
-      io = generate Gen::Resource::Browser,
-        "Alphabet",
-        "a:Bool",
-        "b:Int16",
-        "c:Int32",
-        "d:Int64",
-        "e:String",
-        "f:UUID",
-        "g:Time",
-        "h:Float64",
-        "i:JSON::Any",
-        "j:Array(String)"
-      io.to_s.should_not contain("Must provide valid columns")
-      should_generate_migration named: "create_alphabets.cr", with: "add i : JSON::Any"
-      should_generate_migration named: "create_alphabets.cr", with: "add j : Array(String)"
+      io = generate Gen::Resource::Browser, "Alphabet", "a:JSON::Any"
+
+      io.to_s.should contain("Other complex types can be added manually")
     end
   end
 

--- a/spec/tasks/gen/resource_spec.cr
+++ b/spec/tasks/gen/resource_spec.cr
@@ -4,7 +4,7 @@ include CleanupHelper
 include GeneratorHelper
 
 describe Gen::Action do
-  it "generates actions, model, form and query" do
+  it "generates actions, model, operation and query" do
     with_cleanup do
       Gen::Migration.silence_output do
         io = generate Gen::Resource::Browser, "User", "name:String"
@@ -34,6 +34,26 @@ describe Gen::Action do
         should_generate_migration named: "create_users.cr"
         io.to_s.should contain "at: #{"/users".colorize.green}"
       end
+    end
+  end
+
+  it "allows for all supported column types" do
+    with_cleanup do
+      io = generate Gen::Resource::Browser,
+        "Alphabet",
+        "a:Bool",
+        "b:Int16",
+        "c:Int32",
+        "d:Int64",
+        "e:String",
+        "f:UUID",
+        "g:Time",
+        "h:Float64",
+        "i:JSON::Any",
+        "j:Array(String)"
+      io.to_s.should_not contain("Must provide valid columns")
+      should_generate_migration named: "create_alphabets.cr", with: "add i : JSON::Any"
+      should_generate_migration named: "create_alphabets.cr", with: "add j : Array(String)"
     end
   end
 

--- a/tasks/gen/resource/browser.cr
+++ b/tasks/gen/resource/browser.cr
@@ -38,7 +38,7 @@ class Gen::Resource::Browser < LuckyCli::Task
 
   private def columns : Array(Lucky::GeneratedColumn)
     column_definitions.map do |column_definition|
-      column_name, column_type = column_definition.split(":")
+      column_name, column_type = parse_definition(column_definition)
       Lucky::GeneratedColumn.new(name: column_name, type: column_type)
     end
   end
@@ -134,10 +134,22 @@ class Gen::Resource::Browser < LuckyCli::Task
 
   private def columns_are_valid? : Bool
     column_definitions.any? && column_definitions.all? do |column_definition|
-      column_parts = column_definition.split(":")
-      column_name = column_parts.first
+      column_parts = parse_definition(column_definition)
+      column_name = column_parts.first?.to_s
       column_parts.size == 2 && column_name == column_name.underscore
     end
+  end
+
+  private def parse_definition(column_definition : String) : Array(String)
+    matcher = /^([a-z_0-9]+):(Bool|Int16|Int32|Int64|String|UUID|Time|Float64|JSON::Any|Array\(\w+\))/
+    matched = column_definition.match(matcher)
+    definition = [] of String
+    if matched
+      definition << matched[1] if matched[1]?
+      definition << matched[2] if matched[2]?
+    end
+
+    definition
   end
 
   private def display_success_messages


### PR DESCRIPTION
## Purpose
Fixes #995 

## Description
Prior to this, the `gen.resource.browser` task would fail if you tried to generate a `JSON::Any` column or any of the `Array` column types. We were just doing a simple split on `:` which didn't really work for `JSON::Any`. 

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
