### PR TITLE
Handle Ajax form submission with Turbolinks (#133)

### DIFF
--- a/src/lucky/action.cr
+++ b/src/lucky/action.cr
@@ -22,6 +22,7 @@ abstract class Lucky::Action
   include Lucky::ParamHelpers
   include Lucky::ActionPipes
   include Lucky::Redirectable
+  include Lucky::RedirectableTurbolinksSupport
   include Lucky::VerifyAcceptsFormat
 
   # Must be defined here instead of in Renderable

--- a/src/lucky/redirectable.cr
+++ b/src/lucky/redirectable.cr
@@ -60,14 +60,34 @@ module Lucky::Redirectable
   # ```
   # Note: It's recommended to use the method above that accepts a human friendly version of the status
   def redirect(to path : String, status : Int32 = 302) : Lucky::TextResponse
-    context.response.headers.add "Location", path
-    context.response.headers.add "Turbolinks-Location", path
-    context.response.status_code = status
-    Lucky::TextResponse.new(context, "", "")
+    if request.headers["X-Requested-With"]?.try(&.downcase) == "xmlhttprequest" && request.method != "GET"
+      context.response.headers.add "Location", path
+
+      # do not enable form disabled elements for XHR redirects, see https://github.com/rails/rails/pull/31441
+      context.response.headers.add "X-Xhr-Redirect", path
+
+      Lucky::TextResponse.new(context,
+        "text/javascript",
+        %[Turbolinks.clearCache();\nTurbolinks.visit(#{path.to_json}, {"action": "replace"})],
+        status: 200)
+    else
+      if request.headers["Turbolinks-Referrer"]?
+        store_turbolinks_location_in_session(path)
+      end
+      # ordinary redirect
+      context.response.headers.add "Location", path
+      context.response.status_code = status
+      Lucky::TextResponse.new(context, "", "")
+    end
   end
 
   # :nodoc:
   def redirect(to page_instead_of_action : Lucky::HTMLPage.class, **unused_args)
     {% raise "You accidentally redirected to a Lucky::HTMLPage instead of a Lucky::Action" %}
+  end
+
+  private def store_turbolinks_location_in_session(path : String)
+    cookies.set(:_turbolinks_location, path).http_only(true)
+    # this cookie read at Lucky::RedirectableTurbolinksSupport
   end
 end

--- a/src/lucky/redirectable_turbolinks_support.cr
+++ b/src/lucky/redirectable_turbolinks_support.cr
@@ -1,0 +1,19 @@
+# Set "Turbolinks-Location" from session
+# Needs to change browser address bar at last request, see https://github.com/turbolinks/turbolinks#following-redirects
+#
+# This pipe extracted Lucky::Redirectable, because Lucky::Redirectable included to Lucky::ErrorAction
+# but Lucky::ErrorAction not have pipe support
+module Lucky::RedirectableTurbolinksSupport
+  macro included
+    before set_turbolinks_location_header_from_session
+  end
+
+  private def set_turbolinks_location_header_from_session
+    if turbolinks_location = cookies.get?(:_turbolinks_location)
+      cookies.delete(:_turbolinks_location)
+      # change browser address bar at last request, see https://github.com/turbolinks/turbolinks#following-redirects
+      response.headers["Turbolinks-Location"] = turbolinks_location
+    end
+    continue
+  end
+end


### PR DESCRIPTION
Implements https://github.com/luckyframework/lucky/issues/133

* Handle Ajax form submission with Turbolinks (#133)
* Handle Turbolinks-Location header in [correct way](https://github.com/turbolinks/turbolinks#following-redirects)

Tested on demo app.

## Checklist
* [ x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [ x] - All specs are formatted with `crystal tool format spec src`
* [ x] - Inline documentation has been added and/or updated
* [ x] - Lucky builds on docker with `./script/setup`
* [ x] - All builds and specs pass on docker with `./script/test`