### PR TITLE
Fix params failing to read FixedContentLength

### DIFF
--- a/spec/lucky/params_spec.cr
+++ b/spec/lucky/params_spec.cr
@@ -63,13 +63,13 @@ describe Lucky::Params do
 
   it "works when parsing params twice" do
     request = build_request body: "from=form",
-      content_type: "application/x-www-form-urlencoded"
+      content_type: "application/x-www-form-urlencoded",
+      fixed_length: true
 
     params = Lucky::Params.new(request)
-    dup_params = Lucky::Params.new(request)
 
     params.get?(:from).should eq "form"
-    dup_params.get?(:from).should eq "form"
+    params.get?(:from).should eq "form"
   end
 
   it "works when parsing multipart params twice" do
@@ -81,10 +81,20 @@ describe Lucky::Params do
     }
 
     params = Lucky::Params.new(request)
-    dup_params = Lucky::Params.new(request)
 
     params.nested?(:user)
-    dup_params.nested?(:user)
+    params.nested?(:user)
+  end
+
+  it "works when parsing multipart params twice" do
+    request = build_request body: {page: 1}.to_json,
+      content_type: "application/json",
+      fixed_length: true
+
+    params = Lucky::Params.new(request)
+
+    params.get?(:page).should eq "1"
+    params.get?(:page).should eq "1"
   end
 
   describe "all" do

--- a/spec/support/context_helper.cr
+++ b/spec/support/context_helper.cr
@@ -1,9 +1,12 @@
 module ContextHelper
   extend self
 
-  private def build_request(method = "GET", body = "", content_type = "") : HTTP::Request
+  private def build_request(method = "GET", body = "", content_type = "", fixed_length : Bool = false) : HTTP::Request
     headers = HTTP::Headers.new
     headers.add("Content-Type", content_type)
+    if fixed_length
+      body = HTTP::FixedLengthContent.new(IO::Memory.new(body), body.size)
+    end
     HTTP::Request.new(method, "/", body: body, headers: headers)
   end
 

--- a/src/lucky/json_body_parser.cr
+++ b/src/lucky/json_body_parser.cr
@@ -16,6 +16,6 @@ class Lucky::JsonBodyParser
   end
 
   private def body : String
-    request.body.to_s
+    Lucky::RequestBodyReader.new(request).body
   end
 end

--- a/src/lucky/params.cr
+++ b/src/lucky/params.cr
@@ -477,8 +477,8 @@ class Lucky::Params
     Lucky::JsonBodyParser.new(request).parsed_json
   end
 
-  def body : String
-    request.body.to_s
+  memoize def body : String
+    Lucky::RequestBodyReader.new(request).body
   end
 
   private def empty_params

--- a/src/lucky/request_body_reader.cr
+++ b/src/lucky/request_body_reader.cr
@@ -1,0 +1,13 @@
+# :nodoc:
+class Lucky::RequestBodyReader
+  getter request : HTTP::Request
+
+  def initialize(@request)
+  end
+
+  def body : String
+    (request.body || IO::Memory.new).gets_to_end.tap do |request_body|
+      request.body = IO::Memory.new(request_body)
+    end
+  end
+end


### PR DESCRIPTION
See: https://github.com/luckyframework/lucky_cli/pull/483

When requests come in they are often `HTTP::FixedLengthContent`. When
that's the case, calling `to_s` in the body returns something like this:
`HTTP::FixedLengthContent#d9349234x`

So this reverts back to using `gets_to_end` resetting the body after for
future reads.