### PR TITLE
Return Nil for all HTML tags

### DIFF
--- a/spec/lucky/base_tags_spec.cr
+++ b/spec/lucky/base_tags_spec.cr
@@ -18,37 +18,37 @@ end
 
 describe Lucky::BaseTags do
   it "renders para tag as <p>" do
-    view.para("foo").to_s.should contain "<p>foo</p>"
+    view(&.para("foo")).should contain "<p>foo</p>"
   end
 
   it "renders allowed types in tags" do
-    view.para(42).to_s.should contain "<p>42</p>"
-    view.para(MySpecialClass.new).to_s.should contain "<p>it works</p>"
-    view.para(1_i64).to_s.should contain "<p>1</p>"
-    view.hr.to_s.should contain "<hr>"
+    view(&.para(42)).should contain "<p>42</p>"
+    view(&.para(MySpecialClass.new)).should contain "<p>it works</p>"
+    view(&.para(1_i64)).should contain "<p>1</p>"
+    view(&.hr).should contain "<hr>"
   end
 
   it "renders nested video with source tags and proper attributes" do
-    view do
-      video(attrs: [:autoplay, :controls, :loop], poster: "https://luckyframework.org/nothing.png") do
-        source(src: "https://luckyframework.org/nothing.mp4", type: "video/mp4")
+    view do |page|
+      page.video(attrs: [:autoplay, :controls, :loop], poster: "https://luckyframework.org/nothing.png") do
+        page.source(src: "https://luckyframework.org/nothing.mp4", type: "video/mp4")
       end
-    end.to_s.should contain %{<video poster="https://luckyframework.org/nothing.png" autoplay controls loop><source src="https://luckyframework.org/nothing.mp4" type="video/mp4"></video>}
+    end.should contain %{<video poster="https://luckyframework.org/nothing.png" autoplay controls loop><source src="https://luckyframework.org/nothing.mp4" type="video/mp4"></video>}
 
-    view.video(id: "player", "data-stream": "https://luckyframework.org/demo.mp4").to_s.should eq %{<video id="player" data-stream="https://luckyframework.org/demo.mp4"></video>}
+    view(&.video(id: "player", "data-stream": "https://luckyframework.org/demo.mp4")).should eq %{<video id="player" data-stream="https://luckyframework.org/demo.mp4"></video>}
   end
 
   it "renders a button with a disabled boolean attribute" do
-    view.button("text", attrs: [:disabled]).to_s.should contain "<button disabled>text</button>"
+    view(&.button("text", attrs: [:disabled])).should contain "<button disabled>text</button>"
   end
 
   it "renders an input with autofocus boolean attribute" do
-    view.input(attrs: [:autofocus], type: "text").to_s.should contain %{<input type="text" autofocus>}
+    view(&.input(attrs: [:autofocus], type: "text")).to_s.should contain %{<input type="text" autofocus>}
   end
 
   describe "#style" do
     it "renders a style tag" do
-      view.style("body { font-size: 2em; }").to_s.should contain <<-HTML
+      view(&.style("body { font-size: 2em; }")).should contain <<-HTML
       <style>body { font-size: 2em; }</style>
       HTML
     end
@@ -56,9 +56,7 @@ describe Lucky::BaseTags do
 end
 
 private def view
-  TestPage.new(build_context)
-end
-
-private def view
-  with TestPage.new(build_context) yield
+  TestPage.new(build_context).tap do |page|
+    yield page
+  end.view.to_s
 end

--- a/spec/lucky/custom_tags_spec.cr
+++ b/spec/lucky/custom_tags_spec.cr
@@ -1,4 +1,5 @@
 require "../spec_helper"
+
 include ContextHelper
 
 private class TestPage
@@ -10,46 +11,48 @@ end
 
 describe Lucky::CustomTags do
   it "renders tag in a variety of ways" do
-    view.tag("foo-tag", "content")
+    view(&.tag("foo-tag", "content"))
       .to_s.should contain "<foo-tag>content</foo-tag>"
-    view.tag("foo-tag", 1)
+    view(&.tag("foo-tag", 1))
       .to_s.should contain "<foo-tag>1</foo-tag>"
-    view.tag("foo-tag", "content", class: "my-class")
+    view(&.tag("foo-tag", "content", class: "my-class"))
       .to_s.should contain %(<foo-tag class="my-class">content</foo-tag>)
-    view.tag("foo-tag", 1, class: "my-class")
+    view(&.tag("foo-tag", 1, class: "my-class"))
       .to_s.should contain %(<foo-tag class="my-class">1</foo-tag>)
-    view.tag("foo-tag", "content", data_confirm: "true")
+    view(&.tag("foo-tag", "content", data_confirm: "true"))
       .to_s.should contain %(<foo-tag data-confirm="true">content</foo-tag>)
-    view.tag("foo-tag")
+    view(&.tag("foo-tag"))
       .to_s.should contain "<foo-tag></foo-tag>"
-    view.tag("foo-tag", class: "my-class")
+    view(&.tag("foo-tag", class: "my-class"))
       .to_s.should contain %(<foo-tag class="my-class"></foo-tag>)
-    view.tag("foo-tag", attrs: [:ng_strict_di], ng_app: "ngAppStrictDemo")
+    view(&.tag("foo-tag", attrs: [:ng_strict_di], ng_app: "ngAppStrictDemo"))
       .to_s.should contain %(<foo-tag ng-app="ngAppStrictDemo" ng-strict-di></foo-tag>)
 
-    view.tap do |page|
+    view do |page|
       page.tag("foo-tag") do
         page.text "content"
-      end.to_s.should contain "<foo-tag>content</foo-tag>"
-    end
+      end
+    end.should contain "<foo-tag>content</foo-tag>"
 
-    view.tap do |page|
+    view do |page|
       page.tag("foo-tag", class: "my-class") do
         page.text "content"
-      end.to_s.should contain %(<foo-tag class="my-class">content</foo-tag>)
-    end
+      end
+    end.should contain %(<foo-tag class="my-class">content</foo-tag>)
 
-    view.tap do |page|
+    view do |page|
       page.tag "script", [:async], data_counter: "https://counter.co", src: "count.js" do
-      end.to_s.should contain %(<script data-counter="https://counter.co" src="count.js" async></script>)
-    end
+      end
+    end.should contain %(<script data-counter="https://counter.co" src="count.js" async></script>)
   end
 
   it "has a method for empty tags" do
-    view.empty_tag("br").to_s.should eq "<br>"
+    view(&.empty_tag("br")).should eq "<br>"
   end
 end
 
 private def view
-  TestPage.new(build_context)
+  TestPage.new(build_context).tap do |page|
+    yield page
+  end.view.to_s
 end

--- a/spec/lucky/forgery_protection_helpers_spec.cr
+++ b/spec/lucky/forgery_protection_helpers_spec.cr
@@ -14,7 +14,7 @@ describe Lucky::ForgeryProtectionHelpers do
     context = build_context
     context.session.set(Lucky::ProtectFromForgery::SESSION_KEY, "my_token")
 
-    view(context).csrf_hidden_input.to_s.should contain <<-HTML
+    view(context, &.csrf_hidden_input).should contain <<-HTML
     <input type="hidden" name="#{Lucky::ProtectFromForgery::PARAM_KEY}" value="my_token">
     HTML
   end
@@ -22,10 +22,7 @@ describe Lucky::ForgeryProtectionHelpers do
   it "renders a meta tag for Rails UJS (and other JS that may need it)" do
     context = build_context
     context.session.set(Lucky::ProtectFromForgery::SESSION_KEY, "my_token")
-    page = view(context)
-
-    page.csrf_meta_tags
-    rendered = page.perform_render.to_s
+    rendered = view(context, &.csrf_meta_tags)
 
     rendered.should contain <<-HTML
     <meta name="csrf-param" content="#{Lucky::ProtectFromForgery::PARAM_KEY}">
@@ -37,5 +34,7 @@ describe Lucky::ForgeryProtectionHelpers do
 end
 
 private def view(context)
-  TestPage.new(context)
+  TestPage.new(context).tap do |page|
+    yield page
+  end.view.to_s
 end

--- a/spec/lucky/form_helpers_spec.cr
+++ b/spec/lucky/form_helpers_spec.cr
@@ -1,5 +1,7 @@
 require "../spec_helper"
 
+include ContextHelper
+
 class FormHelpers::Index < TestAction
   route { plain_text "foo " }
 end
@@ -46,29 +48,29 @@ end
 describe Lucky::FormHelpers do
   it "renders a form tag" do
     without_csrf_protection do
-      view.inferred_put_form.to_s.should contain <<-HTML
+      view(&.inferred_put_form).should contain <<-HTML
       <form action="/form_helpers/fake_id" method="post"><input type="hidden" name="_method" value="put">foo</form>
       HTML
 
-      view.inferred_post_form.to_s.should contain <<-HTML
+      view(&.inferred_post_form).should contain <<-HTML
       <form action="/form_helpers" method="post">foo</form>
       HTML
 
-      view.inferred_get_form.to_s.should contain <<-HTML
+      view(&.inferred_get_form).should contain <<-HTML
       <form action="/form_helpers" method="get">foo</form>
       HTML
 
-      view.form_with_html_options.to_s.should contain <<-HTML
+      view(&.form_with_html_options).should contain <<-HTML
       <form action="/form_helpers" method="post" class="cool-form">foo</form>
       HTML
 
-      form = view.form_for(FormHelpers::Index) { }
-      form.to_s.should contain <<-HTML
+      form = view(&.form_for(FormHelpers::Index) { })
+      form.should contain <<-HTML
       <form action="/form_helpers" method="get"></form>
       HTML
 
-      form = view.form_for(FormHelpers::Index, class: "form-block") { }
-      form.to_s.should contain <<-HTML
+      form = view(&.form_for(FormHelpers::Index, class: "form-block") { })
+      form.should contain <<-HTML
       <form action="/form_helpers" method="get" class="form-block"></form>
       HTML
     end
@@ -78,9 +80,9 @@ describe Lucky::FormHelpers do
     context_with_csrf = build_context
     context_with_csrf.session.set(Lucky::ProtectFromForgery::SESSION_KEY, "my_token")
 
-    form = view(context_with_csrf).form_for(FormHelpers::Index) { }
+    form = view(context_with_csrf, &.form_for(FormHelpers::Index) { })
 
-    form.to_s.should contain <<-HTML
+    form.should contain <<-HTML
     <form action="/form_helpers" method="get"><input type="hidden" name="#{Lucky::ProtectFromForgery::PARAM_KEY}" value="my_token"></form>
     HTML
   end
@@ -93,5 +95,7 @@ private def without_csrf_protection
 end
 
 private def view(context : HTTP::Server::Context = build_context)
-  TestPage.new(context)
+  TestPage.new(context).tap do |page|
+    yield page
+  end.view.to_s
 end

--- a/spec/lucky/input_helpers_spec.cr
+++ b/spec/lucky/input_helpers_spec.cr
@@ -55,11 +55,11 @@ end
 
 describe Lucky::InputHelpers do
   it "renders submit input" do
-    view.submit("Save").to_s.should contain <<-HTML
+    view(&.submit("Save")).should contain <<-HTML
     <input type="submit" value="Save">
     HTML
 
-    view.submit("Save", class: "cool").to_s.should contain <<-HTML
+    view(&.submit("Save", class: "cool")).should contain <<-HTML
     <input type="submit" value="Save" class="cool">
     HTML
   end
@@ -67,221 +67,221 @@ describe Lucky::InputHelpers do
   describe "checkbox inputs" do
     it "works for non-booleans" do
       checked_field = form.eula("yes")
-      view.checkbox(checked_field, checked_value: "yes", unchecked_value: "no").to_s.should contain <<-HTML
+      view(&.checkbox(checked_field, checked_value: "yes", unchecked_value: "no")).should contain <<-HTML
       <input type="checkbox" id="user_eula" name="user:eula" value="yes" checked="true">
       HTML
-      view.checkbox(checked_field, checked_value: "yes", unchecked_value: "no").to_s.should contain <<-HTML
+      view(&.checkbox(checked_field, checked_value: "yes", unchecked_value: "no")).should contain <<-HTML
       <input type="hidden" id="" name="user:eula" value="no">
       HTML
 
       checked_field = form.eula("no")
-      view.checkbox(checked_field, checked_value: "yes", unchecked_value: "no").to_s.should contain <<-HTML
+      view(&.checkbox(checked_field, checked_value: "yes", unchecked_value: "no")).should contain <<-HTML
       <input type="checkbox" id="user_eula" name="user:eula" value="yes">
       HTML
-      view.checkbox(checked_field, checked_value: "yes", unchecked_value: "no").to_s.should contain <<-HTML
+      view(&.checkbox(checked_field, checked_value: "yes", unchecked_value: "no")).should contain <<-HTML
       <input type="hidden" id="" name="user:eula" value="no">
       HTML
     end
 
     it "sets checked and unchecked values for booleans automatically" do
       false_field = form.admin(false)
-      view.checkbox(false_field).to_s.should contain <<-HTML
+      view(&.checkbox(false_field)).should contain <<-HTML
       <input type="checkbox" id="user_admin" name="user:admin" value="true">
       HTML
-      view.checkbox(false_field).to_s.should contain <<-HTML
+      view(&.checkbox(false_field)).should contain <<-HTML
       <input type="hidden" id="" name="user:admin" value="false">
       HTML
-      view.checkbox(false_field, attrs: [:checked]).to_s.should contain <<-HTML
+      view(&.checkbox(false_field, attrs: [:checked])).should contain <<-HTML
       <input type="checkbox" id="user_admin" name="user:admin" value="true" checked>
       HTML
 
       true_field = form.admin(true)
-      view.checkbox(true_field).to_s.should contain <<-HTML
+      view(&.checkbox(true_field)).should contain <<-HTML
       <input type="checkbox" id="user_admin" name="user:admin" value="true" checked="true">
       HTML
-      view.checkbox(true_field).to_s.should contain <<-HTML
+      view(&.checkbox(true_field)).should contain <<-HTML
       <input type="hidden" id="" name="user:admin" value="false">
       HTML
-      view.checkbox(true_field, attrs: [:required]).to_s.should contain <<-HTML
+      view(&.checkbox(true_field, attrs: [:required])).should contain <<-HTML
       <input type="checkbox" id="user_admin" name="user:admin" value="true" checked="true" required>
       HTML
     end
   end
 
   it "renders text inputs" do
-    view.text_input(form.first_name).to_s.should contain <<-HTML
+    view(&.text_input(form.first_name)).should contain <<-HTML
     <input type="text" id="user_first_name" name="user:first_name" value="My name">
     HTML
 
-    view.text_input(form.first_name, class: "cool").to_s.should contain <<-HTML
+    view(&.text_input(form.first_name, class: "cool")).should contain <<-HTML
     <input type="text" id="user_first_name" name="user:first_name" value="My name" class="cool">
     HTML
 
-    view.text_input(form.first_name, attrs: [:required]).to_s.should contain <<-HTML
+    view(&.text_input(form.first_name, attrs: [:required])).should contain <<-HTML
     <input type="text" id="user_first_name" name="user:first_name" value="My name" required>
     HTML
   end
 
   it "renders email inputs" do
-    view.email_input(form.first_name).to_s.should contain <<-HTML
+    view(&.email_input(form.first_name)).should contain <<-HTML
     <input type="email" id="user_first_name" name="user:first_name" value="My name">
     HTML
 
-    view.email_input(form.first_name, class: "cool").to_s.should contain <<-HTML
+    view(&.email_input(form.first_name, class: "cool")).should contain <<-HTML
     <input type="email" id="user_first_name" name="user:first_name" value="My name" class="cool">
     HTML
   end
 
   it "renders file inputs" do
-    view.file_input(form.first_name).to_s.should contain <<-HTML
+    view(&.file_input(form.first_name)).should contain <<-HTML
     <input type="file" id="user_first_name" name="user:first_name" value="My name">
     HTML
 
-    view.file_input(form.first_name, class: "cool").to_s.should contain <<-HTML
+    view(&.file_input(form.first_name, class: "cool")).should contain <<-HTML
     <input type="file" id="user_first_name" name="user:first_name" value="My name" class="cool">
     HTML
   end
 
   it "renders color inputs" do
-    view.color_input(form.first_name).to_s.should contain <<-HTML
+    view(&.color_input(form.first_name)).should contain <<-HTML
     <input type="color" id="user_first_name" name="user:first_name" value="My name">
     HTML
 
-    view.color_input(form.first_name, class: "cool").to_s.should contain <<-HTML
+    view(&.color_input(form.first_name, class: "cool")).should contain <<-HTML
     <input type="color" id="user_first_name" name="user:first_name" value="My name" class="cool">
     HTML
   end
 
   it "renders hidden inputs" do
-    view.hidden_input(form.first_name).to_s.should contain <<-HTML
+    view(&.hidden_input(form.first_name)).should contain <<-HTML
     <input type="hidden" id="user_first_name" name="user:first_name" value="My name">
     HTML
 
-    view.hidden_input(form.first_name, class: "cool").to_s.should contain <<-HTML
+    view(&.hidden_input(form.first_name, class: "cool")).should contain <<-HTML
     <input type="hidden" id="user_first_name" name="user:first_name" value="My name" class="cool">
     HTML
   end
 
   it "renders number inputs" do
-    view.number_input(form.first_name).to_s.should contain <<-HTML
+    view(&.number_input(form.first_name)).should contain <<-HTML
     <input type="number" id="user_first_name" name="user:first_name" value="My name">
     HTML
 
-    view.number_input(form.first_name, class: "cool").to_s.should contain <<-HTML
+    view(&.number_input(form.first_name, class: "cool")).should contain <<-HTML
     <input type="number" id="user_first_name" name="user:first_name" value="My name" class="cool">
     HTML
   end
 
   it "renders telephone inputs" do
-    view.telephone_input(form.first_name).to_s.should contain <<-HTML
+    view(&.telephone_input(form.first_name)).should contain <<-HTML
     <input type="tel" id="user_first_name" name="user:first_name" value="My name">
     HTML
 
-    view.telephone_input(form.first_name, class: "cool").to_s.should contain <<-HTML
+    view(&.telephone_input(form.first_name, class: "cool")).should contain <<-HTML
     <input type="tel" id="user_first_name" name="user:first_name" value="My name" class="cool">
     HTML
   end
 
   it "renders url inputs" do
-    view.url_input(form.first_name).to_s.should contain <<-HTML
+    view(&.url_input(form.first_name)).should contain <<-HTML
     <input type="url" id="user_first_name" name="user:first_name" value="My name">
     HTML
 
-    view.url_input(form.first_name, class: "cool").to_s.should contain <<-HTML
+    view(&.url_input(form.first_name, class: "cool")).should contain <<-HTML
     <input type="url" id="user_first_name" name="user:first_name" value="My name" class="cool">
     HTML
   end
 
   it "renders search inputs" do
-    view.search_input(form.first_name).to_s.should contain <<-HTML
+    view(&.search_input(form.first_name)).should contain <<-HTML
     <input type="search" id="user_first_name" name="user:first_name" value="My name">
     HTML
 
-    view.search_input(form.first_name, class: "cool").to_s.should contain <<-HTML
+    view(&.search_input(form.first_name, class: "cool")).should contain <<-HTML
     <input type="search" id="user_first_name" name="user:first_name" value="My name" class="cool">
     HTML
 
-    view.search_input(form.first_name, autofocus: true).to_s.should contain <<-HTML
+    view(&.search_input(form.first_name, autofocus: true)).should contain <<-HTML
     <input type="search" id="user_first_name" name="user:first_name" value="My name" autofocus="true">
     HTML
   end
 
   it "renders password inputs" do
-    view.password_input(form.first_name).to_s.should contain <<-HTML
+    view(&.password_input(form.first_name)).should contain <<-HTML
     <input type="password" id="user_first_name" name="user:first_name" value="">
     HTML
 
-    view.password_input(form.first_name, class: "cool").to_s.should contain <<-HTML
+    view(&.password_input(form.first_name, class: "cool")).should contain <<-HTML
     <input type="password" id="user_first_name" name="user:first_name" value="" class="cool">
     HTML
   end
 
   it "renders range inputs" do
-    view.range_input(form.first_name).to_s.should contain <<-HTML
+    view(&.range_input(form.first_name)).should contain <<-HTML
     <input type="range" id="user_first_name" name="user:first_name" value="My name">
     HTML
 
-    view.range_input(form.first_name, class: "cool").to_s.should contain <<-HTML
+    view(&.range_input(form.first_name, class: "cool")).should contain <<-HTML
     <input type="range" id="user_first_name" name="user:first_name" value="My name" class="cool">
     HTML
   end
 
   it "renders textareas" do
-    view.textarea(form.first_name).to_s.should contain <<-HTML
+    view(&.textarea(form.first_name)).should contain <<-HTML
     <textarea id="user_first_name" name="user:first_name">My name</textarea>
     HTML
 
-    view.textarea(form.first_name, class: "cool").to_s.should contain <<-HTML
+    view(&.textarea(form.first_name, class: "cool")).should contain <<-HTML
     <textarea id="user_first_name" name="user:first_name" class="cool">My name</textarea>
     HTML
 
-    view.textarea(form.first_name, rows: 5, cols: 15).to_s.should contain <<-HTML
+    view(&.textarea(form.first_name, rows: 5, cols: 15)).should contain <<-HTML
     <textarea id="user_first_name" name="user:first_name" rows="5" cols="15">My name</textarea>
     HTML
 
-    view.textarea(form.first_name, attrs: [:required]).to_s.should contain <<-HTML
+    view(&.textarea(form.first_name, attrs: [:required])).should contain <<-HTML
     <textarea id="user_first_name" name="user:first_name" required>My name</textarea>
     HTML
   end
 
   it "renders time inputs" do
-    view.time_input(form.joined_at).to_s.should contain <<-HTML
+    view(&.time_input(form.joined_at)).should contain <<-HTML
     <input type="time" id="user_joined_at" name="user:joined_at" value="10:20:30">
     HTML
 
-    view.time_input(form.joined_at, min: "09:00", max: "18:00").to_s.should contain <<-HTML
+    view(&.time_input(form.joined_at, min: "09:00", max: "18:00")).should contain <<-HTML
     <input type="time" id="user_joined_at" name="user:joined_at" value="10:20:30" min="09:00" max="18:00">
     HTML
 
-    view.time_input(form.joined_at, attrs: [:required], min: "09:00", max: "18:00").to_s.should contain <<-HTML
+    view(&.time_input(form.joined_at, attrs: [:required], min: "09:00", max: "18:00")).should contain <<-HTML
     <input type="time" id="user_joined_at" name="user:joined_at" value="10:20:30" min="09:00" max="18:00" required>
     HTML
   end
 
   it "renders date inputs" do
-    view.date_input(form.joined_at).to_s.should contain <<-HTML
+    view(&.date_input(form.joined_at)).should contain <<-HTML
     <input type="date" id="user_joined_at" name="user:joined_at" value="2016-02-15">
     HTML
 
-    view.date_input(form.joined_at, min: "2019-01-01", max: "2019-12-31").to_s.should contain <<-HTML
+    view(&.date_input(form.joined_at, min: "2019-01-01", max: "2019-12-31")).should contain <<-HTML
     <input type="date" id="user_joined_at" name="user:joined_at" value="2016-02-15" min="2019-01-01" max="2019-12-31">
     HTML
 
-    view.date_input(form.joined_at, attrs: [:required], min: "2019-01-01", max: "2019-12-31").to_s.should contain <<-HTML
+    view(&.date_input(form.joined_at, attrs: [:required], min: "2019-01-01", max: "2019-12-31")).should contain <<-HTML
     <input type="date" id="user_joined_at" name="user:joined_at" value="2016-02-15" min="2019-01-01" max="2019-12-31" required>
     HTML
   end
 
   it "renders datetime-local inputs" do
-    view.datetime_input(form.joined_at).to_s.should contain <<-HTML
+    view(&.datetime_input(form.joined_at)).should contain <<-HTML
     <input type="datetime-local" id="user_joined_at" name="user:joined_at" value="2016-02-15T10:20:30">
     HTML
 
-    view.datetime_input(form.joined_at, min: "2019-01-01T00:00:00", max: "2019-12-31T23:59:59").to_s.should contain <<-HTML
+    view(&.datetime_input(form.joined_at, min: "2019-01-01T00:00:00", max: "2019-12-31T23:59:59")).should contain <<-HTML
     <input type="datetime-local" id="user_joined_at" name="user:joined_at" value="2016-02-15T10:20:30" min="2019-01-01T00:00:00" max="2019-12-31T23:59:59">
     HTML
 
-    view.datetime_input(form.joined_at, attrs: [:required], min: "2019-01-01T00:00:00", max: "2019-12-31T23:59:59").to_s.should contain <<-HTML
+    view(&.datetime_input(form.joined_at, attrs: [:required], min: "2019-01-01T00:00:00", max: "2019-12-31T23:59:59")).should contain <<-HTML
     <input type="datetime-local" id="user_joined_at" name="user:joined_at" value="2016-02-15T10:20:30" min="2019-01-01T00:00:00" max="2019-12-31T23:59:59" required>
     HTML
   end
@@ -292,7 +292,9 @@ private def form
 end
 
 private def view
-  TestPage.new(build_context)
+  TestPage.new(build_context).tap do |page|
+    yield page
+  end.view.to_s
 end
 
 private def have_unchecked_value(value)

--- a/spec/lucky/label_helpers_spec.cr
+++ b/spec/lucky/label_helpers_spec.cr
@@ -59,32 +59,34 @@ end
 
 describe Lucky::LabelHelpers do
   it "renders a label tag" do
-    view.label_without_html_options.to_s.should contain <<-HTML
+    view(&.label_without_html_options).should contain <<-HTML
     <label for="user_first_name">First name</label>
     HTML
 
-    view.label_with_html_options.to_s.should contain <<-HTML
+    view(&.label_with_html_options).should contain <<-HTML
     <label for="user_first_name" class="best-label">First name</label>
     HTML
 
-    view.label_with_nil_text.to_s.should contain <<-HTML
+    view(&.label_with_nil_text).should contain <<-HTML
     <label for="user_first_name">First name</label>
     HTML
 
-    view.label_with_custom_text.to_s.should contain <<-HTML
+    view(&.label_with_custom_text).should contain <<-HTML
     <label for="user_first_name">My Label</label>
     HTML
 
-    view.label_with_custom_text_and_options.to_s.should contain <<-HTML
+    view(&.label_with_custom_text_and_options).should contain <<-HTML
     <label for="user_first_name" class="best-label">My Label</label>
     HTML
 
-    view.label_with_block.to_s.should contain <<-HTML
+    view(&.label_with_block).should contain <<-HTML
     <label for="user_first_name"><strong>Have a thought?</strong>Post here for others to see:</label>
     HTML
   end
 end
 
 private def view
-  TestPage.new(build_context)
+  TestPage.new(build_context).tap do |page|
+    yield page
+  end.view.to_s
 end

--- a/spec/lucky/link_helpers_spec.cr
+++ b/spec/lucky/link_helpers_spec.cr
@@ -53,63 +53,63 @@ end
 
 describe Lucky::LinkHelpers do
   it "renders a link tag" do
-    view.get_route.to_s.should contain %(<a href="/link_helpers">Test</a>)
-    view.non_get_route.to_s.should contain %(<a href="/link_helpers" data-method="post">Test</a>)
-    view
-      .non_get_route_with_options
-      .to_s
+    view(&.get_route).should contain %(<a href="/link_helpers">Test</a>)
+    view(&.non_get_route).should contain %(<a href="/link_helpers" data-method="post">Test</a>)
+    view(&.non_get_route_with_options)
       .should contain %(<a href="/link_helpers" data-method="post" something-custom="foo">Test</a>)
   end
 
   it "renders a link tag with an action" do
-    view.link("Test", to: LinkHelpers::Index).to_s.should contain <<-HTML
+    view(&.link("Test", to: LinkHelpers::Index)).should contain <<-HTML
     <a href="/link_helpers">Test</a>
     HTML
 
-    link = view.link(to: LinkHelpers::Index, class: "link") { }
+    link = view(&.link(to: LinkHelpers::Index, class: "link") { })
 
-    link.to_s.should contain <<-HTML
+    link.should contain <<-HTML
     <a href="/link_helpers" class="link"></a>
     HTML
   end
 
   it "renders a link tag with a block" do
-    view.get_route_with_block.to_s.should contain <<-HTML
+    view(&.get_route_with_block).should contain <<-HTML
     <a href="/link_helpers">Hello</a>
     HTML
   end
 
   it "renders a link tag without text" do
-    view.get_route_without_text.to_s.should contain <<-HTML
+    view(&.get_route_without_text).should contain <<-HTML
     <a href="/link_helpers"></a>
     HTML
   end
 
   it "renders a link with a special data attribute" do
-    view.link(to: LinkHelpers::Index, "data-is-useless": true).to_s.should contain <<-HTML
+    view(&.link(to: LinkHelpers::Index, "data-is-useless": true)).should contain <<-HTML
     <a href="/link_helpers" data-is-useless="true"></a>
     HTML
 
-    view.link(to: LinkHelpers::Index, "data-num": 4).to_s.should contain <<-HTML
+    view(&.link(to: LinkHelpers::Index, "data-num": 4)).should contain <<-HTML
     <a href="/link_helpers" data-num="4"></a>
     HTML
   end
 
   it "renders a link with boolean attrs" do
-    view.get_route_with_text_and_attrs.to_s.should contain <<-HTML
+    view(&.get_route_with_text_and_attrs).should contain <<-HTML
     <a href="/link_helpers" disabled>Text</a>
     HTML
 
-    view.get_route_with_attrs_no_text.to_s.should contain <<-HTML
+    view(&.get_route_with_attrs_no_text).should contain <<-HTML
     <a href="/link_helpers" disabled></a>
     HTML
 
-    view.get_route_with_block_and_attrs.to_s.should contain <<-HTML
+    view(&.get_route_with_block_and_attrs).should contain <<-HTML
     <a href="/link_helpers" disabled>Hello</a>
     HTML
   end
 end
 
 private def view
-  TestPage.new(build_context)
+  TestPage.new(build_context).tap do |page|
+    yield page
+  end.view.to_s
 end

--- a/spec/lucky/render_if_defined_spec.cr
+++ b/spec/lucky/render_if_defined_spec.cr
@@ -5,8 +5,9 @@ include ContextHelper
 abstract class LayoutWithOptionalSidebar
   include Lucky::HTMLPage
 
-  def render
+  def render : String
     render_if_defined :sidebar
+    view.to_s
   end
 end
 

--- a/spec/lucky/specialty_tags_spec.cr
+++ b/spec/lucky/specialty_tags_spec.cr
@@ -11,62 +11,64 @@ end
 
 describe Lucky::SpecialtyTags do
   it "renders doctype" do
-    view.html_doctype.to_s.should contain <<-HTML
+    view(&.html_doctype).should contain <<-HTML
     <!DOCTYPE html>
     HTML
   end
 
   it "renders css link tag" do
-    view.css_link("app.css").to_s.should eq <<-HTML
+    view(&.css_link("app.css")).should eq <<-HTML
     <link href="app.css" rel="stylesheet" media="screen">
     HTML
 
-    view.css_link("app.css", rel: "preload", media: "print").to_s.should eq <<-HTML
+    view(&.css_link("app.css", rel: "preload", media: "print")).should eq <<-HTML
     <link href="app.css" rel="preload" media="print">
     HTML
   end
 
   it "renders js link tag" do
-    view.js_link("app.js").to_s.should contain <<-HTML
+    view(&.js_link("app.js")).should contain <<-HTML
     <script src="app.js"></script>
     HTML
 
-    view.js_link("app.js", foo: "bar").to_s.should contain <<-HTML
+    view(&.js_link("app.js", foo: "bar")).should contain <<-HTML
     <script src="app.js" foo="bar"></script>
     HTML
   end
 
   it "render utf8 meta tag" do
-    view.utf8_charset.to_s.should contain <<-HTML
+    view(&.utf8_charset).should contain <<-HTML
     <meta charset="utf-8">
     HTML
   end
 
   it "renders responsive meta tag" do
-    view.responsive_meta_tag.to_s.should contain <<-HTML
+    view(&.responsive_meta_tag).should contain <<-HTML
     <meta name="viewport" content="width=device-width, initial-scale=1">
     HTML
 
-    view.responsive_meta_tag(width: 600).to_s.should contain <<-HTML
+    view(&.responsive_meta_tag(width: 600)).should contain <<-HTML
     <meta name="viewport" content="initial-scale=1, width=600">
     HTML
 
-    view.responsive_meta_tag(height: 600).to_s.should contain <<-HTML
+    view(&.responsive_meta_tag(height: 600)).should contain <<-HTML
     <meta name="viewport" content="width=device-width, initial-scale=1, height=600">
     HTML
   end
 
   it "renders proper non-breaking space entity" do
-    view.nbsp.to_s.should contain <<-HTML
+    view(&.nbsp).should contain <<-HTML
     &nbsp;
     HTML
 
-    view.nbsp(3).to_s.should contain <<-HTML
+    view(&.nbsp(3)).should contain <<-HTML
     &nbsp;&nbsp;&nbsp;
     HTML
   end
 end
 
 private def view
-  TestPage.new(build_context)
+  TestPage.new(build_context).tap do |page|
+    yield page
+  end.view.to_s
 end

--- a/spec/lucky/text_helpers/highlight_spec.cr
+++ b/spec/lucky/text_helpers/highlight_spec.cr
@@ -1,6 +1,10 @@
-require "./text_helpers_spec"
+require "../../spec_helper"
 
-class TextHelperTestPage
+include ContextHelper
+
+class HighlightTestPage
+  include Lucky::HTMLPage
+
   def test_highlight
     highlight "This is a beautiful morning, but also a beautiful day", "beautiful" { |word|
       # you can't use HTMLPage here since they append to 'view' rather than return in-place
@@ -13,42 +17,50 @@ end
 describe Lucky::TextHelpers do
   describe "highlight" do
     it "highlights" do
-      view.highlight("This is a beautiful morning", "beautiful").to_s.should eq "This is a <mark>beautiful</mark> morning"
-      view.highlight("This is a beautiful morning, but also a beautiful day", "beautiful").to_s.should eq "This is a <mark>beautiful</mark> morning, but also a <mark>beautiful</mark> day"
-      view.highlight("This is a beautiful morning, but also a beautiful day", "beautiful", highlighter: "<b>\\1</b>").to_s.should eq "This is a <b>beautiful</b> morning, but also a <b>beautiful</b> day"
-      view.highlight("This text is not changed because we supplied an empty phrase", "").to_s.should eq "This text is not changed because we supplied an empty phrase"
+      view(&.highlight("This is a beautiful morning", "beautiful")).should eq "This is a <mark>beautiful</mark> morning"
+      view(&.highlight("This is a beautiful morning, but also a beautiful day", "beautiful")).should eq "This is a <mark>beautiful</mark> morning, but also a <mark>beautiful</mark> day"
+      view(&.highlight("This is a beautiful morning, but also a beautiful day", "beautiful", highlighter: "<b>\\1</b>")).should eq "This is a <b>beautiful</b> morning, but also a <b>beautiful</b> day"
+      view(&.highlight("This text is not changed because we supplied an empty phrase", "")).should eq "This text is not changed because we supplied an empty phrase"
     end
 
     it "does not highlight empty text" do
-      view.highlight("   ", "blank text is returned verbatim").to_s.should eq "   "
+      view(&.highlight("   ", "blank text is returned verbatim")).should eq "   "
     end
 
     it "highlights with regexp" do
-      view.highlight("This is a beautiful! morning", "beautiful!").to_s.should eq "This is a <mark>beautiful!</mark> morning"
-      view.highlight("This is a beautiful! morning", "beautiful! morning").to_s.should eq "This is a <mark>beautiful! morning</mark>"
-      view.highlight("This is a beautiful? morning", "beautiful? morning").to_s.should eq "This is a <mark>beautiful? morning</mark>"
+      view(&.highlight("This is a beautiful! morning", "beautiful!")).should eq "This is a <mark>beautiful!</mark> morning"
+      view(&.highlight("This is a beautiful! morning", "beautiful! morning")).should eq "This is a <mark>beautiful! morning</mark>"
+      view(&.highlight("This is a beautiful? morning", "beautiful? morning")).should eq "This is a <mark>beautiful? morning</mark>"
     end
 
     it "highlights accepts regexp" do
-      view.highlight("This day was challenging for judge Allen and his colleagues.", /\ballen\b/i).to_s.should eq "This day was challenging for judge <mark>Allen</mark> and his colleagues."
+      view(&.highlight("This day was challenging for judge Allen and his colleagues.", /\ballen\b/i)).should eq "This day was challenging for judge <mark>Allen</mark> and his colleagues."
     end
 
     it "highlights with multiple phrases in one pass" do
-      view.highlight("wow em", %w(wow em), highlighter: "<em>\\1</em>").to_s.should eq %(<em>wow</em> <em>em</em>)
+      view(&.highlight("wow em", %w(wow em), highlighter: "<em>\\1</em>")).should eq %(<em>wow</em> <em>em</em>)
     end
 
     it "highlights with html" do
-      view.highlight("<p>This is a beautiful morning, but also a beautiful day</p>", "beautiful").to_s.should eq "<p>This is a <mark>beautiful</mark> morning, but also a <mark>beautiful</mark> day</p>"
-      view.highlight("<p>This is a <em>beautiful</em> morning, but also a beautiful day</p>", "beautiful").to_s.should eq "<p>This is a <em><mark>beautiful</mark></em> morning, but also a <mark>beautiful</mark> day</p>"
-      view.highlight("<p>This is a <em class=\"error\">beautiful</em> morning, but also a beautiful <span class=\"last\">day</span></p>", "beautiful").to_s.should eq "<p>This is a <em class=\"error\"><mark>beautiful</mark></em> morning, but also a <mark>beautiful</mark> <span class=\"last\">day</span></p>"
-      view.highlight("<p class=\"beautiful\">This is a beautiful morning, but also a beautiful day</p>", "beautiful").to_s.should eq "<p class=\"beautiful\">This is a <mark>beautiful</mark> morning, but also a <mark>beautiful</mark> day</p>"
-      view.highlight("<p>This is a beautiful <a href=\"http://example.com/beautiful\#top?what=beautiful%20morning&when=now+then\">morning</a>, but also a beautiful day</p>", "beautiful").to_s.should eq "<p>This is a <mark>beautiful</mark> <a href=\"http://example.com/beautiful\#top?what=beautiful%20morning&when=now+then\">morning</a>, but also a <mark>beautiful</mark> day</p>"
-      view.highlight("<div>abc div</div>", "div", highlighter: "<b>\\1</b>").to_s.should eq "<div>abc <b>div</b></div>"
+      view(&.highlight("<p>This is a beautiful morning, but also a beautiful day</p>", "beautiful")).should eq "<p>This is a <mark>beautiful</mark> morning, but also a <mark>beautiful</mark> day</p>"
+      view(&.highlight("<p>This is a <em>beautiful</em> morning, but also a beautiful day</p>", "beautiful")).should eq "<p>This is a <em><mark>beautiful</mark></em> morning, but also a <mark>beautiful</mark> day</p>"
+      view(&.highlight("<p>This is a <em class=\"error\">beautiful</em> morning, but also a beautiful <span class=\"last\">day</span></p>", "beautiful")).should eq "<p>This is a <em class=\"error\"><mark>beautiful</mark></em> morning, but also a <mark>beautiful</mark> <span class=\"last\">day</span></p>"
+      view(&.highlight("<p class=\"beautiful\">This is a beautiful morning, but also a beautiful day</p>", "beautiful")).should eq "<p class=\"beautiful\">This is a <mark>beautiful</mark> morning, but also a <mark>beautiful</mark> day</p>"
+      view(&.highlight("<p>This is a beautiful <a href=\"http://example.com/beautiful\#top?what=beautiful%20morning&when=now+then\">morning</a>, but also a beautiful day</p>", "beautiful")).should eq "<p>This is a <mark>beautiful</mark> <a href=\"http://example.com/beautiful\#top?what=beautiful%20morning&when=now+then\">morning</a>, but also a <mark>beautiful</mark> day</p>"
+      view(&.highlight("<div>abc div</div>", "div", highlighter: "<b>\\1</b>")).should eq "<div>abc <b>div</b></div>"
     end
 
     it "highlights with block" do
-      view.highlight("one two three", ["one", "two", "three"]) { |word| "<b>#{word}</b>" }.to_s.should eq "<b>one</b> <b>two</b> <b>three</b>"
-      view.test_highlight.to_s.should eq "This is a <span data-highlight-word=\"beautiful\" data-color=\"yellow\" data-español=\"bello\">beautiful</span> morning, but also a <span data-highlight-word=\"beautiful\" data-color=\"yellow\" data-español=\"bello\">beautiful</span> day"
+      view(&.highlight("one two three", ["one", "two", "three"]) { |word| "<b>#{word}</b>" })
+        .should eq "<b>one</b> <b>two</b> <b>three</b>"
+      view(&.test_highlight)
+        .should eq "This is a <span data-highlight-word=\"beautiful\" data-color=\"yellow\" data-español=\"bello\">beautiful</span> morning, but also a <span data-highlight-word=\"beautiful\" data-color=\"yellow\" data-español=\"bello\">beautiful</span> day"
     end
   end
+end
+
+def view
+  HighlightTestPage.new(build_context).tap do |page|
+    yield page
+  end.view.to_s
 end

--- a/spec/lucky/text_helpers/text_helpers_spec.cr
+++ b/spec/lucky/text_helpers/text_helpers_spec.cr
@@ -1,4 +1,5 @@
 require "../../spec_helper"
+
 include ContextHelper
 
 class TextHelperTestPage

--- a/spec/lucky/welcome_page_spec.cr
+++ b/spec/lucky/welcome_page_spec.cr
@@ -4,7 +4,7 @@ include ContextHelper
 
 describe Lucky::WelcomePage do
   it "compiles successfully" do
-    html = Lucky::WelcomePage.new(context: build_context).render.to_s
-    html.should contain("Welcome to Lucky")
+    Lucky::WelcomePage.new(context: build_context).tap(&.render).view.to_s
+      .should contain("Welcome to Lucky")
   end
 end

--- a/src/lucky/html_page.cr
+++ b/src/lucky/html_page.cr
@@ -7,7 +7,11 @@ module Lucky::HTMLPage
 
   macro included
     include Lucky::HTMLBuilder
-    private getter view = IO::Memory.new
+    getter view = IO::Memory.new
     needs context : HTTP::Server::Context
+  end
+
+  def to_s(io)
+    io << view
   end
 end

--- a/src/lucky/page_helpers/html_text_helpers.cr
+++ b/src/lucky/page_helpers/html_text_helpers.cr
@@ -70,7 +70,7 @@ module Lucky::HTMLTextHelpers
   # ```html
   # You're such a <strong>nice</strong> and <strong>attractive</strong> person.
   # ```
-  def highlight(text : String, phrases : Array(String | Regex), highlighter : Proc | String = "<mark>\\1</mark>")
+  def highlight(text : String, phrases : Array(String | Regex), highlighter : Proc | String = "<mark>\\1</mark>") : Nil
     if text.blank? || phrases.all?(&.to_s.blank?)
       raw (text || "")
     else
@@ -91,16 +91,16 @@ module Lucky::HTMLTextHelpers
   # Exactly the same as the `highlight` that takes multiple phrases, but with a
   # singular `phrase` argument for readability.
   # ```
-  def highlight(text : String, phrases : Array(String | Regex), &block : String -> _)
+  def highlight(text : String, phrases : Array(String | Regex), &block : String -> _) : Nil
     highlight(text, phrases, highlighter: block)
   end
 
-  def highlight(text : String, phrase : String | Regex, highlighter : Proc | String = "<mark>\\1</mark>")
+  def highlight(text : String, phrase : String | Regex, highlighter : Proc | String = "<mark>\\1</mark>") : Nil
     phrases = [phrase] of String | Regex
     highlight(text, phrases, highlighter: highlighter)
   end
 
-  def highlight(text : String, phrase : String | Regex, &block : String -> _)
+  def highlight(text : String, phrase : String | Regex, &block : String -> _) : Nil
     phrases = [phrase] of String | Regex
     highlight(text, phrases, highlighter: block)
   end

--- a/src/lucky/page_helpers/url_helpers.cr
+++ b/src/lucky/page_helpers/url_helpers.cr
@@ -27,7 +27,7 @@ module Lucky::UrlHelpers
   def current_page?(
     value : String,
     check_query_params : Bool = false
-  )
+  ) : Bool
     request = @context.request
 
     return false unless {"GET", "HEAD"}.includes?(request.method)
@@ -81,7 +81,7 @@ module Lucky::UrlHelpers
   def current_page?(
     action : Lucky::Action.class | Lucky::RouteHelper,
     check_query_params : Bool = false
-  )
+  ) : Bool
     current_page?(action.path, check_query_params)
   end
 

--- a/src/lucky/tags/base_tags.cr
+++ b/src/lucky/tags/base_tags.cr
@@ -20,26 +20,26 @@ module Lucky::BaseTags
         options = EMPTY_HTML_ATTRS,
         attrs : Array(Symbol) = [] of Symbol,
         **other_options
-      )
+      ) : Nil
       merged_options = merge_options(other_options, options)
       {{method_name.id}}(attrs, merged_options) do
         text content
       end
     end
 
-    def {{method_name.id}}(content : String | Lucky::AllowedInTags)
+    def {{method_name.id}}(content : String | Lucky::AllowedInTags) : Nil
       {{method_name.id}}(EMPTY_HTML_ATTRS) do
         text content
       end
     end
 
-    def {{method_name.id}}(&block)
+    def {{method_name.id}}(&block) : Nil
       {{method_name.id}}(EMPTY_HTML_ATTRS) do
         yield
       end
     end
 
-    def {{method_name.id}}(options = EMPTY_HTML_ATTRS, **other_options, &block)
+    def {{method_name.id}}(options = EMPTY_HTML_ATTRS, **other_options, &block) : Nil
       merged_options = merge_options(other_options, options)
       tag_attrs = build_tag_attrs(merged_options)
       view << "<{{tag.id}}" << tag_attrs << ">"
@@ -47,7 +47,7 @@ module Lucky::BaseTags
       view << "</{{tag.id}}>"
     end
 
-    def {{method_name.id}}(attrs : Array(Symbol), options = EMPTY_HTML_ATTRS, **other_options, &block)
+    def {{method_name.id}}(attrs : Array(Symbol), options = EMPTY_HTML_ATTRS, **other_options, &block) : Nil
       boolean_attrs = build_boolean_attrs(attrs)
       merged_options = merge_options(other_options, options)
       tag_attrs = build_tag_attrs(merged_options)
@@ -67,11 +67,11 @@ module Lucky::BaseTags
 
   {% for tag in EMPTY_TAGS %}
     # Generates a `&lt;{{tag.id}}&gt;` tag.
-    def {{tag.id}}
+    def {{tag.id}} : Nil
       view << %(<{{tag.id}}> )
     end
 
-    def {{tag.id}}(options = EMPTY_HTML_ATTRS, **other_options)
+    def {{tag.id}}(options = EMPTY_HTML_ATTRS, **other_options) : Nil
       {{tag.id}}([] of Symbol, options, **other_options)
     end
 
@@ -83,7 +83,7 @@ module Lucky::BaseTags
     # ```
     # {{tag.id}}([:required], {"class" => "cls-1"}) #=> <{{tag.id}} class="cls-1" required>
     # ```
-    def {{tag.id}}(attrs : Array(Symbol), options = EMPTY_HTML_ATTRS, **other_options)
+    def {{tag.id}}(attrs : Array(Symbol), options = EMPTY_HTML_ATTRS, **other_options) : Nil
       bool_attrs = build_boolean_attrs(attrs)
       merged_options = merge_options(other_options, options)
       tag_attrs = build_tag_attrs(merged_options)
@@ -97,7 +97,7 @@ module Lucky::BaseTags
   # text("Hello") # => Hello
   # text("<div>") # => &lt;div&gt;
   # ```
-  def text(content : String | Lucky::AllowedInTags)
+  def text(content : String | Lucky::AllowedInTags) : Nil
     view << HTML.escape(content.to_s)
   end
 
@@ -106,7 +106,7 @@ module Lucky::BaseTags
   # ```
   # style("a { color: red; }") # => <style>a { color: red; }</style>
   # ```
-  def style(styles : String)
+  def style(styles : String) : Nil
     view << "<style>#{styles}</style>"
   end
 

--- a/src/lucky/tags/custom_tags.cr
+++ b/src/lucky/tags/custom_tags.cr
@@ -8,7 +8,7 @@ module Lucky::CustomTags
     options = EMPTY_HTML_ATTRS,
     attrs : Array(Symbol) = [] of Symbol,
     **other_options
-  )
+  ) : Nil
     merged_options = merge_options(other_options, options)
 
     tag(name, attrs, merged_options) do
@@ -16,19 +16,19 @@ module Lucky::CustomTags
     end
   end
 
-  def tag(name : String, content : String | Lucky::AllowedInTags)
+  def tag(name : String, content : String | Lucky::AllowedInTags) : Nil
     tag(EMPTY_HTML_ATTRS) do
       text content
     end
   end
 
-  def tag(name : String, &block)
+  def tag(name : String, &block) : Nil
     tag(EMPTY_HTML_ATTRS) do
       yield
     end
   end
 
-  def tag(name : String, attrs : Array(Symbol) = [] of Symbol, options = EMPTY_HTML_ATTRS, **other_options, &block)
+  def tag(name : String, attrs : Array(Symbol) = [] of Symbol, options = EMPTY_HTML_ATTRS, **other_options, &block) : Nil
     merged_options = merge_options(other_options, options)
     tag_attrs = build_tag_attrs(merged_options)
     boolean_attrs = build_boolean_attrs(attrs)
@@ -39,7 +39,7 @@ module Lucky::CustomTags
 
   # Outputs a custom tag with no tag closing.
   # `empty_tag("br")` => `<br>`
-  def empty_tag(name : String, options = EMPTY_HTML_ATTRS, **other_options)
+  def empty_tag(name : String, options = EMPTY_HTML_ATTRS, **other_options) : Nil
     merged_options = merge_options(other_options, options)
     tag_attrs = build_tag_attrs(merged_options)
     view << "<#{name}" << tag_attrs << ">"

--- a/src/lucky/tags/forgery_protection_helpers.cr
+++ b/src/lucky/tags/forgery_protection_helpers.cr
@@ -5,7 +5,7 @@ module Lucky::ForgeryProtectionHelpers
   # `Lucky::FormHelpers#form_for`. It creates a hidden input with the CSRF
   # token. THis ensures that the form is safe. If you try to submit a form
   # without a CSRF token it will fail with a 403 forbidden status code.
-  def csrf_hidden_input
+  def csrf_hidden_input : Nil
     input type: "hidden",
       name: ProtectFromForgery::PARAM_KEY,
       value: ProtectFromForgery.get_token(@context)
@@ -16,7 +16,7 @@ module Lucky::ForgeryProtectionHelpers
   # These tags are automatically added to MainLayout when generating a new
   # project. They are used by Rails UJS to safely submit forms and non-GET AJAX
   # requests
-  def csrf_meta_tags
+  def csrf_meta_tags : Nil
     meta name: "csrf-param",
       content: ProtectFromForgery::PARAM_KEY
     meta name: "csrf-token",

--- a/src/lucky/tags/form_helpers.cr
+++ b/src/lucky/tags/form_helpers.cr
@@ -3,7 +3,7 @@ module Lucky::FormHelpers
     setting include_csrf_tag : Bool = true
   end
 
-  def form_for(route : Lucky::RouteHelper, **html_options)
+  def form_for(route : Lucky::RouteHelper, **html_options) : Nil
     form_options = {"action" => route.path, "method" => form_method(route)}
     form merge_options(html_options, form_options) do
       csrf_hidden_input if settings.include_csrf_tag
@@ -12,11 +12,11 @@ module Lucky::FormHelpers
     end
   end
 
-  def form_for(route action : Lucky::Action.class, **html_options, &block)
+  def form_for(route action : Lucky::Action.class, **html_options, &block) : Nil
     form_for action.route, **html_options, &block
   end
 
-  private def form_method(route)
+  private def form_method(route) : String
     if route.method == :get
       "get"
     else
@@ -24,7 +24,7 @@ module Lucky::FormHelpers
     end
   end
 
-  private def method_override_input(route)
+  private def method_override_input(route) : Nil
     unless [:post, :get].includes? route.method
       input type: "hidden", name: "_method", value: route.method.to_s
     end

--- a/src/lucky/tags/input_helpers.cr
+++ b/src/lucky/tags/input_helpers.cr
@@ -31,7 +31,7 @@ module Lucky::InputHelpers
     end
   end
 
-  def submit(text : String, **html_options)
+  def submit(text : String, **html_options) : Nil
     input merge_options(html_options, {"type" => "submit", "value" => text})
   end
 
@@ -43,7 +43,7 @@ module Lucky::InputHelpers
   # textarea(attribute)
   # # => <textarea id="param_key_attribute_name" name="param_key:attribute_name"></textarea>
   # ```
-  def textarea(field : Avram::PermittedAttribute, **html_options)
+  def textarea(field : Avram::PermittedAttribute, **html_options) : Nil
     textarea field, EMPTY_BOOLEAN_ATTRIBUTES, **html_options
   end
 
@@ -54,7 +54,7 @@ module Lucky::InputHelpers
   # textarea(attribute, attrs: [:required])
   # # => <textarea id="param_key_attribute_name" name="param_key:attribute_name" required></textarea>
   # ```
-  def textarea(field : Avram::PermittedAttribute, attrs : Array(Symbol), **html_options)
+  def textarea(field : Avram::PermittedAttribute, attrs : Array(Symbol), **html_options) : Nil
     textarea field.param.to_s, merge_options(html_options, {
       "id"   => input_id(field),
       "name" => input_name(field),
@@ -64,7 +64,7 @@ module Lucky::InputHelpers
   def checkbox(field : Avram::PermittedAttribute(T),
                unchecked_value : String,
                checked_value : String,
-               **html_options) forall T
+               **html_options) : Nil forall T
     if field.param == checked_value
       html_options = merge_options(html_options, {"checked" => "true"})
     end
@@ -73,11 +73,11 @@ module Lucky::InputHelpers
     generate_input(field, "checkbox", html_options)
   end
 
-  def checkbox(field : Avram::PermittedAttribute(Bool?), **html_options)
+  def checkbox(field : Avram::PermittedAttribute(Bool?), **html_options) : Nil
     checkbox field, EMPTY_BOOLEAN_ATTRIBUTES, **html_options
   end
 
-  def checkbox(field : Avram::PermittedAttribute(Bool?), attrs : Array(Symbol), **html_options)
+  def checkbox(field : Avram::PermittedAttribute(Bool?), attrs : Array(Symbol), **html_options) : Nil
     unchecked_value = "false"
     if field.value
       html_options = merge_options(html_options, {"checked" => "true"})
@@ -98,7 +98,7 @@ module Lucky::InputHelpers
     # {{input_type.id}}_input(attribute)
     # # => <input type="{{input_type.id}}" id="param_key_attribute_name" name="param_key:attribute_name" value="" />
     # ```
-    def {{input_type.id}}_input(field : Avram::PermittedAttribute, **html_options)
+    def {{input_type.id}}_input(field : Avram::PermittedAttribute, **html_options) : Nil
       {{input_type.id}}_input field, EMPTY_BOOLEAN_ATTRIBUTES, **html_options
     end
 
@@ -109,60 +109,60 @@ module Lucky::InputHelpers
     # {{input_type.id}}_input(attribute, attrs: [:required])
     # # => <input type="{{input_type.id}}" id="param_key_attribute_name" name="param_key:attribute_name" value="" required />
     # ```
-    def {{input_type.id}}_input(field : Avram::PermittedAttribute, attrs : Array(Symbol), **html_options)
+    def {{input_type.id}}_input(field : Avram::PermittedAttribute, attrs : Array(Symbol), **html_options) : Nil
       generate_input(field, {{input_type}}, html_options, attrs: attrs)
     end
   {% end %}
 
   generate_helpful_error_for telephone_input
 
-  def telephone_input(field : Avram::PermittedAttribute, **html_options)
+  def telephone_input(field : Avram::PermittedAttribute, **html_options) : Nil
     telephone_input field, EMPTY_BOOLEAN_ATTRIBUTES, **html_options
   end
 
-  def telephone_input(field : Avram::PermittedAttribute, attrs : Array(Symbol), **html_options)
+  def telephone_input(field : Avram::PermittedAttribute, attrs : Array(Symbol), **html_options) : Nil
     generate_input(field, "tel", html_options, attrs: attrs)
   end
 
   generate_helpful_error_for password_input
 
-  def password_input(field : Avram::PermittedAttribute, **html_options)
+  def password_input(field : Avram::PermittedAttribute, **html_options) : Nil
     password_input field, EMPTY_BOOLEAN_ATTRIBUTES, **html_options
   end
 
-  def password_input(field : Avram::PermittedAttribute, attrs : Array(Symbol), **html_options)
+  def password_input(field : Avram::PermittedAttribute, attrs : Array(Symbol), **html_options) : Nil
     generate_input(field, "password", html_options, {"value" => ""}, attrs)
   end
 
   generate_helpful_error_for time_input
 
-  def time_input(field : Avram::PermittedAttribute, **html_options)
+  def time_input(field : Avram::PermittedAttribute, **html_options) : Nil
     time_input field, EMPTY_BOOLEAN_ATTRIBUTES, **html_options
   end
 
-  def time_input(field : Avram::PermittedAttribute, attrs : Array(Symbol), **html_options)
+  def time_input(field : Avram::PermittedAttribute, attrs : Array(Symbol), **html_options) : Nil
     value = field.value.try(&.to_s("%H:%M:%S")) || field.param.to_s
     generate_input(field, "time", html_options, input_overrides: {"value" => value}, attrs: attrs)
   end
 
   generate_helpful_error_for date_input
 
-  def date_input(field : Avram::PermittedAttribute, **html_options)
+  def date_input(field : Avram::PermittedAttribute, **html_options) : Nil
     date_input field, EMPTY_BOOLEAN_ATTRIBUTES, **html_options
   end
 
-  def date_input(field : Avram::PermittedAttribute, attrs : Array(Symbol), **html_options)
+  def date_input(field : Avram::PermittedAttribute, attrs : Array(Symbol), **html_options) : Nil
     value = field.value.try(&.to_s("%Y-%m-%d")) || field.param.to_s
     generate_input(field, "date", html_options, input_overrides: {"value" => value}, attrs: attrs)
   end
 
   generate_helpful_error_for datetime_input
 
-  def datetime_input(field : Avram::PermittedAttribute, **html_options)
+  def datetime_input(field : Avram::PermittedAttribute, **html_options) : Nil
     datetime_input field, EMPTY_BOOLEAN_ATTRIBUTES, **html_options
   end
 
-  def datetime_input(field : Avram::PermittedAttribute, attrs : Array(Symbol), **html_options)
+  def datetime_input(field : Avram::PermittedAttribute, attrs : Array(Symbol), **html_options) : Nil
     value = field.value.try(&.to_s("%Y-%m-%dT%H:%M:%S")) || field.param.to_s
     generate_input(field, "datetime-local", html_options, input_overrides: {"value" => value}, attrs: attrs)
   end
@@ -171,7 +171,7 @@ module Lucky::InputHelpers
                              type,
                              html_options,
                              input_overrides = {} of String => String,
-                             attrs : Array(Symbol) = [] of Symbol)
+                             attrs : Array(Symbol) = [] of Symbol) : Nil
     input_options = {
       "type"  => type,
       "id"    => input_id(field),

--- a/src/lucky/tags/label_helpers.cr
+++ b/src/lucky/tags/label_helpers.cr
@@ -1,22 +1,22 @@
 module Lucky::LabelHelpers
-  def label_for(field : Avram::PermittedAttribute, text : String? = nil, **html_options)
+  def label_for(field : Avram::PermittedAttribute, text : String? = nil, **html_options) : Nil
     label(
       text || guess_label_name(field),
       merge_options(html_options, {"for" => input_id(field)})
     )
   end
 
-  def label_for(field : Avram::PermittedAttribute, **html_options)
+  def label_for(field : Avram::PermittedAttribute, **html_options) : Nil
     label(merge_options(html_options, {"for" => input_id(field)})) do
       yield
     end
   end
 
-  def label_for(field, **options)
+  def label_for(field, **options) : Nil
     Lucky::InputHelpers.error_message_for_unallowed_field
   end
 
-  def label_for(field, **options)
+  def label_for(field, **options) : Nil
     Lucky::InputHelpers.error_message_for_unallowed_field
     yield
   end

--- a/src/lucky/tags/link_helpers.cr
+++ b/src/lucky/tags/link_helpers.cr
@@ -1,29 +1,29 @@
 module Lucky::LinkHelpers
-  def link(text, to : Lucky::RouteHelper, attrs : Array(Symbol) = [] of Symbol, **html_options)
+  def link(text, to : Lucky::RouteHelper, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
     a text, merge_options(html_options, link_to_href(to)), attrs
   end
 
-  def link(text, to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options)
+  def link(text, to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
     a text, merge_options(html_options, link_to_href(to.route)), attrs
   end
 
-  def link(to : Lucky::RouteHelper, attrs : Array(Symbol) = [] of Symbol, **html_options)
+  def link(to : Lucky::RouteHelper, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
     a attrs, merge_options(html_options, link_to_href(to)) do
       yield
     end
   end
 
-  def link(to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options)
+  def link(to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
     a attrs, merge_options(html_options, link_to_href(to.route)) do
       yield
     end
   end
 
-  def link(to : Lucky::RouteHelper, attrs : Array(Symbol) = [] of Symbol, **html_options)
+  def link(to : Lucky::RouteHelper, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
     a(attrs, merge_options(html_options, link_to_href(to))) { }
   end
 
-  def link(to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options)
+  def link(to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
     a(attrs, merge_options(html_options, link_to_href(to.route))) { }
   end
 

--- a/src/lucky/tags/select_helpers.cr
+++ b/src/lucky/tags/select_helpers.cr
@@ -1,11 +1,11 @@
 module Lucky::SelectHelpers
-  def select_input(field : Avram::PermittedAttribute, **html_options)
+  def select_input(field : Avram::PermittedAttribute, **html_options) : Nil
     select_tag merge_options(html_options, {"name" => input_name(field)}) do
       yield
     end
   end
 
-  def options_for_select(field : Avram::PermittedAttribute(T), select_options : Array(Tuple(String, T)), **html_options) forall T
+  def options_for_select(field : Avram::PermittedAttribute(T), select_options : Array(Tuple(String, T)), **html_options) : Nil forall T
     select_options.each do |option_name, option_value|
       attributes = {"value" => option_value.to_s}
 

--- a/src/lucky/tags/specialty_tags.cr
+++ b/src/lucky/tags/specialty_tags.cr
@@ -1,13 +1,13 @@
 module Lucky::SpecialtyTags
   # Generates an HTML5 doctype tag.
-  def html_doctype
+  def html_doctype : Nil
     view << "<!DOCTYPE html>"
   end
 
   # Generates a link tag for a stylesheet at the path *href*.
   #
   # Additional tag attributes can be passed in keyword arguments via *options*.
-  def css_link(href, **options)
+  def css_link(href, **options) : Nil
     options = {href: href, rel: "stylesheet", media: "screen"}.merge(options)
     empty_tag "link", **options
   end
@@ -16,7 +16,7 @@ module Lucky::SpecialtyTags
   #
   # Additional tag attributes can be passed in as keyword arguments via
   # *options*.
-  def js_link(src, **options)
+  def js_link(src, **options) : Nil
     options = {src: src}.merge(options)
     tag "script", **options
   end
@@ -26,7 +26,7 @@ module Lucky::SpecialtyTags
   # It is highly encouraged to specify the character encoding as early in a
   # page's `<head>` as possible as some browsers only look at the first 1024
   # bytes to determine the encoding.
-  def utf8_charset
+  def utf8_charset : Nil
     meta charset: "utf-8"
   end
 
@@ -37,7 +37,7 @@ module Lucky::SpecialtyTags
   # as specify additional properties. Please refer to [MDN's documentation on
   # the viewport meta tag](https://developer.mozilla.org/en-US/docs/Mozilla/Mobile/Viewport_meta_tag)
   # for usage details.
-  def responsive_meta_tag(**options)
+  def responsive_meta_tag(**options) : Nil
     options = {width: "device-width", initial_scale: "1"}.merge(options)
     meta name: "viewport", content: build_viewport_properties(options)
   end
@@ -54,7 +54,7 @@ module Lucky::SpecialtyTags
   # NOTE: Should **never** be used to render unescaped user-generated data, as
   # this can leave one vulnerable to [cross-site scripting
   # attacks](https://en.wikipedia.org/wiki/Cross-site_scripting).
-  def raw(string : String)
+  def raw(string : String) : Nil
     view << string
   end
 
@@ -71,12 +71,12 @@ module Lucky::SpecialtyTags
   # link "About", to: About::Index
   # ```
   # Would generate `<a href="/">Home</a><span>&nbsp;|&nbsp;</span><a href="/about">About</a>`
-  def nbsp(how_many : Int32 = 1)
+  def nbsp(how_many : Int32 = 1) : Nil
     how_many.times { raw("&nbsp;") }
     view
   end
 
-  private def build_viewport_properties(options)
+  private def build_viewport_properties(options) : String
     String.build do |attrs|
       options.each_with_index do |key, value, index|
         attrs << ", " if index > 0


### PR DESCRIPTION
Closes #1071

This makes it clear the output should not be used. It also makes it
easier to use procs as arguments in components because
everything returns `Nil` instead of `Nil | IO::Memory`

May do some cleanup in a future PR