### PR TITLE
Bump Dockerfile to lastest crystal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.32.0
+FROM crystallang/crystal:0.33.0
 WORKDIR /data
 
 RUN apt-get update && \


### PR DESCRIPTION
## Purpose
Just keeping consistent with the crystal version we're using

## Description
Bump Dockerfile to crystal 0.33.0

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
