### PR TITLE
Allow needs with metaclass

### DIFF
--- a/spec/lucky/assignable_spec.cr
+++ b/spec/lucky/assignable_spec.cr
@@ -49,12 +49,18 @@ class PageWithDefaultsFirst
   needs nothing : Bool = false
   needs extra_css : String?
   needs extra_html : String? = nil
+  needs optional_metaclass : String.class | Nil
   needs status : String = "special"
   needs title : String
 
   def render
     text "#{@status} #{@title}"
   end
+end
+
+class PageWithMetaclass
+  include Lucky::HTMLPage
+  needs string_class : String.class
 end
 
 describe "Assigns within multiple pages with the same name" do
@@ -64,5 +70,6 @@ describe "Assigns within multiple pages with the same name" do
     PageThree.new build_context, name: "Paul", admin_name: "Pablo", title: "Admin"
     PageWithQuestionMark.new(build_context, signed_in?: true).perform_render.to_s.should contain("true")
     PageWithDefaultsFirst.new(build_context, required: "thing", title: "foo").perform_render.to_s.should contain("special foo")
+    PageWithMetaclass.new(build_context, string_class: String)
   end
 end

--- a/src/lucky/html_builder.cr
+++ b/src/lucky/html_builder.cr
@@ -46,7 +46,13 @@ module Lucky::HTMLBuilder
   macro generate_needy_initializer
     {% if !@type.abstract? %}
       {% sorted_assigns = ASSIGNS.sort_by { |dec|
-           dec.type.resolve.nilable? || dec.value || dec.value == nil || dec.value == false ? 1 : 0
+           has_explicit_value =
+             dec.type.is_a?(Metaclass) ||
+               dec.type.types.map(&.id).includes?(Nil.id) ||
+               dec.value ||
+               dec.value == nil ||
+               dec.value == false
+           has_explicit_value ? 1 : 0
          } %}
       def initialize(
         {% for declaration in sorted_assigns %}


### PR DESCRIPTION
Closes #1017

This was an uncaught regression when we fixed sorting of needs.
Luckily the website uses a metaclass so we caught this before announcing
the new release :)