### PR TITLE
Adding a new method to action classes to return permitted param declarations

### DIFF
--- a/spec/lucky/action_spec.cr
+++ b/spec/lucky/action_spec.cr
@@ -224,19 +224,19 @@ describe Lucky::Action do
     end
   end
 
-  describe ".permitted_query_params" do
+  describe ".query_param_declarations" do
     it "returns an empty array" do
-      PlainText::Index.permitted_query_params.size.should eq 0
+      PlainText::Index.query_param_declarations.size.should eq 0
     end
 
     it "returns required param declarations" do
-      RequiredParams::Index.permitted_query_params.size.should eq 1
-      RequiredParams::Index.permitted_query_params.first.should eq "required_page : Int32"
+      RequiredParams::Index.query_param_declarations.size.should eq 1
+      RequiredParams::Index.query_param_declarations.first.should eq "required_page : Int32"
     end
 
     it "returns optional param declarations" do
-      OptionalParams::Index.permitted_query_params.size.should eq 6
-      OptionalParams::Index.permitted_query_params.should contain "bool_with_false_default : Bool | ::Nil"
+      OptionalParams::Index.query_param_declarations.size.should eq 6
+      OptionalParams::Index.query_param_declarations.should contain "bool_with_false_default : Bool | ::Nil"
     end
   end
 

--- a/spec/lucky/action_spec.cr
+++ b/spec/lucky/action_spec.cr
@@ -224,6 +224,22 @@ describe Lucky::Action do
     end
   end
 
+  describe ".permitted_query_params" do
+    it "returns an empty array" do
+      PlainText::Index.permitted_query_params.size.should eq 0
+    end
+
+    it "returns required param declarations" do
+      RequiredParams::Index.permitted_query_params.size.should eq 1
+      RequiredParams::Index.permitted_query_params.first.should eq "required_page : Int32"
+    end
+
+    it "returns optional param declarations" do
+      OptionalParams::Index.permitted_query_params.size.should eq 6
+      OptionalParams::Index.permitted_query_params.should contain "bool_with_false_default : Bool | ::Nil"
+    end
+  end
+
   describe "params" do
     it "can get params" do
       action = PlainText::Index.new(build_context(path: "/?q=test"), params)

--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -276,6 +276,9 @@ module Lucky::Routable
   macro included
     PARAM_DECLARATIONS = [] of Crystal::Macros::TypeDeclaration
 
+    @@permitted_query_params : Array(String) = [] of String
+    class_getter permitted_query_params : Array(String)
+
     macro inherited
       inherit_param_declarations
     end
@@ -345,6 +348,7 @@ module Lucky::Routable
   # `/user_confirmations?token=abc123`
   macro param(type_declaration)
     {% PARAM_DECLARATIONS << type_declaration %}
+    @@permitted_query_params << "{{ type_declaration.var }} : {{ type_declaration.type }}"
 
     def {{ type_declaration.var }} : {{ type_declaration.type }}
       {% is_nilable_type = type_declaration.type.is_a?(Union) %}

--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -276,8 +276,8 @@ module Lucky::Routable
   macro included
     PARAM_DECLARATIONS = [] of Crystal::Macros::TypeDeclaration
 
-    @@permitted_query_params : Array(String) = [] of String
-    class_getter permitted_query_params : Array(String)
+    @@query_param_declarations : Array(String) = [] of String
+    class_getter query_param_declarations : Array(String)
 
     macro inherited
       inherit_param_declarations
@@ -348,7 +348,7 @@ module Lucky::Routable
   # `/user_confirmations?token=abc123`
   macro param(type_declaration)
     {% PARAM_DECLARATIONS << type_declaration %}
-    @@permitted_query_params << "{{ type_declaration.var }} : {{ type_declaration.type }}"
+    @@query_param_declarations << "{{ type_declaration.var }} : {{ type_declaration.type }}"
 
     def {{ type_declaration.var }} : {{ type_declaration.type }}
       {% is_nilable_type = type_declaration.type.is_a?(Union) %}


### PR DESCRIPTION
## Purpose
This is a precursor to #1070 

## Description
Before this PR there was no way to know what params have been defined on an Action class. Also interesting thing, calling something like `Users::Index::PARAM_DECLARATIONS` would throw an exception that `Crystal::Macros::TypeDeclaration` was undefined. I guess that constant only lives inside of macros...

Well, now we have a method called `permitted_query_params` on the class. This will be useful for adding which params are allowed in a route when running `lucky routes`. 

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
