### PR TITLE
Add missing Cyrstal HTTP Client methods

### DIFF
--- a/spec/lucky/base_http_client_spec.cr
+++ b/spec/lucky/base_http_client_spec.cr
@@ -85,7 +85,7 @@ describe Lucky::BaseHTTPClient do
     end
   end
 
-  {% for method in [:put, :patch, :post, :delete, :get] %}
+  {% for method in [:put, :patch, :post, :delete, :get, :options] %}
     describe "\#{{method.id}}" do
       it "sends correct request to correct uri and gives the correct response" do
         with_fake_server(path: "hello", response_body: "world") do
@@ -115,6 +115,33 @@ describe Lucky::BaseHTTPClient do
       end
     end
   {% end %}
+end
+
+describe "head" do
+  it "sends the correct request to the correct uri and gets an empty response body" do
+    with_fake_server(path: "hello", response_body: "world") do
+      response = MyClient.new.head(
+        path: "hello",
+        foo: "bar"
+      )
+
+      response.body.should eq ""
+      request = server.last_request
+      request.method.should eq("HEAD")
+      request.path.should eq "hello"
+    end
+  end
+  it "works without params" do
+    with_fake_server(path: "hello", response_body: "world") do
+      response = MyClient.new.head(path: "hello")
+
+      response.body.should eq ""
+      request = server.last_request
+      request.method.should eq("HEAD")
+      request.path.should eq "hello"
+      request.body.not_nil!.gets_to_end.should eq("{}")
+    end
+  end
 end
 
 private def with_fake_server(path : String, response_body : String)

--- a/src/lucky/base_http_client.cr
+++ b/src/lucky/base_http_client.cr
@@ -12,7 +12,7 @@ abstract class Lucky::BaseHTTPClient
     @client = HTTP::Client.new(host, port: port)
   end
 
-  {% for method in [:get, :put, :patch, :post, :exec] %}
+  {% for method in [:get, :put, :patch, :post, :exec, :delete, :options, :head] %}
     def self.{{ method.id }}(*args, **named_args)
       new.{{ method.id }}(*args, **named_args)
     end
@@ -90,7 +90,7 @@ abstract class Lucky::BaseHTTPClient
     @client.exec(method: route_helper.method.to_s.upcase, path: route_helper.path, body: params.to_json)
   end
 
-  {% for method in [:put, :patch, :post, :delete, :get] %}
+  {% for method in [:put, :patch, :post, :delete, :get, :options, :head] %}
     def {{ method.id }}(path : String, **params) : HTTP::Client::Response
       {{ method.id }}(path, params)
     end


### PR DESCRIPTION
Fixes #1063 

I updated the instance method specs to include the :options request type [here](https://github.com/luckyframework/lucky/compare/master...rnice01:missing-http-client-methods?expand=1#diff-e6b95b08ee4663a22e90491d70a0cbdaR88).

I opted to add a separate describe block for the :head requests as the response body _should_ return empty. My other thought was to change the array of symbols with the request type names to an array of hashes with the request type and expected response body. So then I could get rid of the duplication for the :head request. Thoughts on that?

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
