### PR TITLE
[WIP] Generate getters right away

### DIFF
--- a/spec/lucky/assignable_spec.cr
+++ b/spec/lucky/assignable_spec.cr
@@ -68,6 +68,19 @@ class PageWithMetaclass
   end
 end
 
+class OverrideGetterPage
+  include Lucky::HTMLPage
+  needs name : String = "Oops! Not set"
+
+  def render
+    text name
+  end
+
+  def name
+    "Joe"
+  end
+end
+
 describe "Assigns within multiple pages with the same name" do
   it "should only appear once in the initializer" do
     PageOne.new build_context, title: "foo", name: "Paul", second: "second"
@@ -77,5 +90,6 @@ describe "Assigns within multiple pages with the same name" do
     PageWithDefaultsFirst.new(build_context, required: "thing", title: "foo").perform_render.to_s.should contain("special foo")
     PageWithMetaclass.new(build_context, string_class: String)
       .perform_render.to_s.should contain("called from an auto-generated getter")
+    OverrideGetterPage.new(build_context).perform_render.to_s.should eq("Joe")
   end
 end

--- a/src/lucky/assignable.cr
+++ b/src/lucky/assignable.cr
@@ -29,6 +29,17 @@ module Lucky::Assignable
       {% if declaration.var.stringify.ends_with?("?") %}
         {% raise "Using '?' in a 'needs' var name is no longer supported. Now Lucky generates a method ending in '?' if the type is 'Bool'." %}
       {% end %}
+
+      {% if declaration.type.stringify == "Bool" %}
+        def {{ declaration.var }}?
+          @{{ declaration.var }}
+        end
+      {% else %}
+        def {{ declaration.var }}
+          @{{ declaration.var }}
+        end
+      {% end %}
+
       {% ASSIGNS << declaration %}
     {% end %}
   end

--- a/src/lucky/html_builder.cr
+++ b/src/lucky/html_builder.cr
@@ -28,7 +28,6 @@ module Lucky::HTMLBuilder
   macro setup_initializer_hook
     macro finished
       generate_needy_initializer
-      generate_getters
     end
 
     macro included


### PR DESCRIPTION
We were generating getters at the very end, which meant it would
overwrite similarly named methods, which is not expected behavior.