### PR TITLE
Raise helpful message on invalid key, fixes #426

### DIFF
--- a/spec/lucky/session_handler_spec.cr
+++ b/spec/lucky/session_handler_spec.cr
@@ -88,7 +88,3 @@ describe Lucky::SessionHandler do
     header.should contain("HttpOnly")
   end
 end
-
-private def encryptor
-  Lucky::MessageEncryptor.new(Lucky::Server.settings.secret_key_base)
-end

--- a/spec/lucky/support/message_encrypter_spec.cr
+++ b/spec/lucky/support/message_encrypter_spec.cr
@@ -1,0 +1,28 @@
+require "../../spec_helper"
+
+describe Lucky::MessageEncryptor do
+  describe "#encrypt" do
+    it "raises a helpful error if the secret_key_base is not a valid key" do
+      encryptor = Lucky::MessageEncryptor.new("definately not a valid key")
+
+      expect_raises(Lucky::MessageEncryptor::InvalidSecretKeyBase) do
+        encryptor.encrypt("anything")
+      end
+    end
+  end
+
+  describe "#decrypt" do
+    it "raises a helpful error if the secret_key_base is not a valid key" do
+      encryptor = Lucky::MessageEncryptor.new("definately not a valid key")
+      expect_raises(Lucky::MessageEncryptor::InvalidSecretKeyBase) do
+        encryptor.decrypt(irrelevant_data)
+      end
+    end
+  end
+end
+
+private def irrelevant_data
+  data = IO::Memory.new
+  data << Base64.strict_encode("irrelevant")
+  data.to_slice
+end

--- a/src/lucky/support/message_encryptor.cr
+++ b/src/lucky/support/message_encryptor.cr
@@ -30,7 +30,7 @@ module Lucky
     def encrypt(value) : Bytes
       cipher = OpenSSL::Cipher.new(@cipher_algorithm)
       cipher.encrypt
-      cipher.key = @secret
+      set_cipher_key(cipher)
 
       # Rely on OpenSSL for the initialization vector
       iv = cipher.random_iv
@@ -49,13 +49,41 @@ module Lucky
       iv = value[value.size - @block_size, @block_size]
 
       cipher.decrypt
-      cipher.key = @secret
+      set_cipher_key(cipher)
       cipher.iv = iv
 
       decrypted_data = IO::Memory.new
       decrypted_data.write cipher.update(data)
       decrypted_data.write cipher.final
       decrypted_data.to_slice
+    end
+
+    private def set_cipher_key(cipher)
+      begin
+        cipher.key = @secret
+      rescue error : ArgumentError
+        raise InvalidSecretKeyBase.new(<<-MESSAGE
+          The secret key is invalid:
+
+            #{error.message}
+
+          You can generate a new key using 'lucky gen.secret_key' in your terminal:
+
+            ▸ lucky gen.secret_key
+
+          Usually the key is set in 'config/server.cr'
+
+            Lucky::Server.configure do |settings|
+             settings.secret_key_base = "your-new-key"
+            end
+
+
+          MESSAGE
+        )
+      end
+    end
+
+    class InvalidSecretKeyBase < Exception
     end
   end
 end


### PR DESCRIPTION
## Purpose

See #426 

When setting an invalid key, an error deep from the
cookie jar and then ssl cipher is not exactly
helpful to the user. We can rescue from the
error deep down and raise a more helpful one.

## Description

The output rendered to the console as well as the error page doesn't actually look that great. If you have any ideas on how to improve that, please let me know :)

<img width="1168" alt="Bildschirmfoto 2020-04-13 um 12 31 15" src="https://user-images.githubusercontent.com/68024/79117387-47fe5d80-7d8b-11ea-98a1-b3a411b92000.png">

<img width="1011" alt="Bildschirmfoto 2020-04-13 um 12 32 01" src="https://user-images.githubusercontent.com/68024/79117398-4b91e480-7d8b-11ea-88ab-baf8d1142fba.png">

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
