### PR TITLE
Use all caps and BEGIN/END when mounting

### DIFF
--- a/spec/lucky/component_spec.cr
+++ b/spec/lucky/component_spec.cr
@@ -68,10 +68,10 @@ describe "components rendering" do
   it "prints a comment when configured to do so" do
     Lucky::HTMLPage.temp_config(render_component_comments: true) do
       contents = TestMountPage.new(build_context).render.to_s
-      contents.should contain("<!-- Started: ComplexTestComponent -->")
-      contents.should contain("<!-- Finished: ComplexTestComponent -->")
-      contents.should contain("<!-- Started: ComponentWithBlock -->")
-      contents.should contain("<!-- Finished: ComponentWithBlock -->")
+      contents.should contain("<!-- BEGIN: ComplexTestComponent -->")
+      contents.should contain("<!-- END: ComplexTestComponent -->")
+      contents.should contain("<!-- BEGIN: ComponentWithBlock -->")
+      contents.should contain("<!-- END: ComponentWithBlock -->")
     end
   end
 end

--- a/src/lucky/mount_component.cr
+++ b/src/lucky/mount_component.cr
@@ -36,9 +36,9 @@ module Lucky::MountComponent
 
   private def print_component_comment(component : Lucky::BaseComponent) : Nil
     if Lucky::HTMLPage.settings.render_component_comments
-      raw "<!-- Started: #{component.class.name} -->"
+      raw "<!-- BEGIN: #{component.class.name} -->"
       yield
-      raw "<!-- Finished: #{component.class.name} -->"
+      raw "<!-- END: #{component.class.name} -->"
     else
       yield
     end


### PR DESCRIPTION
We've had this feature for awhile and I really like it. Turns out GitHub does the same thing and has recently added ActionView template annotations/comments to Rails.

I much prefer the all-caps BEGIN/END because it is a bit shorter *and* it stands out more, making it easier to spot things in the HTML.

See https://github.com/rails/rails/pull/38848 for a screenshot

I'd like to also add the file path, it's nice for copy pasting straight into your editor to get to the component. It can be done separately though: https://github.com/luckyframework/lucky/issues/1089