### PR TITLE
[Breaking change] Removing link overload that takes a String. 

### DIFF
--- a/spec/lucky/link_helpers_spec.cr
+++ b/spec/lucky/link_helpers_spec.cr
@@ -26,32 +26,14 @@ private class TestPage
     link "Test", to: LinkHelpers::Create, something_custom: "foo"
   end
 
-  def string_path
-    link "Test", to: "/foos"
-  end
-
-  def string_path_with_options
-    link "Test", to: "/foos", data_method: "post"
-  end
-
   def get_route_with_block
     link to: LinkHelpers::Index do
       text "Hello"
     end
   end
 
-  def string_path_with_block
-    link to: "/foo" do
-      text "Hello"
-    end
-  end
-
   def get_route_without_text
     link to: LinkHelpers::Index
-  end
-
-  def string_path_without_text
-    link to: "/foo"
   end
 
   def get_route_with_text_and_attrs
@@ -67,14 +49,6 @@ private class TestPage
       text "Hello"
     end
   end
-
-  def string_path_with_attrs
-    link "Test", to: "/foos", attrs: [:disabled]
-  end
-
-  def string_path_with_attrs_no_text
-    link to: "/foos", attrs: [:disabled]
-  end
 end
 
 describe Lucky::LinkHelpers do
@@ -85,8 +59,6 @@ describe Lucky::LinkHelpers do
       .non_get_route_with_options
       .to_s
       .should contain %(<a href="/link_helpers" data-method="post" something-custom="foo">Test</a>)
-    view.string_path.to_s.should contain %(<a href="/foos">Test</a>)
-    view.string_path_with_options.to_s.should contain %(<a href="/foos" data-method="post">Test</a>)
   end
 
   it "renders a link tag with an action" do
@@ -102,20 +74,12 @@ describe Lucky::LinkHelpers do
   end
 
   it "renders a link tag with a block" do
-    view.string_path_with_block.to_s.should contain <<-HTML
-    <a href="/foo">Hello</a>
-    HTML
-
     view.get_route_with_block.to_s.should contain <<-HTML
     <a href="/link_helpers">Hello</a>
     HTML
   end
 
   it "renders a link tag without text" do
-    view.string_path_without_text.to_s.should contain <<-HTML
-    <a href="/foo"></a>
-    HTML
-
     view.get_route_without_text.to_s.should contain <<-HTML
     <a href="/link_helpers"></a>
     HTML
@@ -142,14 +106,6 @@ describe Lucky::LinkHelpers do
 
     view.get_route_with_block_and_attrs.to_s.should contain <<-HTML
     <a href="/link_helpers" disabled>Hello</a>
-    HTML
-
-    view.string_path_with_attrs.to_s.should contain <<-HTML
-    <a href="/foos" disabled>Test</a>
-    HTML
-
-    view.string_path_with_attrs_no_text.to_s.should contain <<-HTML
-    <a href="/foos" disabled></a>
     HTML
   end
 end

--- a/spec/lucky/text_helpers/truncate_spec.cr
+++ b/spec/lucky/text_helpers/truncate_spec.cr
@@ -3,19 +3,19 @@ require "./text_helpers_spec"
 class TextHelperTestPage
   def test_truncate
     truncate "Hello World", length: 8 do
-      link "Continue", "#"
+      a "Continue", href: "#"
     end
   end
 
   def text_truncate_with_block_invoked
     truncate("Here is a long test and I need a continue to read link", length: 27) do
-      link "Continue", "#"
+      a "Continue", href: "#"
     end
   end
 
   def text_truncate_without_block_invoked
     truncate("Hello World", length: 12) do
-      link "Continue", "#"
+      a "Continue", href: "#"
     end
   end
 end

--- a/src/lucky/tags/link_helpers.cr
+++ b/src/lucky/tags/link_helpers.cr
@@ -36,16 +36,33 @@ module Lucky::LinkHelpers
   end
 
   def link(text, to : String, attrs : Array(Symbol) = [] of Symbol, **html_options)
-    a text, merge_options(html_options, {"href" => to}), attrs
+    {%
+      raise <<-ERROR
+      `link` no longer supports passing a String to `to`.
+      Use `a()` or pass an Action class instead.
+
+      Example:
+        a "Home", href: "/"
+
+        link "Home", to: Home::Index
+      ERROR
+    %}
   end
 
   def link(to : String, attrs : Array(Symbol) = [] of Symbol, **html_options)
-    a attrs, merge_options(html_options, {"href" => to}) do
-      yield
-    end
-  end
+    {%
+      raise <<-ERROR
+      `link` no longer supports passing a String to `to`.
+      Use `a()` or pass an Action class instead.
 
-  def link(to : String, attrs : Array(Symbol) = [] of Symbol, **html_options)
-    a(attrs, merge_options(html_options, {"href" => to})) { }
+      Example:
+        a href: "/" do
+        end
+
+        link to: Home::Index do
+        end
+      ERROR
+    %}
+    yield
   end
 end


### PR DESCRIPTION
## Purpose
Fixes #1033 
Fixes #1026 

## Description
This removes the overloads for the `link` helper that take a String for the path. One of the overloads was `link(to : String, **opts)` which meant you could define `link "Home"`, and it would be fine, but that shouldn't be. This also helps to keep links a bit more safe by using the Action class as the preferred method.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
