### PR TITLE
Implementing a new UI for lucky routes 

### DIFF
--- a/tasks/routes.cr
+++ b/tasks/routes.cr
@@ -1,21 +1,58 @@
 require "lucky_cli"
 require "colorize"
-require "shell-table"
 
 class Routes < LuckyCli::Task
   summary "Show all the routes for the app"
 
   def call
-    routes = Lucky::Router.routes.map do |route|
-      [route.method.to_s.upcase, route.path.colorize.green, route.action]
+    table = String.build do |output|
+      Lucky::Router.routes.map do |route|
+        output << "#{route.method.to_s.upcase} #{route.path.colorize.green}\n"
+        output << "  Action       ▸ #{route.action}\n"
+        if has_query_params?(route.action)
+          output << "  Query params ▸ #{query_param_display(route.action)}\n"
+        end
+        output << "  Route helper ▸ #{route_helper_display(route.action)}\n"
+        output << "\n\n"
+      end
     end
 
-    table = ShellTable.new(
-      labels: ["Verb", "URI", "Action"],
-      label_color: :blue,
-      rows: routes
-    )
-
     puts table
+  end
+
+  private def has_query_params?(action : Lucky::Action.class) : Bool
+    action.query_param_declarations.any?
+  end
+
+  private def param_declaration(declaration : String) : Array(String)
+    declaration.split(" : ")
+  end
+
+  private def query_param_display(action : Lucky::Action.class) : String
+    action.query_param_declarations.map { |declaration|
+      name, type = param_declaration(declaration)
+      "#{name} : #{type.colorize.yellow}"
+    }.join(", ")
+  end
+
+  private def route_helper_display(action : Lucky::Action.class) : String
+    if has_query_params?(action)
+      first_param = action.query_param_declarations.first
+      name, type = param_declaration(first_param)
+      %{#{action}.with(#{name}: "#{example_param_by_type(type)}")}
+    else
+      "#{action}.route"
+    end
+  end
+
+  private def example_param_by_type(type : String) : String
+    case type
+    when .includes?("Int")
+      "4"
+    when .includes?("Bool")
+      "false"
+    else
+      "example"
+    end
   end
 end

--- a/tasks/routes.cr
+++ b/tasks/routes.cr
@@ -27,7 +27,7 @@ class Routes < LuckyCli::Task
     <<-TEXT.colorize.dim
 
     Routing documentation:
-    
+
       https://luckyframework.org/guides/http-and-routing/routing-and-params
     TEXT
   end

--- a/tasks/routes.cr
+++ b/tasks/routes.cr
@@ -27,6 +27,7 @@ class Routes < LuckyCli::Task
     <<-TEXT.colorize.dim
 
     Routing documentation:
+    
       https://luckyframework.org/guides/http-and-routing/routing-and-params
     TEXT
   end

--- a/tasks/routes.cr
+++ b/tasks/routes.cr
@@ -6,13 +6,12 @@ class Routes < LuckyCli::Task
 
   def call
     table = String.build do |output|
+      output << "#{print_banner_message}\n\n"
       Lucky::Router.routes.map do |route|
-        output << "#{route.method.to_s.upcase} #{route.path.colorize.green}\n"
-        output << "  Action       ▸ #{route.action}\n"
-        if has_query_params?(route.action)
-          output << "  Query params ▸ #{query_param_display(route.action)}\n"
+        output << "#{route.method.to_s.upcase} #{route.path.colorize.bold.underline} #{dim_arrow} #{route.action.colorize.green}\n"
+        route.action.query_param_declarations.each do |param|
+          output << " #{dim_arrow} #{param}\n"
         end
-        output << "  Route helper ▸ #{route_helper_display(route.action)}\n"
         output << "\n\n"
       end
     end
@@ -20,39 +19,15 @@ class Routes < LuckyCli::Task
     puts table
   end
 
-  private def has_query_params?(action : Lucky::Action.class) : Bool
-    action.query_param_declarations.any?
+  private def dim_arrow
+    "▸".colorize.dim
   end
 
-  private def param_declaration(declaration : String) : Array(String)
-    declaration.split(" : ")
-  end
+  private def print_banner_message
+    <<-TEXT.colorize.dim
 
-  private def query_param_display(action : Lucky::Action.class) : String
-    action.query_param_declarations.map { |declaration|
-      name, type = param_declaration(declaration)
-      "#{name} : #{type.colorize.yellow}"
-    }.join(", ")
-  end
-
-  private def route_helper_display(action : Lucky::Action.class) : String
-    if has_query_params?(action)
-      first_param = action.query_param_declarations.first
-      name, type = param_declaration(first_param)
-      %{#{action}.with(#{name}: "#{example_param_by_type(type)}")}
-    else
-      "#{action}.route"
-    end
-  end
-
-  private def example_param_by_type(type : String) : String
-    case type
-    when .includes?("Int")
-      "4"
-    when .includes?("Bool")
-      "false"
-    else
-      "example"
-    end
+    Routing documentation:
+      https://luckyframework.org/guides/http-and-routing/routing-and-params
+    TEXT
   end
 end


### PR DESCRIPTION
## Purpose
Fixes #1070

## Description
<img width="570" alt="Screen Shot 2020-04-29 at 2 10 20 PM" src="https://user-images.githubusercontent.com/2391/80648289-c3ffd300-8a24-11ea-8aa7-3e589ee6b6cb.png">

I wanted to keep it in the table, but on smaller screens, the table rows ended up wrapping when you had too many params (like a search form). This is a new UI that includes a bit more information. My thought is once the native task args are in place, we could add a compact flag to print these out in a smaller more concise manner if people wanted.

I open to suggestions on how to make this look really pretty. When you run `lucky routes`, your first thought should be "wow, this is amazing!". So any ideas anyone has would be awesome.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [ ] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [ ] - Lucky builds on docker with `./script/setup`
* [ ] - All builds and specs pass on docker with `./script/test`
