### PR TITLE
Remove changed file log

### DIFF
--- a/tasks/watch.cr
+++ b/tasks/watch.cr
@@ -189,7 +189,6 @@ module LuckySentry
         if FILE_TIMESTAMPS[file]? && FILE_TIMESTAMPS[file] != timestamp
           FILE_TIMESTAMPS[file] = timestamp
           file_changed = true
-          puts "#{file} has changed".colorize(:yellow)
         elsif FILE_TIMESTAMPS[file]?.nil?
           FILE_TIMESTAMPS[file] = timestamp
           file_changed = true if (app_processes.none? &.terminated?)


### PR DESCRIPTION
I've never seen this and thought "Oh yeah I did change that file!"

I think we can just remove it so there is less noise in the log