### PR TITLE
Return error if you try to generate a model that already exists

### DIFF
--- a/spec/tasks/gen/model_spec.cr
+++ b/spec/tasks/gen/model_spec.cr
@@ -86,4 +86,19 @@ describe Gen::Model do
       io.to_s.should contain("Model name should only contain letters")
     end
   end
+
+  it "displays an error if the model has already been generated" do
+    with_cleanup do
+      ARGV.push("User")
+
+      Gen::Migration.silence_output do
+        io = IO::Memory.new
+        Gen::Model.new.call(io)
+      end
+
+      io = IO::Memory.new
+      Gen::Model.new.call(io)
+      io.to_s.should contain("A model by the name 'User' already exists.")
+    end
+  end
 end

--- a/spec/tasks/gen/model_spec.cr
+++ b/spec/tasks/gen/model_spec.cr
@@ -98,7 +98,7 @@ describe Gen::Model do
 
       io = IO::Memory.new
       Gen::Model.new.call(io)
-      io.to_s.should contain("A model by the name 'User' already exists.")
+      io.to_s.should contain("'User' model already exists at ./src/models/user.cr")
     end
   end
 end

--- a/tasks/gen/model.cr
+++ b/tasks/gen/model.cr
@@ -61,7 +61,7 @@ class Gen::Model < LuckyCli::Task
   end
 
   private def resource_name_not_taken
-    @error = "A model by the name '#{resource_name.camelcase}' already exists."
+    @error = "'#{resource_name.camelcase}' model already exists at #{"./src/models/#{template.underscored_name}.cr"}."
     !File.exists?("./src/models/#{template.underscored_name}.cr")
   end
 

--- a/tasks/gen/model.cr
+++ b/tasks/gen/model.cr
@@ -35,7 +35,8 @@ class Gen::Model < LuckyCli::Task
     resource_name_is_present &&
       resource_name_is_camelcase &&
       resource_name_matches_format &&
-      columns_are_supported
+      columns_are_supported &&
+      resource_name_not_taken
   end
 
   private def resource_name_is_present
@@ -57,6 +58,11 @@ class Gen::Model < LuckyCli::Task
   private def columns_are_supported
     @error = unsupported_columns_error("model")
     columns_are_valid?
+  end
+
+  private def resource_name_not_taken
+    @error = "A model by the name '#{resource_name.camelcase}' already exists."
+    !File.exists?("./src/models/#{template.underscored_name}.cr")
   end
 
   private def template


### PR DESCRIPTION
## Purpose
Fixes #1008

## Description
For those sleepy late programming moments!

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
