### PR TITLE
Added missing deleted? method to cookie jar. 

### DIFF
--- a/spec/lucky/cookies/cookie_jar_spec.cr
+++ b/spec/lucky/cookies/cookie_jar_spec.cr
@@ -136,6 +136,23 @@ describe Lucky::CookieJar do
     end
   end
 
+  describe "deleted?" do
+    it "returns true when the cookie looks like a deleted cookie" do
+      jar = Lucky::CookieJar.empty_jar
+      jar.set(:go, "now!")
+      jar.deleted?(:go).should be_false
+
+      jar.delete(:go)
+
+      jar.deleted?(:go).should be_true
+    end
+
+    it "returns false when the cookie doesn't even exist" do
+      jar = Lucky::CookieJar.empty_jar
+      jar.deleted?(:non).should be_false
+    end
+  end
+
   describe "#clear" do
     it "deletes all the cookies in the jar" do
       jar = Lucky::CookieJar.empty_jar

--- a/src/lucky/cookies/cookie_jar.cr
+++ b/src/lucky/cookies/cookie_jar.cr
@@ -55,6 +55,16 @@ class Lucky::CookieJar
     end
   end
 
+  # Returns `true` if the cookie has been expired, and has no value.
+  # Will return `false` if the cookie does not exist, or is valid.
+  def deleted?(key : Key) : Bool
+    if cookie = cookies[key.to_s]?
+      cookie.expired? && cookie.value == ""
+    else
+      false
+    end
+  end
+
   def get_raw(key : Key) : HTTP::Cookie
     get_raw?(key) || raise CookieNotFoundError.new(key)
   end


### PR DESCRIPTION
## Purpose
Fixes #963

## Description
In the guides we make mention of a `cookies.deleted?()` method that never actually existed. I'm not sure where it came from (probably me), but this adds that method in. 

Deleting cookies is weird because to delete a cookie, you set the value to an empty string, and the expire time to something in the past. It's actually up to the individual browsers to remove that cookie. This `deleted?` method will return true if the cookie is both `expired? && value.blank?` otherwise it's just false.

**Side note:** in the guides, we also make mention of `session.deleted?(:name)`. I decided to not implement this because if a session key is deleted,  then it's just `nil`. I'm ok with adding it for consistency in the API, but initially I didn't think it's necessary. 

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
