### PR TITLE
Change development ENV from PORT to DEV_PORT

### DIFF
--- a/src/lucky/server_settings.cr
+++ b/src/lucky/server_settings.cr
@@ -10,7 +10,7 @@ module Lucky::ServerSettings
   end
 
   def port : Int32
-    ENV["PORT"]?.try(&.to_i) || settings["port"].as_i
+    ENV["DEV_PORT"]?.try(&.to_i) || settings["port"].as_i
   end
 
   private def settings


### PR DESCRIPTION
## Purpose
Fixes #570

## Description
If you need to change the port your local app runs on, the local process runners like overmind will automatically set `PORT` to 5000 ignoring your change. This changes the local ENV to `DEV_PORT` so we can still use `lucky dev` but run on a different port.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
