### PR TITLE
Add option for columns in model generator.

### DIFF
--- a/spec/tasks/gen/model_spec.cr
+++ b/spec/tasks/gen/model_spec.cr
@@ -17,7 +17,7 @@ describe Gen::Model do
           "./src/models/customer.cr": "table"
         should_create_files_with_contents io,
           "./src/models/customer.cr": "class Customer < BaseModel",
-          "./src/operations/save_customer.cr": "class SaveCustomer < Customer::SaveOperation",
+          "./src/operations/save_customer.cr": "class SaveCustomer < Customer::SaveOperation\nend",
           "./src/queries/customer_query.cr": "class CustomerQuery < Customer::BaseQuery"
         should_generate_migration named: "create_customers.cr"
       end
@@ -35,6 +35,9 @@ describe Gen::Model do
 
         should_create_files_with_contents io,
           "./src/models/contact_info.cr": "table"
+        should_create_files_with_contents io,
+          "./src/models/contact_info.cr": "column name : String",
+          "./src/operations/save_contact_info.cr": "permit_columns name, contacted_at"
         should_create_files_with_contents io,
           "./src/models/contact_info.cr": "class ContactInfo < BaseModel",
           "./src/operations/save_contact_info.cr": "class SaveContactInfo < ContactInfo::SaveOperation",

--- a/spec/tasks/gen/model_spec.cr
+++ b/spec/tasks/gen/model_spec.cr
@@ -8,6 +8,26 @@ describe Gen::Model do
     with_cleanup do
       Gen::Migration.silence_output do
         io = IO::Memory.new
+        model_name = "Customer"
+        ARGV.push(model_name)
+
+        Gen::Model.new.call(io)
+
+        should_create_files_with_contents io,
+          "./src/models/customer.cr": "table"
+        should_create_files_with_contents io,
+          "./src/models/customer.cr": "class Customer < BaseModel",
+          "./src/operations/save_customer.cr": "class SaveCustomer < Customer::SaveOperation",
+          "./src/queries/customer_query.cr": "class CustomerQuery < Customer::BaseQuery"
+        should_generate_migration named: "create_customers.cr"
+      end
+    end
+  end
+
+  it "generates a model with columns" do
+    with_cleanup do
+      Gen::Migration.silence_output do
+        io = IO::Memory.new
         model_name = "ContactInfo"
         ARGV.push(model_name, "name:String", "contacted_at:Time")
 
@@ -26,14 +46,12 @@ describe Gen::Model do
   end
 
   it "displays an error when given a more complex type" do
-    with_cleanup do
-      io = IO::Memory.new
-      ARGV.push("Alphabet", "a:JSON::Any")
+    io = IO::Memory.new
+    ARGV.push("Alphabet", "a:JSON::Any")
 
-      Gen::Model.new.call(io)
+    Gen::Model.new.call(io)
 
-      io.to_s.should contain("Other complex types can be added manually")
-    end
+    io.to_s.should contain("Other complex types can be added manually")
   end
 
   it "displays an error if given no arguments" do

--- a/spec/tasks/gen/model_spec.cr
+++ b/spec/tasks/gen/model_spec.cr
@@ -9,18 +9,30 @@ describe Gen::Model do
       Gen::Migration.silence_output do
         io = IO::Memory.new
         model_name = "ContactInfo"
-        ARGV.push(model_name)
+        ARGV.push(model_name, "name:String", "contacted_at:Time")
 
         Gen::Model.new.call(io)
 
-        should_generate_migration named: "create_contact_infos.cr"
         should_create_files_with_contents io,
           "./src/models/contact_info.cr": "table"
         should_create_files_with_contents io,
           "./src/models/contact_info.cr": "class ContactInfo < BaseModel",
           "./src/operations/save_contact_info.cr": "class SaveContactInfo < ContactInfo::SaveOperation",
           "./src/queries/contact_info_query.cr": "class ContactInfoQuery < ContactInfo::BaseQuery"
+        should_generate_migration named: "create_contact_infos.cr",
+          with: "add contacted_at : Time"
       end
+    end
+  end
+
+  it "displays an error when given a more complex type" do
+    with_cleanup do
+      io = IO::Memory.new
+      ARGV.push("Alphabet", "a:JSON::Any")
+
+      Gen::Model.new.call(io)
+
+      io.to_s.should contain("Other complex types can be added manually")
     end
   end
 

--- a/spec/tasks/gen/model_spec.cr
+++ b/spec/tasks/gen/model_spec.cr
@@ -16,8 +16,10 @@ describe Gen::Model do
         should_create_files_with_contents io,
           "./src/models/customer.cr": "table"
         should_create_files_with_contents io,
+          "./src/operations/save_customer.cr": "# permit_columns column_1, column_2"
+        should_create_files_with_contents io,
           "./src/models/customer.cr": "class Customer < BaseModel",
-          "./src/operations/save_customer.cr": "class SaveCustomer < Customer::SaveOperation\nend",
+          "./src/operations/save_customer.cr": "class SaveCustomer < Customer::SaveOperation",
           "./src/queries/customer_query.cr": "class CustomerQuery < Customer::BaseQuery"
         should_generate_migration named: "create_customers.cr"
       end
@@ -37,7 +39,7 @@ describe Gen::Model do
           "./src/models/contact_info.cr": "table"
         should_create_files_with_contents io,
           "./src/models/contact_info.cr": "column name : String",
-          "./src/operations/save_contact_info.cr": "permit_columns name, contacted_at"
+          "./src/operations/save_contact_info.cr": "# permit_columns name, contacted_at"
         should_create_files_with_contents io,
           "./src/models/contact_info.cr": "class ContactInfo < BaseModel",
           "./src/operations/save_contact_info.cr": "class SaveContactInfo < ContactInfo::SaveOperation",

--- a/spec/tasks/gen/resource_spec.cr
+++ b/spec/tasks/gen/resource_spec.cr
@@ -31,6 +31,8 @@ describe Gen::Resource::Browser do
           "./src/models/user.cr": "class User < BaseModel",
           "./src/queries/user_query.cr": "class UserQuery < User::BaseQuery",
           "./src/operations/save_user.cr": "class SaveUser < User::SaveOperation"
+        should_create_files_with_contents io,
+          "./src/operations/save_user.cr": "# permit_columns name, signed_up"
         should_generate_migration named: "create_users.cr"
         should_generate_migration named: "create_users.cr", with: "add signed_up : Time"
         io.to_s.should contain "at: #{"/users".colorize.green}"

--- a/spec/tasks/gen/resource_spec.cr
+++ b/spec/tasks/gen/resource_spec.cr
@@ -3,7 +3,7 @@ require "../../spec_helper"
 include CleanupHelper
 include GeneratorHelper
 
-describe Gen::Action do
+describe Gen::Resource::Browser do
   it "generates actions, model, operation and query" do
     with_cleanup do
       Gen::Migration.silence_output do

--- a/tasks/gen/mixins/migration_with_columns.cr
+++ b/tasks/gen/mixins/migration_with_columns.cr
@@ -1,6 +1,14 @@
 module Gen::Mixins::MigrationWithColumns
   SUPPORTED_TYPES = {"Bool", "Float64", "Int16", "Int32", "Int64", "String", "Time", "UUID"}
 
+  def create_migration
+    Avram::Migrator::MigrationGenerator.new(
+      "Create#{pluralized_name}",
+      migrate_contents: migrate_contents,
+      rollback_contents: rollback_contents
+    ).generate
+  end
+
   private def migrate_contents : String
     String.build do |string|
       string << "# Learn about migrations at: https://luckyframework.org/guides/database/migrations"

--- a/tasks/gen/mixins/migration_with_columns.cr
+++ b/tasks/gen/mixins/migration_with_columns.cr
@@ -38,8 +38,8 @@ module Gen::Mixins::MigrationWithColumns
     !!ARGV[1]?
   end
 
-  private def columns_are_valid?(required : Bool = false) : Bool
-    (!required || column_definitions.any?) && column_definitions.all? do |column_definition|
+  private def columns_are_valid? : Bool
+    column_definitions.all? do |column_definition|
       column_parts = parse_definition(column_definition)
       column_name = column_parts.first
       column_type = column_parts.last

--- a/tasks/gen/mixins/migration_with_columns.cr
+++ b/tasks/gen/mixins/migration_with_columns.cr
@@ -1,0 +1,70 @@
+module Gen::Mixins::MigrationWithColumns
+  SUPPORTED_TYPES = {"Bool", "Float64", "Int16", "Int32", "Int64", "String", "Time", "UUID"}
+
+  private def migrate_contents : String
+    String.build do |string|
+      string << "# Learn about migrations at: https://luckyframework.org/guides/database/migrations"
+      string << "\n"
+      string << "create table_for(#{subject_name}) do\n"
+      string << "  primary_key id : Int64\n"
+      string << "  add_timestamps\n"
+      columns.each do |column|
+        string << "  add #{column.name} : #{column.type}\n"
+      end
+      string << "end"
+    end
+  end
+
+  private def rollback_contents : String
+    "drop table_for(#{subject_name})"
+  end
+
+  private def columns : Array(Lucky::GeneratedColumn)
+    column_definitions.map do |column_definition|
+      column_name, column_type = parse_definition(column_definition)
+      Lucky::GeneratedColumn.new(name: column_name, type: column_type)
+    end
+  end
+
+  private def column_definitions
+    if column_arguments?
+      ARGV.skip(1)
+    else
+      [] of String
+    end
+  end
+
+  private def column_arguments? : Bool
+    !!ARGV[1]?
+  end
+
+  private def columns_are_valid? : Bool
+    column_definitions.any? && column_definitions.all? do |column_definition|
+      column_parts = parse_definition(column_definition)
+      column_name = column_parts.first
+      column_type = column_parts.last
+      column_parts.size == 2 &&
+        column_name == column_name.underscore &&
+        SUPPORTED_TYPES.includes?(column_type)
+    end
+  end
+
+  private def parse_definition(column_definition : String) : Array(String)
+    column_definition.split(':', 2)
+  end
+
+  private def unsupported_columns_error(subject : String, generator : String = subject)
+    <<-ERR
+    Must provide a supported column type for the #{subject}: lucky gen.#{generator || subject} #{subject_name.camelcase} name:String
+
+    Other complex types can be added manually. See https://luckyframework.org/guides/database/migrations#add-column for more details.
+    ERR
+  end
+end
+
+class Lucky::GeneratedColumn
+  getter name, type
+
+  def initialize(@name : String, @type : String)
+  end
+end

--- a/tasks/gen/mixins/migration_with_columns.cr
+++ b/tasks/gen/mixins/migration_with_columns.cr
@@ -5,7 +5,7 @@ module Gen::Mixins::MigrationWithColumns
     String.build do |string|
       string << "# Learn about migrations at: https://luckyframework.org/guides/database/migrations"
       string << "\n"
-      string << "create table_for(#{subject_name}) do\n"
+      string << "create table_for(#{resource_name}) do\n"
       string << "  primary_key id : Int64\n"
       string << "  add_timestamps\n"
       columns.each do |column|
@@ -16,7 +16,7 @@ module Gen::Mixins::MigrationWithColumns
   end
 
   private def rollback_contents : String
-    "drop table_for(#{subject_name})"
+    "drop table_for(#{resource_name})"
   end
 
   private def columns : Array(Lucky::GeneratedColumn)
@@ -38,8 +38,8 @@ module Gen::Mixins::MigrationWithColumns
     !!ARGV[1]?
   end
 
-  private def columns_are_valid? : Bool
-    column_definitions.any? && column_definitions.all? do |column_definition|
+  private def columns_are_valid?(required : Bool = false) : Bool
+    (!required || column_definitions.any?) && column_definitions.all? do |column_definition|
       column_parts = parse_definition(column_definition)
       column_name = column_parts.first
       column_type = column_parts.last
@@ -55,7 +55,7 @@ module Gen::Mixins::MigrationWithColumns
 
   private def unsupported_columns_error(subject : String, generator : String = subject)
     <<-ERR
-    Must provide a supported column type for the #{subject}: lucky gen.#{generator || subject} #{subject_name.camelcase} name:String
+    Must provide a supported column type for the #{subject}: lucky gen.#{generator || subject} #{resource_name.camelcase} name:String
 
     Other complex types can be added manually. See https://luckyframework.org/guides/database/migrations#add-column for more details.
     ERR

--- a/tasks/gen/model.cr
+++ b/tasks/gen/model.cr
@@ -72,7 +72,7 @@ class Gen::Model < LuckyCli::Task
   end
 
   private def template
-    Lucky::ModelTemplate.new(resource_name)
+    Lucky::ModelTemplate.new(resource_name, columns)
   end
 
   private def display_success_messages

--- a/tasks/gen/model.cr
+++ b/tasks/gen/model.cr
@@ -31,18 +31,6 @@ class Gen::Model < LuckyCli::Task
     TEXT
   end
 
-  def create_migration
-    Avram::Migrator::MigrationGenerator.new(
-      "Create#{pluralized_resource_name}",
-      migrate_contents: migrate_contents,
-      rollback_contents: rollback_contents
-    ).generate
-  end
-
-  private def pluralized_resource_name
-    Wordsmith::Inflector.pluralize(resource_name)
-  end
-
   private def valid?
     resource_name_is_present &&
       resource_name_is_camelcase &&
@@ -87,6 +75,10 @@ class Gen::Model < LuckyCli::Task
 
   private def resource_name
     ARGV.first
+  end
+
+  private def pluralized_name
+    Wordsmith::Inflector.pluralize(resource_name)
   end
 
   private def underscored_name

--- a/tasks/gen/model.cr
+++ b/tasks/gen/model.cr
@@ -7,6 +7,7 @@ require "./mixins/migration_with_columns"
 
 class Gen::Model < LuckyCli::Task
   include Gen::Mixins::MigrationWithColumns
+
   summary "Generate a model, query, and save operation"
   getter io : IO = STDOUT
 
@@ -32,37 +33,37 @@ class Gen::Model < LuckyCli::Task
 
   def create_migration
     Avram::Migrator::MigrationGenerator.new(
-      "Create#{pluralized_subject_name}",
+      "Create#{pluralized_resource_name}",
       migrate_contents: migrate_contents,
       rollback_contents: rollback_contents
     ).generate
   end
 
-  private def pluralized_subject_name
-    Wordsmith::Inflector.pluralize(subject_name)
+  private def pluralized_resource_name
+    Wordsmith::Inflector.pluralize(resource_name)
   end
 
   private def valid?
-    subject_name_is_present &&
-      subject_name_is_camelcase &&
-      subject_name_matches_format &&
+    resource_name_is_present &&
+      resource_name_is_camelcase &&
+      resource_name_matches_format &&
       columns_are_supported
   end
 
-  private def subject_name_is_present
+  private def resource_name_is_present
     @error = "Model name is required. Example: lucky gen.model User"
     ARGV.first?
   end
 
-  private def subject_name_is_camelcase
-    @error = "Model name should be camel case. Example: lucky gen.model #{subject_name.camelcase}"
-    subject_name.camelcase == subject_name
+  private def resource_name_is_camelcase
+    @error = "Model name should be camel case. Example: lucky gen.model #{resource_name.camelcase}"
+    resource_name.camelcase == resource_name
   end
 
-  private def subject_name_matches_format
-    formatted = subject_name.gsub(/[^\w]/, "")
+  private def resource_name_matches_format
+    formatted = resource_name.gsub(/[^\w]/, "")
     @error = "Model name should only contain letters. Example: lucky gen.model #{formatted}"
-    subject_name == formatted
+    resource_name == formatted
   end
 
   private def columns_are_supported
@@ -71,7 +72,7 @@ class Gen::Model < LuckyCli::Task
   end
 
   private def template
-    Lucky::ModelTemplate.new(subject_name)
+    Lucky::ModelTemplate.new(resource_name)
   end
 
   private def display_success_messages
@@ -81,10 +82,10 @@ class Gen::Model < LuckyCli::Task
   end
 
   private def success_message(filename, type = nil)
-    "Generated #{subject_name.colorize(:green)}#{type.colorize(:green)} in #{filename.colorize(:green)}"
+    "Generated #{resource_name.colorize(:green)}#{type.colorize(:green)} in #{filename.colorize(:green)}"
   end
 
-  private def subject_name
+  private def resource_name
     ARGV.first
   end
 

--- a/tasks/gen/resource/browser.cr
+++ b/tasks/gen/resource/browser.cr
@@ -41,20 +41,16 @@ class Gen::Resource::Browser < LuckyCli::Task
 
   private def generate_resource
     Lucky::ResourceTemplate.new(resource_name, columns).render("./src/")
-    Avram::Migrator::MigrationGenerator.new(
-      "Create" + pluralized_resource,
-      migrate_contents: migrate_contents,
-      rollback_contents: rollback_contents
-    ).generate
+    create_migration
     display_success_messages
   end
 
   private def display_path_to_resource
-    io.puts "\nView list of #{pluralized_resource} in your browser at: #{path_to_resource.colorize.green}"
+    io.puts "\nView list of #{pluralized_name} in your browser at: #{path_to_resource.colorize.green}"
   end
 
   private def path_to_resource
-    "/" + pluralized_resource.underscore
+    "/" + pluralized_name.underscore
   end
 
   private def validate! : Void
@@ -106,13 +102,13 @@ class Gen::Resource::Browser < LuckyCli::Task
     success_message(resource_name + "Query", "./src/queries/#{underscored_resource}_query.cr")
     %w(index show new create edit update delete).each do |action|
       success_message(
-        pluralized_resource + "::" + action.capitalize,
+        pluralized_name + "::" + action.capitalize,
         "./src/actions/#{folder_name}/#{action}.cr"
       )
     end
     %w(index show new edit).each do |action|
       success_message(
-        pluralized_resource + "::" + action.capitalize + "Page",
+        pluralized_name + "::" + action.capitalize + "Page",
         "./src/pages/#{folder_name}/#{action}_page.cr"
       )
     end
@@ -126,7 +122,7 @@ class Gen::Resource::Browser < LuckyCli::Task
     Wordsmith::Inflector.pluralize underscored_resource
   end
 
-  private def pluralized_resource
+  private def pluralized_name
     Wordsmith::Inflector.pluralize resource_name
   end
 
@@ -156,10 +152,10 @@ class Lucky::ResourceTemplate < Teeplate::FileTree
     @operation_filename = operation_class.underscore
     @query_filename = query_class.underscore
     @underscored_resource = @resource.underscore
-    @folder_name = pluralized_resource.underscore
+    @folder_name = pluralized_name.underscore
   end
 
-  private def pluralized_resource
+  private def pluralized_name
     Wordsmith::Inflector.pluralize(resource)
   end
 

--- a/tasks/gen/resource/browser.cr
+++ b/tasks/gen/resource/browser.cr
@@ -6,6 +6,7 @@ require "../mixins/migration_with_columns"
 
 class Gen::Resource::Browser < LuckyCli::Task
   include Gen::Mixins::MigrationWithColumns
+
   summary "Generate a resource (model, operation, query, actions, and pages)"
   getter io : IO = STDOUT
 
@@ -39,7 +40,7 @@ class Gen::Resource::Browser < LuckyCli::Task
   end
 
   private def generate_resource
-    Lucky::ResourceTemplate.new(subject_name, columns).render("./src/")
+    Lucky::ResourceTemplate.new(resource_name, columns).render("./src/")
     Avram::Migrator::MigrationGenerator.new(
       "Create" + pluralized_resource,
       migrate_contents: migrate_contents,
@@ -65,32 +66,32 @@ class Gen::Resource::Browser < LuckyCli::Task
   end
 
   private def validate_name_is_present!
-    if subject_name?.nil? || subject_name?.try &.empty?
+    if resource_name?.nil? || resource_name?.try &.empty?
       error "Resource name is required. Example: lucky gen.resource.browser User"
     end
   end
 
   private def validate_not_namespaced!
-    if subject_name.includes?("::")
+    if resource_name.includes?("::")
       error "Namespaced resources are not supported"
     end
   end
 
   private def validate_name_is_singular!
-    singularized_name = Wordsmith::Inflector.singularize(subject_name)
-    if singularized_name != subject_name
+    singularized_name = Wordsmith::Inflector.singularize(resource_name)
+    if singularized_name != resource_name
       error "Resource must be singular. Example: lucky gen.resource.browser #{singularized_name}"
     end
   end
 
   private def validate_name_is_camelcase!
-    if subject_name.camelcase != subject_name
-      error "Resource name should be camel case. Example: lucky gen.resource.browser #{subject_name.camelcase}"
+    if resource_name.camelcase != resource_name
+      error "Resource name should be camel case. Example: lucky gen.resource.browser #{resource_name.camelcase}"
     end
   end
 
   private def validate_has_supported_columns!
-    if !columns_are_valid?
+    if !columns_are_valid?(required: true)
       error unsupported_columns_error("resource", "resource.browser")
     end
   end
@@ -100,9 +101,9 @@ class Gen::Resource::Browser < LuckyCli::Task
   end
 
   private def display_success_messages
-    success_message(subject_name, "./src/models/#{underscored_resource}.cr")
-    success_message("Save" + subject_name, "./src/operations/save_#{underscored_resource}.cr")
-    success_message(subject_name + "Query", "./src/queries/#{underscored_resource}_query.cr")
+    success_message(resource_name, "./src/models/#{underscored_resource}.cr")
+    success_message("Save" + resource_name, "./src/operations/save_#{underscored_resource}.cr")
+    success_message(resource_name + "Query", "./src/queries/#{underscored_resource}_query.cr")
     %w(index show new create edit update delete).each do |action|
       success_message(
         pluralized_resource + "::" + action.capitalize,
@@ -118,7 +119,7 @@ class Gen::Resource::Browser < LuckyCli::Task
   end
 
   private def underscored_resource
-    subject_name.underscore
+    resource_name.underscore
   end
 
   private def folder_name
@@ -126,18 +127,18 @@ class Gen::Resource::Browser < LuckyCli::Task
   end
 
   private def pluralized_resource
-    Wordsmith::Inflector.pluralize subject_name
+    Wordsmith::Inflector.pluralize resource_name
   end
 
   private def success_message(class_name : String, filename : String) : Void
     io.puts "Generated #{class_name.colorize.green} in #{filename.colorize.green}"
   end
 
-  private def subject_name
-    subject_name?.not_nil!
+  private def resource_name
+    resource_name?.not_nil!
   end
 
-  private def subject_name?
+  private def resource_name?
     ARGV.first?
   end
 end

--- a/tasks/gen/resource/browser.cr
+++ b/tasks/gen/resource/browser.cr
@@ -91,7 +91,7 @@ class Gen::Resource::Browser < LuckyCli::Task
   end
 
   private def validate_has_supported_columns!
-    if !columns_are_valid?(required: true)
+    if column_definitions.empty? || !columns_are_valid?
       error unsupported_columns_error("resource", "resource.browser")
     end
   end

--- a/tasks/gen/templates/model/models/{{underscored_name}}.cr.ecr
+++ b/tasks/gen/templates/model/models/{{underscored_name}}.cr.ecr
@@ -1,4 +1,7 @@
 class <%= @name %> < BaseModel
   table do
+    <%- @columns.each do |column| -%>
+    column <%= column.name %> : <%= column.type %>
+    <%- end -%>
   end
 end

--- a/tasks/gen/templates/model/operations/save_{{underscored_name}}.cr.ecr
+++ b/tasks/gen/templates/model/operations/save_{{underscored_name}}.cr.ecr
@@ -1,5 +1,6 @@
 class Save<%= @name %> < <%= @name %>::SaveOperation
-<%- if @columns.any? -%>
-  permit_columns <%= @columns.map(&.name).join(", ") %>
-<%- end -%>
+  # To save user provided params to the database, you must permit them
+  # https://luckyframework.org/guides/database/validating-saving#perma-permitting-columns
+  #
+  # permit_columns <%= columns_list %>
 end

--- a/tasks/gen/templates/model/operations/save_{{underscored_name}}.cr.ecr
+++ b/tasks/gen/templates/model/operations/save_{{underscored_name}}.cr.ecr
@@ -1,2 +1,5 @@
 class Save<%= @name %> < <%= @name %>::SaveOperation
+<%- if @columns.any? -%>
+  permit_columns <%= @columns.map(&.name).join(", ") %>
+<%- end -%>
 end

--- a/tasks/gen/templates/model_template.cr
+++ b/tasks/gen/templates/model_template.cr
@@ -1,5 +1,6 @@
 class Lucky::ModelTemplate < Teeplate::FileTree
   @name : String
+  @columns : Array(Lucky::GeneratedColumn)
   @pluralized_name : String
   @underscored_name : String
 
@@ -7,7 +8,7 @@ class Lucky::ModelTemplate < Teeplate::FileTree
 
   directory "#{__DIR__}/model/"
 
-  def initialize(@name : String)
+  def initialize(@name : String, @columns : Array(Lucky::GeneratedColumn))
     @underscored_name = @name.underscore
     @pluralized_name = Wordsmith::Inflector.pluralize(@underscored_name)
   end

--- a/tasks/gen/templates/model_template.cr
+++ b/tasks/gen/templates/model_template.cr
@@ -12,4 +12,15 @@ class Lucky::ModelTemplate < Teeplate::FileTree
     @underscored_name = @name.underscore
     @pluralized_name = Wordsmith::Inflector.pluralize(@underscored_name)
   end
+
+  def columns_list
+    (@columns.any? ? @columns : example_columns).map(&.name).join(", ")
+  end
+
+  private def example_columns
+    [
+      Lucky::GeneratedColumn.new("column_1", ""),
+      Lucky::GeneratedColumn.new("column_2", ""),
+    ]
+  end
 end

--- a/tasks/gen/templates/resource/actions/{{folder_name}}/create.cr.ecr
+++ b/tasks/gen/templates/resource/actions/{{folder_name}}/create.cr.ecr
@@ -1,4 +1,4 @@
-class <%= pluralized_resource %>::Create < BrowserAction
+class <%= pluralized_name %>::Create < BrowserAction
   route do
     <%= operation_class %>.create(params) do |operation, <%= underscored_resource %>|
       if <%= underscored_resource %>

--- a/tasks/gen/templates/resource/actions/{{folder_name}}/delete.cr.ecr
+++ b/tasks/gen/templates/resource/actions/{{folder_name}}/delete.cr.ecr
@@ -1,4 +1,4 @@
-class <%= pluralized_resource %>::Delete < BrowserAction
+class <%= pluralized_name %>::Delete < BrowserAction
   route do
     <%= query_class %>.find(<%= resource_id_method_name %>).delete
     flash.success = "Deleted the record"

--- a/tasks/gen/templates/resource/actions/{{folder_name}}/edit.cr.ecr
+++ b/tasks/gen/templates/resource/actions/{{folder_name}}/edit.cr.ecr
@@ -1,4 +1,4 @@
-class <%= pluralized_resource %>::Edit < BrowserAction
+class <%= pluralized_name %>::Edit < BrowserAction
   route do
     <%= underscored_resource %> = <%= query_class %>.find(<%= resource_id_method_name %>)
     html EditPage,

--- a/tasks/gen/templates/resource/actions/{{folder_name}}/index.cr.ecr
+++ b/tasks/gen/templates/resource/actions/{{folder_name}}/index.cr.ecr
@@ -1,5 +1,5 @@
-class <%= pluralized_resource %>::Index < BrowserAction
+class <%= pluralized_name %>::Index < BrowserAction
   route do
-    html IndexPage, <%= pluralized_resource.underscore %>: <%= query_class %>.new
+    html IndexPage, <%= pluralized_name.underscore %>: <%= query_class %>.new
   end
 end

--- a/tasks/gen/templates/resource/actions/{{folder_name}}/new.cr.ecr
+++ b/tasks/gen/templates/resource/actions/{{folder_name}}/new.cr.ecr
@@ -1,4 +1,4 @@
-class <%= pluralized_resource %>::New < BrowserAction
+class <%= pluralized_name %>::New < BrowserAction
   route do
     html NewPage, operation: <%= operation_class %>.new
   end

--- a/tasks/gen/templates/resource/actions/{{folder_name}}/show.cr.ecr
+++ b/tasks/gen/templates/resource/actions/{{folder_name}}/show.cr.ecr
@@ -1,4 +1,4 @@
-class <%= pluralized_resource %>::Show < BrowserAction
+class <%= pluralized_name %>::Show < BrowserAction
   route do
     html ShowPage, <%= underscored_resource %>: <%= query_class %>.find(<%= resource_id_method_name %>)
   end

--- a/tasks/gen/templates/resource/actions/{{folder_name}}/update.cr.ecr
+++ b/tasks/gen/templates/resource/actions/{{folder_name}}/update.cr.ecr
@@ -1,4 +1,4 @@
-class <%= pluralized_resource %>::Update < BrowserAction
+class <%= pluralized_name %>::Update < BrowserAction
   route do
     <%= underscored_resource %> = <%= query_class %>.find(<%= resource_id_method_name %>)
     <%= operation_class %>.update(<%= underscored_resource %>, params) do |operation, <%= underscored_resource %>|

--- a/tasks/gen/templates/resource/operations/{{operation_filename}}.cr.ecr
+++ b/tasks/gen/templates/resource/operations/{{operation_filename}}.cr.ecr
@@ -1,3 +1,6 @@
 class <%= operation_class %> < <%= resource %>::SaveOperation
-  permit_columns <%= columns.map(&.name).join(", ") %>
+  # To save user provided params to the database, you must permit them
+  # https://luckyframework.org/guides/database/validating-saving#perma-permitting-columns
+  #
+  # permit_columns <%= columns.map(&.name).join(", ") %>
 end

--- a/tasks/gen/templates/resource/pages/{{folder_name}}/edit_page.cr.ecr
+++ b/tasks/gen/templates/resource/pages/{{folder_name}}/edit_page.cr.ecr
@@ -1,16 +1,16 @@
-class <%= pluralized_resource %>::EditPage < MainLayout
+class <%= pluralized_name %>::EditPage < MainLayout
   needs operation : <%= operation_class %>
   needs <%= underscored_resource %> : <%= resource %>
   quick_def page_title, "Edit <%= resource %> with id: #{@<%= underscored_resource %>.id}"
 
   def content
-    link "Back to all <%= pluralized_resource %>", <%= pluralized_resource %>::Index
+    link "Back to all <%= pluralized_name %>", <%= pluralized_name %>::Index
     h1 "Edit <%= resource %> with id: #{@<%= underscored_resource %>.id}"
     render_<%= underscored_resource %>_form(@operation)
   end
 
   def render_<%= underscored_resource %>_form(op)
-    form_for <%= pluralized_resource %>::Update.with(@<%= underscored_resource %>.id) do
+    form_for <%= pluralized_name %>::Update.with(@<%= underscored_resource %>.id) do
       <%- columns.each_with_index do |column, index| -%>
       mount Shared::Field.new(op.<%= column.name %>)<% if index.zero? %>, &.text_input(autofocus: "true")<% end %>
       <%- end -%>

--- a/tasks/gen/templates/resource/pages/{{folder_name}}/index_page.cr.ecr
+++ b/tasks/gen/templates/resource/pages/{{folder_name}}/index_page.cr.ecr
@@ -1,18 +1,18 @@
-class <%= pluralized_resource %>::IndexPage < MainLayout
-  needs <%= pluralized_resource.underscore %> : <%= query_class %>
-  quick_def page_title, "All <%= pluralized_resource %>"
+class <%= pluralized_name %>::IndexPage < MainLayout
+  needs <%= pluralized_name.underscore %> : <%= query_class %>
+  quick_def page_title, "All <%= pluralized_name %>"
 
   def content
-    h1 "All <%= pluralized_resource %>"
-    link "New <%= resource %>", to: <%= pluralized_resource %>::New
-    render_<%= pluralized_resource.underscore %>
+    h1 "All <%= pluralized_name %>"
+    link "New <%= resource %>", to: <%= pluralized_name %>::New
+    render_<%= pluralized_name.underscore %>
   end
 
-  def render_<%= pluralized_resource.underscore %>
+  def render_<%= pluralized_name.underscore %>
     ul do
-      @<%= pluralized_resource.underscore %>.each do |<%= underscored_resource %>|
+      @<%= pluralized_name.underscore %>.each do |<%= underscored_resource %>|
         li do
-          link <%= underscored_resource %>.<%= columns.first.name %>, <%= pluralized_resource %>::Show.with(<%= underscored_resource %>)
+          link <%= underscored_resource %>.<%= columns.first.name %>, <%= pluralized_name %>::Show.with(<%= underscored_resource %>)
         end
       end
     end

--- a/tasks/gen/templates/resource/pages/{{folder_name}}/new_page.cr.ecr
+++ b/tasks/gen/templates/resource/pages/{{folder_name}}/new_page.cr.ecr
@@ -1,14 +1,14 @@
-class <%= pluralized_resource %>::NewPage < MainLayout
+class <%= pluralized_name %>::NewPage < MainLayout
   needs operation : <%= operation_class %>
-  quick_def page_title, "New <%= pluralized_resource %>"
+  quick_def page_title, "New <%= pluralized_name %>"
 
   def content
-    h1 "New <%= pluralized_resource %>"
+    h1 "New <%= pluralized_name %>"
     render_<%= underscored_resource %>_form(@operation)
   end
 
   def render_<%= underscored_resource %>_form(op)
-    form_for <%= pluralized_resource %>::Create do
+    form_for <%= pluralized_name %>::Create do
       <%- columns.each_with_index do |column, index| -%>
       mount Shared::Field.new(op.<%= column.name %>)<% if index.zero? %>, &.text_input(autofocus: "true")<% end %>
       <%- end -%>

--- a/tasks/gen/templates/resource/pages/{{folder_name}}/show_page.cr.ecr
+++ b/tasks/gen/templates/resource/pages/{{folder_name}}/show_page.cr.ecr
@@ -1,9 +1,9 @@
-class <%= pluralized_resource %>::ShowPage < MainLayout
+class <%= pluralized_name %>::ShowPage < MainLayout
   needs <%= underscored_resource %> : <%= resource %>
   quick_def page_title, "<%= resource %> with id: #{@<%= underscored_resource %>.id}"
 
   def content
-    link "Back to all <%= pluralized_resource %>", <%= pluralized_resource %>::Index
+    link "Back to all <%= pluralized_name %>", <%= pluralized_name %>::Index
     h1 "<%= resource %> with id: #{@<%= underscored_resource %>.id}"
     render_actions
     render_<%= underscored_resource %>_fields
@@ -11,10 +11,10 @@ class <%= pluralized_resource %>::ShowPage < MainLayout
 
   def render_actions
     section do
-      link "Edit", <%= pluralized_resource %>::Edit.with(@<%= underscored_resource %>.id)
+      link "Edit", <%= pluralized_name %>::Edit.with(@<%= underscored_resource %>.id)
       text " | "
       link "Delete",
-        <%= pluralized_resource %>::Delete.with(@<%= underscored_resource %>.id),
+        <%= pluralized_name %>::Delete.with(@<%= underscored_resource %>.id),
         data_confirm: "Are you sure?"
     end
   end


### PR DESCRIPTION
## Purpose
Adds the option to define columns with the `gen.model` generator, as discussed in #1007.

## Description
Basically, I moved some code around, extracted common behaviour into a mixin and dried up some parts.

To simplify sharing, I renamed the following methods:
- `model_name` -> `subject_name`
- `resource_name` -> `subject_name` 

## Checklist
* [X] - An issue already exists detailing the issue/or feature request that this PR fixes
* [X] - All specs are formatted with `crystal tool format spec src`
* [X] - Inline documentation has been added and/or updated
* [X] - Lucky builds on docker with `./script/setup`
* [X] - All builds and specs pass on docker with `./script/test`
