### PR TITLE
Change ajax? helper to check only XMLHttpRequest presence

### DIFF
--- a/spec/lucky/mime_type_spec.cr
+++ b/spec/lucky/mime_type_spec.cr
@@ -4,7 +4,7 @@ include ContextHelper
 
 describe Lucky::MimeType do
   describe "determine_clients_desired_format" do
-    it "returns the format for the 'Accept' header if it is an AJAX request" do
+    it "returns the format for the 'Accept' header" do
       format = determine_format("accept": "application/json", "X-Requested-With": "XmlHttpRequest")
       format.should eq(:json)
     end
@@ -24,12 +24,7 @@ describe Lucky::MimeType do
       format.should eq(:csv)
     end
 
-    it "returns :ajax if it is an AJAX request and no 'Accept' header is given" do
-      format = determine_format("X-Requested-With": "XmlHttpRequest")
-      format.should eq(:ajax)
-    end
-
-    describe "when the 'Accept' header is the default browser header, and it is not an AJAX request" do
+    describe "when the 'Accept' header is the default browser header" do
       it "returns :html if :html is an accepted format" do
         default_browser_header = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
         format = determine_format(default_format: :csv, headers: {"accept": default_browser_header}, accepted_formats: [:html, :csv])
@@ -43,7 +38,7 @@ describe Lucky::MimeType do
       end
     end
 
-    it "falls back to 'default_format' if no accept header and not AJAX" do
+    it "falls back to 'default_format' if no accept header" do
       format = determine_format(default_format: :csv)
       format.should eq(:csv)
     end

--- a/spec/lucky/request_type_helper_spec.cr
+++ b/spec/lucky/request_type_helper_spec.cr
@@ -49,11 +49,6 @@ describe Lucky::RequestTypeHelpers do
     override_format :foo, &.html?.should(be_false)
   end
 
-  it "checks if client accepts AJAX" do
-    override_format :ajax, &.ajax?.should(be_true)
-    override_format :foo, &.ajax?.should(be_false)
-  end
-
   it "checks if client accepts XML" do
     override_format :xml, &.xml?.should(be_true)
     override_format :foo, &.xml?.should(be_false)
@@ -62,6 +57,14 @@ describe Lucky::RequestTypeHelpers do
   it "checks if client accepts plain text" do
     override_format :plain_text, &.plain_text?.should(be_true)
     override_format :foo, &.plain_text?.should(be_false)
+  end
+
+  it "checks if request send via AJAX" do
+    action = FakeAction.new
+    action.ajax?.should(be_false)
+
+    action.context.request.headers["X-Requested-With"] = "XMLHttpRequest"
+    action.ajax?.should(be_true)
   end
 end
 

--- a/src/lucky/mime_type.cr
+++ b/src/lucky/mime_type.cr
@@ -53,8 +53,6 @@ class Lucky::MimeType
 
       if usable_accept_header? && accept
         from_accept_header(accept)
-      elsif ajax?
-        :ajax
       elsif accepts_html? && default_accept_header_that_browsers_send?
         :html
       else
@@ -79,9 +77,7 @@ class Lucky::MimeType
     end
 
     private def usable_accept_header? : Bool
-      !!(accept_header && !default_accept_header_that_browsers_send?) ||
-        # If an Ajax request, it should still be possible to accept a different format
-        !!(accept_header && ajax?)
+      !!(accept_header && !default_accept_header_that_browsers_send?)
     end
 
     private def accept_header : String?
@@ -100,10 +96,6 @@ class Lucky::MimeType
       accept = accept_header
 
       !!accept && !!(accept =~ /,\s*\*\/\*|\*\/\*\s*,/)
-    end
-
-    private def ajax? : Bool
-      request.headers["X-Requested-With"]?.try(&.downcase) == "xmlhttprequest"
     end
   end
 end

--- a/src/lucky/redirectable.cr
+++ b/src/lucky/redirectable.cr
@@ -60,7 +60,7 @@ module Lucky::Redirectable
   # ```
   # Note: It's recommended to use the method above that accepts a human friendly version of the status
   def redirect(to path : String, status : Int32 = 302) : Lucky::TextResponse
-    if request.headers["X-Requested-With"]?.try(&.downcase) == "xmlhttprequest" && request.method != "GET"
+    if ajax? && request.method != "GET"
       context.response.headers.add "Location", path
 
       # do not enable form disabled elements for XHR redirects, see https://github.com/rails/rails/pull/31441

--- a/src/lucky/request_type_helpers.cr
+++ b/src/lucky/request_type_helpers.cr
@@ -61,13 +61,6 @@ module Lucky::RequestTypeHelpers
     accepts?(:json)
   end
 
-  # Check if the request is AJAX
-  #
-  # This tests if the `X-Requested-With` header is `XMLHttpRequest`
-  def ajax? : Bool
-    accepts?(:ajax)
-  end
-
   # Check if the request is HTML
   #
   # Browsers typically send vague Accept headers. Because of that this will return `true` when:
@@ -91,6 +84,13 @@ module Lucky::RequestTypeHelpers
   # with the optional character set per W3 RFC1341 7.1
   def plain_text? : Bool
     accepts?(:plain_text)
+  end
+
+  # Check if the request is AJAX
+  #
+  # This tests if the `X-Requested-With` header is `XMLHttpRequest`
+  def ajax? : Bool
+    request.headers["X-Requested-With"]?.try(&.downcase) == "xmlhttprequest"
   end
 
   # :nodoc:


### PR DESCRIPTION
Use ajax? in redirect helper instead of inline check

Fixes #1131

## Checklist
* [x ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [ x] - All specs are formatted with `crystal tool format spec src`
* [ x] - Inline documentation has been added and/or updated
* [ x] - Lucky builds on docker with `./script/setup`
* [ x] - All builds and specs pass on docker with `./script/test`
