### PR TITLE
Updating how custom tags take boolean attributes

### DIFF
--- a/spec/lucky/custom_tags_spec.cr
+++ b/spec/lucky/custom_tags_spec.cr
@@ -38,6 +38,11 @@ describe Lucky::CustomTags do
         page.text "content"
       end.to_s.should contain %(<foo-tag class="my-class">content</foo-tag>)
     end
+
+    view.tap do |page|
+      page.tag "script", [:async], data_counter: "https://counter.co", src: "count.js" do
+      end.to_s.should contain %(<script data-counter="https://counter.co" src="count.js" async></script>)
+    end
   end
 
   it "has a method for empty tags" do

--- a/src/lucky/tags/custom_tags.cr
+++ b/src/lucky/tags/custom_tags.cr
@@ -9,10 +9,9 @@ module Lucky::CustomTags
     attrs : Array(Symbol) = [] of Symbol,
     **other_options
   )
-    bool_attrs = build_boolean_attrs(attrs)
     merged_options = merge_options(other_options, options)
 
-    tag(name, bool_attrs, merged_options) do
+    tag(name, attrs, merged_options) do
       text content
     end
   end
@@ -29,9 +28,10 @@ module Lucky::CustomTags
     end
   end
 
-  def tag(name : String, boolean_attrs : String = "", options = EMPTY_HTML_ATTRS, **other_options, &block)
+  def tag(name : String, attrs : Array(Symbol) = [] of Symbol, options = EMPTY_HTML_ATTRS, **other_options, &block)
     merged_options = merge_options(other_options, options)
     tag_attrs = build_tag_attrs(merged_options)
+    boolean_attrs = build_boolean_attrs(attrs)
     view << "<#{name}" << tag_attrs << boolean_attrs << ">"
     check_tag_content!(yield)
     view << "</#{name}>"


### PR DESCRIPTION
## Purpose
Fixes #1001

## Description
If you used a custom tag with a boolean attribute and a block, the boolean attributes had to be passed as a string as opposed to any other form which is an array of symbols. It also made the attributes butt up against the previous attr value which could lead to issues. 

This PR pushes the bool attr building down a tag level which fixes all that. 

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
