### PR TITLE
Adding new CookieNotFoundError

### DIFF
--- a/spec/lucky/cookies/cookie_jar_spec.cr
+++ b/spec/lucky/cookies/cookie_jar_spec.cr
@@ -33,7 +33,7 @@ describe Lucky::CookieJar do
   it "raises CookieNotFoundError when getting a raw cookie that doesn't exist" do
     jar = Lucky::CookieJar.empty_jar
 
-    expect_raises Lucky::CookieNotFoundError, "No cookie with the key: snickerdoodle" do
+    expect_raises Lucky::CookieNotFoundError, "No cookie found with the key: 'snickerdoodle'" do
       jar.get_raw(:snickerdoodle)
     end
   end
@@ -41,7 +41,7 @@ describe Lucky::CookieJar do
   it "raises CookieNotFoundError when getting an encrypted cookie that doesn't exist" do
     jar = Lucky::CookieJar.empty_jar
 
-    expect_raises Lucky::CookieNotFoundError, "No cookie for 'snickerdoodle'" do
+    expect_raises Lucky::CookieNotFoundError, "No cookie found with the key: 'snickerdoodle'" do
       jar.get(:snickerdoodle)
     end
   end

--- a/spec/lucky/cookies/cookie_jar_spec.cr
+++ b/spec/lucky/cookies/cookie_jar_spec.cr
@@ -30,6 +30,22 @@ describe Lucky::CookieJar do
     jar.get_raw?("missing").should be_nil
   end
 
+  it "raises CookieNotFoundError when getting a raw cookie that doesn't exist" do
+    jar = Lucky::CookieJar.empty_jar
+
+    expect_raises Lucky::CookieNotFoundError, "No cookie with the key: snickerdoodle" do
+      jar.get_raw(:snickerdoodle)
+    end
+  end
+
+  it "raises CookieNotFoundError when getting an encrypted cookie that doesn't exist" do
+    jar = Lucky::CookieJar.empty_jar
+
+    expect_raises Lucky::CookieNotFoundError, "No cookie for 'snickerdoodle'" do
+      jar.get(:snickerdoodle)
+    end
+  end
+
   it "catches values with old or incorrect keys and returns nil" do
     jar_with_old_secret = Lucky::CookieJar.empty_jar
     Lucky::Server.temp_config(secret_key_base: "a" * 32) do

--- a/src/lucky/cookies/cookie_jar.cr
+++ b/src/lucky/cookies/cookie_jar.cr
@@ -56,7 +56,7 @@ class Lucky::CookieJar
   end
 
   def get_raw(key : Key) : HTTP::Cookie
-    get_raw?(key) || raise CookieNotFoundError.new("No cookie with the key: #{key}")
+    get_raw?(key) || raise CookieNotFoundError.new(key)
   end
 
   def get_raw?(key : Key) : HTTP::Cookie?
@@ -64,7 +64,7 @@ class Lucky::CookieJar
   end
 
   def get(key : Key) : String
-    get?(key) || raise CookieNotFoundError.new("No cookie for '#{key}'")
+    get?(key) || raise CookieNotFoundError.new(key)
   end
 
   def get?(key : Key) : String?

--- a/src/lucky/cookies/cookie_jar.cr
+++ b/src/lucky/cookies/cookie_jar.cr
@@ -56,7 +56,7 @@ class Lucky::CookieJar
   end
 
   def get_raw(key : Key) : HTTP::Cookie
-    get_raw?(key) || raise "No cookie with the key: #{key}"
+    get_raw?(key) || raise CookieNotFoundError.new("No cookie with the key: #{key}")
   end
 
   def get_raw?(key : Key) : HTTP::Cookie?
@@ -64,7 +64,7 @@ class Lucky::CookieJar
   end
 
   def get(key : Key) : String
-    get?(key) || raise "No cookie for '#{key}'"
+    get?(key) || raise CookieNotFoundError.new("No cookie for '#{key}'")
   end
 
   def get?(key : Key) : String?

--- a/src/lucky/errors.cr
+++ b/src/lucky/errors.cr
@@ -101,6 +101,24 @@ module Lucky
 
   # Raised when getting a cookie that doesn't exist.
   class CookieNotFoundError < Error
+    include Lucky::RenderableError
+
+    getter :key
+
+    def initialize(@key : String | Symbol)
+    end
+
+    def message : String
+      "No cookie found with the key: '#{key}'"
+    end
+
+    def renderable_status : Int32
+      400
+    end
+
+    def renderable_message : String
+      message
+    end
   end
 
   class InvalidSignatureError < Error

--- a/src/lucky/errors.cr
+++ b/src/lucky/errors.cr
@@ -99,6 +99,10 @@ module Lucky
   class CookieOverflowError < Error
   end
 
+  # Raised when getting a cookie that doesn't exist.
+  class CookieNotFoundError < Error
+  end
+
   class InvalidSignatureError < Error
   end
 


### PR DESCRIPTION
## Purpose
Fixes #964

## Description
When you try to call a cookie by a key, and that cookie is not found, we currently just raise a simple string error. This means that in your code you'll need to just call `rescue` which could be dangerous and mask other potential errors. 

This PR adds in a new `CookieNotFoundError` class to allow you to rescue from that specifically. I didn't change the error message that was returned, but just wrapped it in a class.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
