### PR TITLE
make cookies.delete("not_existing") not fail

### DIFF
--- a/src/lucky/cookies/cookie_jar.cr
+++ b/src/lucky/cookies/cookie_jar.cr
@@ -49,7 +49,7 @@ class Lucky::CookieJar
   end
 
   def delete(key : Key) : Nil
-    if cookie = cookies[key.to_s]
+    if cookie = cookies[key.to_s]?
       cookie.expires(1.year.ago).value("")
       set_cookies[key.to_s] = cookie
     end


### PR DESCRIPTION
make ```cookies.delete("not_existing")``` have same behaviour as ```session.delete("not_existing")```, when delete key that not exists, return nil instead of fail

## Description
Please include any relevant code samples or screen shots that may help to overview of this PR.
Link to specific lines of code, or examples if you need to.

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [ ] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [ ] - Lucky builds on docker with `./script/setup`
* [ ] - All builds and specs pass on docker with `./script/test`
