### PR TITLE
Clarify upgrade notes for 0.16.0 -> 0.17.0

### DIFF
--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -245,7 +245,7 @@ If you're not sure about an upgrade step, or simply want to look at an example, 
 ### General updates
 - Rename: Action rendering method `text` to `plain_text`.
 - Update: use of `number_to_currency` now returns a String instead of writing to the view directly.
-- Delete: `config/static_file_handler.cr`. The `Lucky::StaticFileHandler` no longer has config settings.
+- Delete: `config/static_file_handler.cr`.
 - Add: a new `Lucky::LogHandler` configure to the bottom of `config/logger.cr`.
 - Update: `Avram::Repo.configure` to `Avram.configure` in `config/logger.cr`.
 <details>


### PR DESCRIPTION
## Purpose
I got confused and thought I needed to remove the `Lucky::StaticFileHandler` from my `src/app_server.cr`. It's just that we don't need to configure the static file handler anymore, but we still want one.