### PR TITLE
Start on moving to new Dexter

### DIFF
--- a/output
+++ b/output
@@ -1,0 +1,1 @@
+paulcsmith

--- a/shard.yml
+++ b/shard.yml
@@ -40,7 +40,7 @@ dependencies:
     version: ~> 0.2.0
   avram:
     github: luckyframework/avram
-    version: ~> 0.13.0
+    branch: master
   lucky_router:
     github: luckyframework/lucky_router
     version: ~> 0.2.0
@@ -55,7 +55,7 @@ dependencies:
     version: ~> 0.1.0
   dexter:
     github: luckyframework/dexter
-    version: ~> 0.1.2
+    version: ~> 0.2.0
 
 development_dependencies:
   ameba:

--- a/spec/lucky/action_pipes_spec.cr
+++ b/spec/lucky/action_pipes_spec.cr
@@ -142,7 +142,7 @@ describe Lucky::Action do
 
   describe "handles before pipes" do
     it "runs through all the pipes if no Lucky::Response is returned" do
-      with_log do |log_io|
+      Lucky::ContinuedPipeLog.dexter.temp_config do |log_io|
         response = Pipes::Index.new(build_context, params).call
 
         log = log_io.to_s
@@ -159,7 +159,7 @@ describe Lucky::Action do
     end
 
     it "halts before pipes if a Lucky::Response is returned" do
-      with_log do |log_io|
+      Lucky::Log.dexter.temp_config do |log_io|
         response = Pipes::HaltedBefore.new(build_context, params).call
 
         log = log_io.to_s
@@ -173,7 +173,7 @@ describe Lucky::Action do
     end
 
     it "halts after pipes if a Lucky::Response is returned" do
-      with_log do |log_io|
+      Lucky::Log.dexter.temp_config do |log_io|
         response = Pipes::HaltedAfter.new(build_context, params).call
 
         log = log_io.to_s
@@ -195,21 +195,6 @@ describe Lucky::Action do
       action.pipe_data[1].should eq("cat")
       action.pipe_data[2].should eq("red")
       action.pipe_data[3].should eq("yellow")
-    end
-  end
-end
-
-private def with_log
-  log_io = IO::Memory.new
-  logger = Dexter::Logger.new(
-    log_io,
-    level: Logger::Severity::DEBUG,
-    log_formatter: RawLogFormatter
-  )
-
-  Lucky.temp_config(logger: logger) do
-    Lucky::Action.temp_config(pipe_log_level: Logger::Severity::INFO) do
-      yield log_io
     end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -9,9 +9,7 @@ Spec.before_each do
   ARGV.clear
 end
 
-Lucky.configure do |settings|
-  settings.logger = Dexter::Logger.new(nil)
-end
+Log.dexter.configure(:none)
 
 Lucky::Session.configure do |settings|
   settings.key = "_app_session"

--- a/src/lucky.cr
+++ b/src/lucky.cr
@@ -21,11 +21,6 @@ require "./lucky/paginator/*"
 require "./lucky/paginator/components/*"
 
 module Lucky
-  Habitat.create do
-    setting logger : Dexter::Logger
-  end
-
-  def self.logger
-    settings.logger
-  end
+  Log              = ::Log.for("lucky")
+  ContinuedPipeLog = Log.for("continued_pipe_log")
 end

--- a/src/lucky/action_pipes.cr
+++ b/src/lucky/action_pipes.cr
@@ -162,14 +162,12 @@ module Lucky::ActionPipes
 
   # :nodoc:
   def self.log_halted_pipe(pipe_method_name : String) : Nil
-    Lucky.logger.warn({halted_by: pipe_method_name})
+    Lucky::Log.dexter.warn { {halted_by: pipe_method_name} }
   end
 
   # :nodoc:
   def self.log_continued_pipe(pipe_method_name : String) : Nil
-    Lucky::Action.settings.pipe_log_level.try do |level|
-      Lucky.logger.log(level, {ran_pipe: pipe_method_name})
-    end
+    Lucky::ContinuedPipeLog.dexter.info { {ran_pipe: pipe_method_name} }
   end
 
   # :nodoc:

--- a/src/lucky/error_handler.cr
+++ b/src/lucky/error_handler.cr
@@ -3,7 +3,6 @@ class Lucky::ErrorHandler
 
   Habitat.create do
     setting show_debug_output : Bool
-    setting logger : Dexter::Logger = Lucky.logger
   end
 
   private getter action
@@ -18,7 +17,7 @@ class Lucky::ErrorHandler
   end
 
   private def call_error_action(context : HTTP::Server::Context, error : Exception) : HTTP::Server::Context
-    settings.logger.error(exception: error.inspect_with_backtrace)
+    Lucky::Log.dexter.error { {exception: error.inspect_with_backtrace} }
     action.new(context).perform_action(error)
     context
   end

--- a/src/lucky/errors.cr
+++ b/src/lucky/errors.cr
@@ -46,7 +46,7 @@ module Lucky
 
       You can teach Lucky how to handle this header:
 
-          # Add this in config/mime_types.cr
+          #{"# Add this in config/mime_types.cr".colorize.dim}
           Lucky::MimeType.register "#{accept_header}", :custom_format
 
       Or use one of these headers Lucky knows about:

--- a/src/lucky/log_handler.cr
+++ b/src/lucky/log_handler.cr
@@ -2,6 +2,17 @@ require "colorize"
 
 class Lucky::LogHandler
   include HTTP::Handler
+  # These constants are used here and in the PrettyLogFormatter to make sure
+  # that the formatter looks for the right keys!
+  REQUEST_START_KEYS = {
+    method: "method",
+    path:   "path",
+  }
+
+  REQUEST_END_KEYS = {
+    status:   "status",
+    duration: "duration",
+  }
 
   Habitat.create do
     setting skip_if : Proc(HTTP::Server::Context, Bool)?
@@ -22,20 +33,24 @@ class Lucky::LogHandler
   end
 
   private def log_request_start(context) : Nil
-    logger.info({
-      method: context.request.method,
-      path:   context.request.resource,
-    })
+    Lucky::Log.dexter.info do
+      {
+        REQUEST_START_KEYS[:method] => context.request.method,
+        REQUEST_START_KEYS[:path]   => context.request.resource,
+      }
+    end
   end
 
   private def log_request_end(context, duration) : Nil
-    logger.info({
-      status:   context.response.status_code,
-      duration: Lucky::LoggerHelpers.elapsed_text(duration),
-    })
+    Lucky::Log.dexter.info do
+      {
+        REQUEST_END_KEYS[:status]   => context.response.status_code,
+        REQUEST_END_KEYS[:duration] => Lucky::LoggerHelpers.elapsed_text(duration),
+      }
+    end
   end
 
-  private def log_exception(context, time, e) : Nil
-    logger.error({unhandled_exception: e.inspect_with_backtrace})
+  private def log_exception(context : HTTP::Server::Context, time : Time, e : Exception) : Nil
+    Lucky::Log.error(exception: e) { "" }
   end
 end

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -159,7 +159,7 @@ module Lucky::Renderable
 
   private def log_response(response : Lucky::Response) : Nil
     response.debug_message.try do |message|
-      Lucky.logger.debug(message)
+      Lucky::Log.debug { message }
     end
   end
 

--- a/src/lucky/route_handler.cr
+++ b/src/lucky/route_handler.cr
@@ -6,7 +6,7 @@ class Lucky::RouteHandler
   def call(context)
     handler = Lucky::Router.find_action(context.request)
     if handler
-      Lucky.logger.debug({handled_by: handler.payload.to_s})
+      Lucky::Log.dexter.debug { {handled_by: handler.payload.to_s} }
       handler.payload.new(context, handler.params).perform_action
     else
       call_next(context)

--- a/src/lucky/route_not_found_handler.cr
+++ b/src/lucky/route_not_found_handler.cr
@@ -11,7 +11,7 @@ class Lucky::RouteNotFoundHandler
 
   def call(context)
     if has_fallback?(context)
-      Lucky.logger.debug(handled_by_fallback: fallback_action.name.to_s)
+      Lucky::Log.dexter.debug { {handled_by_fallback: fallback_action.name.to_s} }
       fallback_action.new(context, {} of String => String).perform_action
     else
       raise Lucky::RouteNotFoundError.new(context)


### PR DESCRIPTION
Moves everything to Dexter 0.2.0 and Crystal `Log`.

Updates PrettyLogFormatter to work with Dexter and `Log::Context`

Also updates exception formatting to be easier to parse and properly indented. Also dims non-app lines

<img width="751" alt="Screen Shot 2020-04-19 at 12 02 46 PM" src="https://user-images.githubusercontent.com/22394/79692942-014eae80-8236-11ea-9bf6-753e13fb4458.png">
<img width="757" alt="Screen Shot 2020-04-19 at 12 03 46 PM" src="https://user-images.githubusercontent.com/22394/79692943-01e74500-8236-11ea-992b-1172a4b0ec8b.png">
