### PR TITLE
Serialize UUIDs by default, fixes #1069

### DIFF
--- a/spec/lucky/serializer_spec.cr
+++ b/spec/lucky/serializer_spec.cr
@@ -18,6 +18,15 @@ private class TestNestedJSON < Lucky::Serializer
   end
 end
 
+private class TestUuidJSON < Lucky::Serializer
+  def initialize(@id : UUID)
+  end
+
+  def render
+    {id: @id}
+  end
+end
+
 describe Lucky::Serializer do
   describe "#to_json" do
     it "calls to_json on the render data" do
@@ -27,6 +36,11 @@ describe Lucky::Serializer do
     it "handles nested JSON classes" do
       nested = TestNestedJSON.new(user_name: "Picard")
       nested.to_json.should eq({user: {name: "Picard"}}.to_json)
+    end
+
+    it "handles UUIds without user's having to include uuid/json manually" do
+      id = UUID.new("87b3042b-9b9a-41b7-8b15-a93d3f17025e")
+      TestUuidJSON.new(id).to_json.should eq({id: id.to_s}.to_json)
     end
   end
 end

--- a/src/lucky/serializer.cr
+++ b/src/lucky/serializer.cr
@@ -1,3 +1,5 @@
+require "uuid/json"
+
 abstract class Lucky::Serializer
   def to_json(io)
     render.to_json(io)


### PR DESCRIPTION
## Purpose

See #1069.

It's actually just a matter of using the right include,
but since I had to hunt that down in the docs as well
(https://crystal-lang.org/api/0.34.0/UUID.html#new(pull:JSON::PullParser)-class-method)
I'd say it is a win for lucky to include that for the serializer
by default.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
