### PR TITLE
Revert removal of label text inference and allow `nil`

### DIFF
--- a/spec/lucky/label_helpers_spec.cr
+++ b/spec/lucky/label_helpers_spec.cr
@@ -1,5 +1,7 @@
 require "../spec_helper"
 
+include ContextHelper
+
 class TestUser
   def first_name
     "My Name"
@@ -31,6 +33,10 @@ private class TestPage
     label_for form.first_name, class: "best-label"
   end
 
+  def label_with_nil_text
+    label_for form.first_name, text: nil
+  end
+
   def label_with_custom_text
     label_for form.first_name, "My Label"
   end
@@ -59,6 +65,10 @@ describe Lucky::LabelHelpers do
 
     view.label_with_html_options.to_s.should contain <<-HTML
     <label for="user_first_name" class="best-label">First name</label>
+    HTML
+
+    view.label_with_nil_text.to_s.should contain <<-HTML
+    <label for="user_first_name">First name</label>
     HTML
 
     view.label_with_custom_text.to_s.should contain <<-HTML

--- a/spec/lucky/label_helpers_spec.cr
+++ b/spec/lucky/label_helpers_spec.cr
@@ -1,7 +1,5 @@
 require "../spec_helper"
 
-include ContextHelper
-
 class TestUser
   def first_name
     "My Name"
@@ -26,11 +24,19 @@ private class TestPage
   end
 
   def label_without_html_options
-    label_for form.first_name, "First name"
+    label_for form.first_name
   end
 
   def label_with_html_options
-    label_for form.first_name, "First name", class: "best-label"
+    label_for form.first_name, class: "best-label"
+  end
+
+  def label_with_custom_text
+    label_for form.first_name, "My Label"
+  end
+
+  def label_with_custom_text_and_options
+    label_for form.first_name, "My Label", class: "best-label"
   end
 
   def label_with_block
@@ -53,6 +59,14 @@ describe Lucky::LabelHelpers do
 
     view.label_with_html_options.to_s.should contain <<-HTML
     <label for="user_first_name" class="best-label">First name</label>
+    HTML
+
+    view.label_with_custom_text.to_s.should contain <<-HTML
+    <label for="user_first_name">My Label</label>
+    HTML
+
+    view.label_with_custom_text_and_options.to_s.should contain <<-HTML
+    <label for="user_first_name" class="best-label">My Label</label>
     HTML
 
     view.label_with_block.to_s.should contain <<-HTML

--- a/src/lucky/tags/label_helpers.cr
+++ b/src/lucky/tags/label_helpers.cr
@@ -1,4 +1,12 @@
 module Lucky::LabelHelpers
+  def label_for(field : Avram::PermittedAttribute, **html_options)
+    label_for(
+      field,
+      Wordsmith::Inflector.humanize(field.name.to_s),
+      **html_options
+    )
+  end
+
   def label_for(field : Avram::PermittedAttribute, text : String, **html_options)
     label(
       text,
@@ -10,19 +18,6 @@ module Lucky::LabelHelpers
     label(merge_options(html_options, {"for" => input_id(field)})) do
       yield
     end
-  end
-
-  def label_for(field : Avram::PermittedAttribute, **options)
-    {% raise <<-ERROR
-      'label_for' no longer guesses the label text. Please provide the text for this label.
-
-      Try this...
-
-        ▸ label_for operation.my_attribute, "This is the label text"
-
-
-      ERROR
-    %}
   end
 
   def label_for(field, **options)

--- a/src/lucky/tags/label_helpers.cr
+++ b/src/lucky/tags/label_helpers.cr
@@ -1,15 +1,7 @@
 module Lucky::LabelHelpers
-  def label_for(field : Avram::PermittedAttribute, **html_options)
-    label_for(
-      field,
-      Wordsmith::Inflector.humanize(field.name.to_s),
-      **html_options
-    )
-  end
-
-  def label_for(field : Avram::PermittedAttribute, text : String, **html_options)
+  def label_for(field : Avram::PermittedAttribute, text : String? = nil, **html_options)
     label(
-      text,
+      text || guess_label_name(field),
       merge_options(html_options, {"for" => input_id(field)})
     )
   end
@@ -27,5 +19,9 @@ module Lucky::LabelHelpers
   def label_for(field, **options)
     Lucky::InputHelpers.error_message_for_unallowed_field
     yield
+  end
+
+  private def guess_label_name(field)
+    Wordsmith::Inflector.humanize(field.name.to_s)
   end
 end


### PR DESCRIPTION
https://github.com/luckyframework/lucky/issues/1028#issuecomment-599078910

> Actually I may just be overthinking this. Lucky wants to avoid bugs,
but also be practical. Sometimes nils can sneak in when you don't expect
it...but maybe label_text is not one of those places. I have a hard time
seeing a use case where someone is conditionally generating a label and
it might accidentally be nil. I think of all the apps I've ever written
I've never accidentally set label text to nil.

> So I think what I'll do is make the label text String?. So that if you
pass nil to text it will infer the label name like it does now when you
leave the arg off completely. That way we can still keep the component
flexible by allowing String? but we also keep label_for flexible. I'll
go ahead and make that change now. This also means existing apps will
still work when you upgrade and this will no longer be a breaking change
👍