### PR TITLE
Prints io directly instead of converting to string

### DIFF
--- a/spec/lucky/action_rendering_spec.cr
+++ b/spec/lucky/action_rendering_spec.cr
@@ -131,7 +131,7 @@ describe Lucky::Action do
     it "render assigns" do
       response = Rendering::Index.new(build_context, params).call
 
-      response.body.should contain "Anything"
+      response.body.to_s.should contain "Anything"
       response.debug_message.to_s.should contain "Rendering::IndexPage"
     end
   end
@@ -139,12 +139,12 @@ describe Lucky::Action do
   # See issue https://github.com/luckyframework/lucky/issues/678
   it "renders page classes when prefixed with ::" do
     response = Namespaced::Rendering::Index.new(build_context, params).call
-    response.body.should contain "Anything"
+    response.body.to_s.should contain "Anything"
   end
 
   it "renders JSON" do
     response = Rendering::JSON::Index.new(build_context, params).call
-    response.body.should eq %({"name":"Paul"})
+    response.body.to_s.should eq %({"name":"Paul"})
     response.status.should eq 200
 
     status = Rendering::JSON::WithStatus.new(build_context, params).call.status
@@ -156,7 +156,7 @@ describe Lucky::Action do
 
   it "renders XML" do
     response = Rendering::Xml::Index.new(build_context, params).call
-    response.body.should eq %(<anything />)
+    response.body.to_s.should eq %(<anything />)
     response.status.should eq 200
 
     status = Rendering::Xml::WithStatus.new(build_context, params).call.status
@@ -168,7 +168,7 @@ describe Lucky::Action do
 
   it "renders head response with no body" do
     response = Rendering::HeadOnly.new(build_context, params).call
-    response.body.should eq ""
+    response.body.to_s.should eq ""
     response.status.should eq 204
 
     response = Rendering::HeadOnly::WithSymbolStatus.new(build_context, params).call
@@ -177,15 +177,15 @@ describe Lucky::Action do
 
   it "renders text" do
     response = Rendering::Text::Index.new(build_context, params).call
-    response.body.should eq "Anything"
+    response.body.to_s.should eq "Anything"
     response.status.should eq 200
 
     response = Rendering::Text::WithStatus.new(build_context, params).call
-    response.body.should eq "Anything"
+    response.body.to_s.should eq "Anything"
     response.status.should eq 201
 
     response = Rendering::Text::WithSymbolStatus.new(build_context, params).call
-    response.body.should eq "Anything"
+    response.body.to_s.should eq "Anything"
     response.status.should eq 201
   end
 

--- a/spec/lucky/action_spec.cr
+++ b/spec/lucky/action_spec.cr
@@ -213,13 +213,13 @@ describe Lucky::Action do
   describe "rendering" do
     it "renders plain text" do
       response = PlainText::Index.new(build_context, params).call
-      response.body.should eq "plain"
+      response.body.to_s.should eq "plain"
       response.content_type.should eq "text/plain"
     end
 
     it "infer the correct HTML page to render" do
       response = Tests::Index.new(build_context, params).call
-      response.body.should contain "Rendered from Tests::IndexPage"
+      response.body.to_s.should contain "Rendered from Tests::IndexPage"
       response.content_type.should eq "text/html"
     end
   end

--- a/spec/lucky/infer_page_spec.cr
+++ b/spec/lucky/infer_page_spec.cr
@@ -25,13 +25,13 @@ end
 
 describe Lucky::Action do
   it "renders fully qualified pages" do
-    body = Rendering::Foo.new(build_context, params).call.body
+    body = Rendering::Foo.new(build_context, params).call.body.to_s
 
     body.should contain "EditPage"
   end
 
   it "renders within the same namespace" do
-    body = Rendering::WithinSameNameSpace.new(build_context, params).call.body
+    body = Rendering::WithinSameNameSpace.new(build_context, params).call.body.to_s
 
     body.should contain "WithinSameNameSpace"
   end

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -80,11 +80,10 @@ module Lucky::Renderable
         {{ key }}: {{ key }},
       {% end %}
     )
-    body = view.perform_render.to_s
     Lucky::TextResponse.new(
       context,
       "text/html",
-      body,
+      view.perform_render,
       debug_message: log_message(view),
     )
   end

--- a/src/lucky/text_response.cr
+++ b/src/lucky/text_response.cr
@@ -14,7 +14,7 @@ class Lucky::TextResponse < Lucky::Response
 
   def initialize(@context : HTTP::Server::Context,
                  @content_type : String,
-                 @body : String,
+                 @body : String | IO,
                  @status : Int32? = nil,
                  @debug_message : String? = nil)
   end


### PR DESCRIPTION
Closes #507

This prints the io directly to the response, rather than making it a
string first. The bigger the response, the more helpful this will be.

Benchmarks of printing directly v. converting to String first:

```crystal
require "benchmark"

text = <<-TEXT
Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
TEXT

string_text = text * 40_000
io_text = IO::Memory.new(string_text)

Benchmark.ips do |x|
  x.report("string") do
    io = IO::Memory.new
    io.print(io_text.to_s)
  end
  x.report("io") do
    io = IO::Memory.new
    io.print(io_text)
  end
end
```

Results:

```
string 942.67  (  1.06ms) (± 1.33%)  12.7MB/op   2.78× slower
    io   2.62k (381.73µs) (± 3.52%)   8.0MB/op        fastest
```

So far medium/large HTML responses this will shave off about .6ms. Not massive, but a quick and easy win