### PR TITLE
Adding ability to pass boolean attrs to link helper methods

### DIFF
--- a/spec/lucky/link_helpers_spec.cr
+++ b/spec/lucky/link_helpers_spec.cr
@@ -53,6 +53,28 @@ private class TestPage
   def string_path_without_text
     link to: "/foo"
   end
+
+  def get_route_with_text_and_attrs
+    link "Text", to: LinkHelpers::Index, attrs: [:disabled]
+  end
+
+  def get_route_with_attrs_no_text
+    link to: LinkHelpers::Index, attrs: [:disabled]
+  end
+
+  def get_route_with_block_and_attrs
+    link to: LinkHelpers::Index, attrs: [:disabled] do
+      text "Hello"
+    end
+  end
+
+  def string_path_with_attrs
+    link "Test", to: "/foos", attrs: [:disabled]
+  end
+
+  def string_path_with_attrs_no_text
+    link to: "/foos", attrs: [:disabled]
+  end
 end
 
 describe Lucky::LinkHelpers do
@@ -106,6 +128,28 @@ describe Lucky::LinkHelpers do
 
     view.link(to: LinkHelpers::Index, "data-num": 4).to_s.should contain <<-HTML
     <a href="/link_helpers" data-num="4"></a>
+    HTML
+  end
+
+  it "renders a link with boolean attrs" do
+    view.get_route_with_text_and_attrs.to_s.should contain <<-HTML
+    <a href="/link_helpers" disabled>Text</a>
+    HTML
+
+    view.get_route_with_attrs_no_text.to_s.should contain <<-HTML
+    <a href="/link_helpers" disabled></a>
+    HTML
+
+    view.get_route_with_block_and_attrs.to_s.should contain <<-HTML
+    <a href="/link_helpers" disabled>Hello</a>
+    HTML
+
+    view.string_path_with_attrs.to_s.should contain <<-HTML
+    <a href="/foos" disabled>Test</a>
+    HTML
+
+    view.string_path_with_attrs_no_text.to_s.should contain <<-HTML
+    <a href="/foos" disabled></a>
     HTML
   end
 end

--- a/src/lucky/tags/link_helpers.cr
+++ b/src/lucky/tags/link_helpers.cr
@@ -1,30 +1,30 @@
 module Lucky::LinkHelpers
-  def link(text, to : Lucky::RouteHelper, **html_options)
-    a text, merge_options(html_options, link_to_href(to))
+  def link(text, to : Lucky::RouteHelper, attrs : Array(Symbol) = [] of Symbol, **html_options)
+    a text, merge_options(html_options, link_to_href(to)), attrs
   end
 
-  def link(text, to : Lucky::Action.class, **html_options)
-    a text, merge_options(html_options, link_to_href(to.route))
+  def link(text, to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options)
+    a text, merge_options(html_options, link_to_href(to.route)), attrs
   end
 
-  def link(to : Lucky::RouteHelper, **html_options)
-    a merge_options(html_options, link_to_href(to)) do
+  def link(to : Lucky::RouteHelper, attrs : Array(Symbol) = [] of Symbol, **html_options)
+    a attrs, merge_options(html_options, link_to_href(to)) do
       yield
     end
   end
 
-  def link(to : Lucky::Action.class, **html_options)
-    a merge_options(html_options, link_to_href(to.route)) do
+  def link(to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options)
+    a attrs, merge_options(html_options, link_to_href(to.route)) do
       yield
     end
   end
 
-  def link(to : Lucky::RouteHelper, **html_options)
-    a(merge_options(html_options, link_to_href(to))) { }
+  def link(to : Lucky::RouteHelper, attrs : Array(Symbol) = [] of Symbol, **html_options)
+    a(attrs, merge_options(html_options, link_to_href(to))) { }
   end
 
-  def link(to : Lucky::Action.class, **html_options)
-    a(merge_options(html_options, link_to_href(to.route))) { }
+  def link(to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options)
+    a(attrs, merge_options(html_options, link_to_href(to.route))) { }
   end
 
   private def link_to_href(route)
@@ -35,17 +35,17 @@ module Lucky::LinkHelpers
     end
   end
 
-  def link(text, to : String, **html_options)
-    a text, merge_options(html_options, {"href" => to})
+  def link(text, to : String, attrs : Array(Symbol) = [] of Symbol, **html_options)
+    a text, merge_options(html_options, {"href" => to}), attrs
   end
 
-  def link(to : String, **html_options)
-    a merge_options(html_options, {"href" => to}) do
+  def link(to : String, attrs : Array(Symbol) = [] of Symbol, **html_options)
+    a attrs, merge_options(html_options, {"href" => to}) do
       yield
     end
   end
 
-  def link(to : String, **html_options)
-    a(merge_options(html_options, {"href" => to})) { }
+  def link(to : String, attrs : Array(Symbol) = [] of Symbol, **html_options)
+    a(attrs, merge_options(html_options, {"href" => to})) { }
   end
 end


### PR DESCRIPTION
## Purpose
Fixes #1029

## Description
You can already use the `a()` method and pass boolean attrs, but now this PR lets you pass those in the `link` methods as well.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
