### PR TITLE
permit_columns when generating a resource

### DIFF
--- a/spec/tasks/gen/resource_spec.cr
+++ b/spec/tasks/gen/resource_spec.cr
@@ -32,7 +32,7 @@ describe Gen::Resource::Browser do
           "./src/queries/user_query.cr": "class UserQuery < User::BaseQuery",
           "./src/operations/save_user.cr": "class SaveUser < User::SaveOperation"
         should_create_files_with_contents io,
-          "./src/operations/save_user.cr": "# permit_columns name, signed_up"
+          "./src/operations/save_user.cr": "permit_columns name, signed_up"
         should_generate_migration named: "create_users.cr"
         should_generate_migration named: "create_users.cr", with: "add signed_up : Time"
         io.to_s.should contain "at: #{"/users".colorize.green}"

--- a/tasks/gen/templates/resource/operations/{{operation_filename}}.cr.ecr
+++ b/tasks/gen/templates/resource/operations/{{operation_filename}}.cr.ecr
@@ -1,6 +1,5 @@
 class <%= operation_class %> < <%= resource %>::SaveOperation
   # To save user provided params to the database, you must permit them
   # https://luckyframework.org/guides/database/validating-saving#perma-permitting-columns
-  #
-  # permit_columns <%= columns.map(&.name).join(", ") %>
+  permit_columns <%= columns.map(&.name).join(", ") %>
 end


### PR DESCRIPTION
This was causing an error because the resource generator generates field inputs so needs these columns to be permitted

So I removed the comment for the resource generator. The model generator still leaves it uncommented since it doesn't generate any inputs.

Here's the error:

```
In src/pages/comments/edit_page.cr:14:27
522
523 14 | mount Shared::Field.new(op.title), &.text_input(autofocus: "true")
524                          ^--
525Error: no overload matches 'Shared::Field(T).new' with type Avram::Attribute(String | Nil)+
526
527
```