### PR TITLE
Adding new select_prompt method to generate a blank option.

### DIFF
--- a/spec/lucky/select_helpers_spec.cr
+++ b/spec/lucky/select_helpers_spec.cr
@@ -17,6 +17,11 @@ private class TestPage
     self
   end
 
+  def render_prompt(label)
+    select_prompt(label)
+    self
+  end
+
   def html
     view
   end
@@ -52,6 +57,12 @@ describe Lucky::SelectHelpers do
       .html.to_s.should eq <<-HTML
       <option value="1" selected="true">Volvo</option><option value="3">BMW</option>
       HTML
+  end
+
+  it "renders a blank option as a prompt" do
+    view.render_prompt("Which one do you want?").html.to_s.should eq <<-HTML
+    <option value="">Which one do you want?</option>
+    HTML
   end
 end
 

--- a/src/lucky/tags/select_helpers.cr
+++ b/src/lucky/tags/select_helpers.cr
@@ -16,6 +16,12 @@ module Lucky::SelectHelpers
     end
   end
 
+  # Renders an <option> HTML tag with no value
+  # The text is set to `label`.
+  def select_prompt(label : String) : Nil
+    option(label, value: "")
+  end
+
   private def input_name(field)
     "#{field.param_key}:#{field.name}"
   end


### PR DESCRIPTION
## Purpose
Fixes #1027

## Description
This adds a new `select_prompt` method to just generate a blank option so it's clear that this is just your prompt.

```crystal
select_tag(operation.fighters) do
  select_prompt("Choose your character")
  options_for_select(operation.fighters, [{"SubZero", 1}])
end
```

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
