### PR TITLE
Adding component file path to debug component comments.

### DIFF
--- a/spec/lucky/component_spec.cr
+++ b/spec/lucky/component_spec.cr
@@ -68,9 +68,9 @@ describe "components rendering" do
   it "prints a comment when configured to do so" do
     Lucky::HTMLPage.temp_config(render_component_comments: true) do
       contents = TestMountPage.new(build_context).render.to_s
-      contents.should contain("<!-- BEGIN: ComplexTestComponent -->")
+      contents.should contain("<!-- BEGIN: spec/lucky/component_spec.cr ComplexTestComponent -->")
       contents.should contain("<!-- END: ComplexTestComponent -->")
-      contents.should contain("<!-- BEGIN: ComponentWithBlock -->")
+      contents.should contain("<!-- BEGIN: spec/lucky/component_spec.cr ComponentWithBlock -->")
       contents.should contain("<!-- END: ComponentWithBlock -->")
     end
   end

--- a/spec/lucky/component_spec.cr
+++ b/spec/lucky/component_spec.cr
@@ -68,9 +68,9 @@ describe "components rendering" do
   it "prints a comment when configured to do so" do
     Lucky::HTMLPage.temp_config(render_component_comments: true) do
       contents = TestMountPage.new(build_context).render.to_s
-      contents.should contain("<!-- BEGIN: spec/lucky/component_spec.cr ComplexTestComponent -->")
+      contents.should contain("<!-- BEGIN: ComplexTestComponent spec/lucky/component_spec.cr -->")
       contents.should contain("<!-- END: ComplexTestComponent -->")
-      contents.should contain("<!-- BEGIN: spec/lucky/component_spec.cr ComponentWithBlock -->")
+      contents.should contain("<!-- BEGIN: ComponentWithBlock spec/lucky/component_spec.cr -->")
       contents.should contain("<!-- END: ComponentWithBlock -->")
     end
   end

--- a/src/lucky/base_component.cr
+++ b/src/lucky/base_component.cr
@@ -3,6 +3,14 @@ require "./html_builder"
 abstract class Lucky::BaseComponent
   include Lucky::HTMLBuilder
 
+  macro inherited
+    # Returns the relative file location to the
+    # project root. e.g. src/components/my_component.cr
+    def self.file_location
+      __FILE__.gsub("#{Dir.current}/", "")
+    end
+  end
+
   private def view : IO
     @view || raise "No view was set. Use 'mount' or call 'render_to_string'."
   end

--- a/src/lucky/mount_component.cr
+++ b/src/lucky/mount_component.cr
@@ -36,7 +36,7 @@ module Lucky::MountComponent
 
   private def print_component_comment(component : Lucky::BaseComponent) : Nil
     if Lucky::HTMLPage.settings.render_component_comments
-      raw "<!-- BEGIN: #{component.class.name} -->"
+      raw "<!-- BEGIN: #{component.class.file_location} #{component.class.name} -->"
       yield
       raw "<!-- END: #{component.class.name} -->"
     else

--- a/src/lucky/mount_component.cr
+++ b/src/lucky/mount_component.cr
@@ -36,7 +36,7 @@ module Lucky::MountComponent
 
   private def print_component_comment(component : Lucky::BaseComponent) : Nil
     if Lucky::HTMLPage.settings.render_component_comments
-      raw "<!-- BEGIN: #{component.class.file_location} #{component.class.name} -->"
+      raw "<!-- BEGIN: #{component.class.name} #{component.class.file_location} -->"
       yield
       raw "<!-- END: #{component.class.name} -->"
     else


### PR DESCRIPTION
## Purpose
Fixes #1089 
Fixes #850 

## Description
This adds a new method to components to get the file_location of that component. It also now displays that file_location in the HTML comments generated by components when you have HTMLPage render_component_comments turned on. The idea will be to help you locate components a little quicker in larger applications.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
