### PR TITLE
Add current_page? helper for pages.

### DIFF
--- a/spec/lucky/url_helpers_spec.cr
+++ b/spec/lucky/url_helpers_spec.cr
@@ -53,6 +53,15 @@ describe Lucky::UrlHelpers do
           .should be_false
       end
 
+      it "deals with escaped characters in query params" do
+        view_for("/pages?description=Some%20d%C3%A9scription")
+          .current_page?("/pages?description=Some déscription", check_query_params: true)
+          .should be_true
+        view_for("/pages?description=Some%20d%C3%A9scription")
+          .current_page?("/pages?description=Some%20d%C3%A9scription", check_query_params: true)
+          .should be_true
+      end
+
       it "checks query params if explicitly required" do
         view_for("/action?order=desc&page=1")
           .current_page?("/action?order=desc&page=1", check_query_params: true)

--- a/spec/support/context_helper.cr
+++ b/spec/support/context_helper.cr
@@ -1,7 +1,12 @@
 module ContextHelper
   extend self
 
-  private def build_request(method = "GET", body = "", content_type = "", fixed_length : Bool = false) : HTTP::Request
+  private def build_request(
+    method = "GET",
+    body = "",
+    content_type = "",
+    fixed_length : Bool = false
+  ) : HTTP::Request
     headers = HTTP::Headers.new
     headers.add("Content-Type", content_type)
     if fixed_length
@@ -10,7 +15,10 @@ module ContextHelper
     HTTP::Request.new(method, "/", body: body, headers: headers)
   end
 
-  def build_context(path = "/", request : HTTP::Request? = nil) : HTTP::Server::Context
+  def build_context(
+    path = "/",
+    request : HTTP::Request? = nil
+  ) : HTTP::Server::Context
     build_context_with_io(IO::Memory.new, path: path, request: request)
   end
 
@@ -26,7 +34,11 @@ module ContextHelper
     )
   end
 
-  private def build_context_with_io(io : IO, path = "/", request = nil) : HTTP::Server::Context
+  private def build_context_with_io(
+    io : IO,
+    path = "/",
+    request = nil
+  ) : HTTP::Server::Context
     request = request || HTTP::Request.new("GET", path)
     response = HTTP::Server::Response.new(io)
     HTTP::Server::Context.new request, response

--- a/src/lucky/page_helpers/url_helpers.cr
+++ b/src/lucky/page_helpers/url_helpers.cr
@@ -1,0 +1,65 @@
+module Lucky::UrlHelpers
+  # Tests if the given path matches the current request path.
+  #
+  # ```
+  # # Let's say we are visiting https://example.com/shop/products?order=desc&page=1
+  # current_page?("/shop/checkout")
+  # # => false
+  # current_page?("/shop/products")
+  # # => true
+  # current_page?("/shop/products/")
+  # # => true
+  # current_page?("/shop/products?order=desc&page=1")
+  # # => false
+  # current_page?("/shop/products?order=desc&page=1", check_query_params: true)
+  # # => true
+  # current_page?("https://example.com/shop/products")
+  # # => true
+  # current_page?("https://example.com/shop/products?order=desc&page=1")
+  # # => false
+  # ```
+  def current_page?(
+    path : String,
+    check_query_params : Bool = false
+  )
+    return false unless {"GET", "HEAD"}.includes?(@context.request.method)
+
+    uri = URI.parse(path)
+
+    if check_query_params
+      resource = @context.request.resource
+      path = uri.full_path
+    else
+      resource = URI.parse(@context.request.resource).path
+      path = uri.path
+    end
+
+    unless path == '/'
+      path = path.chomp('/')
+      resource = resource.chomp('/')
+    end
+
+    path == resource
+  end
+
+  # Tests if the given path matches the current request path.
+  #
+  # ```
+  # # Visiting https://example.com/pages/123
+  # current_page?(Pages::Show.with(123))
+  # # => true
+  # current_page?(Pages::Show.with(456))
+  # # => false
+  # # Visiting https://example.com/pages
+  # current_page?(Pages::Index)
+  # # => true
+  # current_page?(Blog::Index)
+  # # => false
+  # ```
+  def current_page?(
+    action : Class | Lucky::RouteHelper,
+    check_query_params : Bool = false
+  )
+    current_page?(action.path)
+  end
+end

--- a/src/lucky/page_helpers/url_helpers.cr
+++ b/src/lucky/page_helpers/url_helpers.cr
@@ -43,8 +43,8 @@ module Lucky::UrlHelpers
     end
 
     if check_query_params
-      path += uri.query_params.map(&.join).sort!.join
-      resource += request_uri.query_params.map(&.join).sort!.join
+      path += comparable_query_params(uri.query_params)
+      resource += comparable_query_params(request_uri.query_params)
     end
 
     if value.match(/^\w+:\/\//)
@@ -83,5 +83,9 @@ module Lucky::UrlHelpers
     check_query_params : Bool = false
   )
     current_page?(action.path, check_query_params)
+  end
+
+  private def comparable_query_params(query_params : HTTP::Params) : String
+    URI.decode(query_params.map(&.join).sort!.join)
   end
 end

--- a/src/lucky/page_helpers/url_helpers.cr
+++ b/src/lucky/page_helpers/url_helpers.cr
@@ -69,10 +69,7 @@ module Lucky::UrlHelpers
   # current_page?(Blog::Index)
   # # => false
   # ```
-  def current_page?(
-    action : Lucky::Action.class | Lucky::RouteHelper,
-    check_query_params : Bool = false
-  )
+  def current_page?(action : Lucky::Action.class | Lucky::RouteHelper)
     current_page?(action.path)
   end
 end


### PR DESCRIPTION
## Purpose
Implementing #1073.

## Description
This adds the `current_page?` helper with similar functionality like the one in Rails. Although, it does not cover all Rails' cases. What it does not do:

1. handle cases with [double escaped params](https://github.com/rails/rails/blob/master/actionview/test/template/url_helper_test.rb#L594-L598)
2. handle cases with [different encoding](https://github.com/rails/rails/blob/master/actionview/test/template/url_helper_test.rb#L586-L592)
3. test against a [full uri](https://github.com/rails/rails/blob/master/actionview/lib/action_view/helpers/url_helper.rb#L567), including `protocol` and `port`

I'm not quite sure if they are relevant or even possible. Looking at the available data in a request, I wonder if it is even feasible to implement point **3**. There is no notion of the protocol, but even then, would we even need to test the protocol?

## Checklist
* [X] - An issue already exists detailing the issue/or feature request that this PR fixes
* [X] - All specs are formatted with `crystal tool format spec src`
* [X] - Inline documentation has been added and/or updated
* [X] - Lucky builds on docker with `./script/setup`
* [X] - All builds and specs pass on docker with `./script/test`
