### PR TITLE
Adding in a new radio input helper.

### DIFF
--- a/spec/lucky/input_helpers_spec.cr
+++ b/spec/lucky/input_helpers_spec.cr
@@ -46,12 +46,12 @@ class InputTestForm
   end
 
   def status(value : String)
-      Avram::PermittedAttribute(String?).new(
-        name: :status,
-        param: nil,
-        value: value,
-        param_key: "user"
-      )
+    Avram::PermittedAttribute(String?).new(
+      name: :status,
+      param: nil,
+      value: value,
+      param_key: "user"
+    )
   end
 end
 

--- a/spec/lucky/input_helpers_spec.cr
+++ b/spec/lucky/input_helpers_spec.cr
@@ -44,6 +44,15 @@ class InputTestForm
       param_key: "user"
     )
   end
+
+  def status(value : String)
+      Avram::PermittedAttribute(String?).new(
+        name: :status,
+        param: nil,
+        value: value,
+        param_key: "user"
+      )
+  end
 end
 
 private class TestPage
@@ -104,6 +113,32 @@ describe Lucky::InputHelpers do
       HTML
       view(&.checkbox(true_field, attrs: [:required])).should contain <<-HTML
       <input type="checkbox" id="user_admin" name="user:admin" value="true" checked="true" required>
+      HTML
+    end
+  end
+
+  describe "radio inputs" do
+    it "renders radio inputs" do
+      radio_field = form.status("approved")
+
+      rendered = view { |page|
+        page.radio(radio_field, "approved")
+        page.radio(radio_field, "unapproved")
+      }
+      rendered.should contain <<-HTML
+      <input type="radio" id="user_status_approved" name="user:status" value="approved" checked="true">
+      HTML
+
+      rendered.should contain <<-HTML
+      <input type="radio" id="user_status_unapproved" name="user:status" value="unapproved">
+      HTML
+    end
+
+    it "renders radio inputs with boolean attrs" do
+      radio_field = form.status("approved")
+
+      view(&.radio(radio_field, "approved", attrs: [:required])).should contain <<-HTML
+      <input type="radio" id="user_status_approved" name="user:status" value="approved" checked="true" required>
       HTML
     end
   end

--- a/src/lucky/tags/input_helpers.cr
+++ b/src/lucky/tags/input_helpers.cr
@@ -89,6 +89,38 @@ module Lucky::InputHelpers
 
   generate_helpful_error_for checkbox
 
+  # Returns a radio input field.
+  #
+  # ```
+  # radio(attribute, "checked_value")
+  # # => <input type="radio" id="param_key_attribute_name_checked_value" name="param_key:attribute_name" value="checked_value" checked="true">
+  # ```
+  def radio(field : Avram::PermittedAttribute(String?),
+            checked_value : String,
+            **html_options) : Nil
+    radio field, checked_value, EMPTY_BOOLEAN_ATTRIBUTES, **html_options
+  end
+
+  # Similar to radio; this allows for Boolean attributes through `attrs`.
+  #
+  # ```
+  # radio(attribute, "checked_value", attrs: [:required])
+  # # => <input type="radio" id="param_key_attribute_name_checked_value" name="param_key:attribute_name" value="checked_value" checked="true" required />
+  # ```
+  def radio(field : Avram::PermittedAttribute(String?),
+            checked_value : String,
+            attrs : Array(Symbol),
+            **html_options) : Nil
+    if field.value == checked_value
+      html_options = merge_options(html_options, {"checked" => "true"})
+    end
+    overrides = {"id" => input_id(field) + "_#{checked_value}", "value" => checked_value}
+    html_options = merge_options(html_options, overrides)
+    generate_input(field, "radio", html_options, attrs: attrs)
+  end
+
+  generate_helpful_error_for radio
+
   {% for input_type in ["text", "email", "file", "color", "hidden", "number", "url", "search", "range"] %}
     generate_helpful_error_for {{input_type.id}}_input
 


### PR DESCRIPTION
## Purpose
Fixes #1023

## Description
This adds in a missing `radio` helper method

```crystal
para "What's your favorite framework?"
label_for(op.question, "Lucky")
radio(op.question, "lucky")
label_for(op.question, "Rails")
radio(op.question, "rails")
label_for(op.question, "Sails")
radio(op.question, "sails")
label_for(op.question, "Grails")
radio(op.question, "grails")
```

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
