### PR TITLE
Escape HTML in HTML helpers by default

### DIFF
--- a/spec/lucky/text_helpers/highlight_spec.cr
+++ b/spec/lucky/text_helpers/highlight_spec.cr
@@ -41,13 +41,17 @@ describe Lucky::TextHelpers do
       view(&.highlight("wow em", %w(wow em), highlighter: "<em>\\1</em>")).should eq %(<em>wow</em> <em>em</em>)
     end
 
-    it "highlights with html" do
-      view(&.highlight("<p>This is a beautiful morning, but also a beautiful day</p>", "beautiful")).should eq "<p>This is a <mark>beautiful</mark> morning, but also a <mark>beautiful</mark> day</p>"
-      view(&.highlight("<p>This is a <em>beautiful</em> morning, but also a beautiful day</p>", "beautiful")).should eq "<p>This is a <em><mark>beautiful</mark></em> morning, but also a <mark>beautiful</mark> day</p>"
-      view(&.highlight("<p>This is a <em class=\"error\">beautiful</em> morning, but also a beautiful <span class=\"last\">day</span></p>", "beautiful")).should eq "<p>This is a <em class=\"error\"><mark>beautiful</mark></em> morning, but also a <mark>beautiful</mark> <span class=\"last\">day</span></p>"
-      view(&.highlight("<p class=\"beautiful\">This is a beautiful morning, but also a beautiful day</p>", "beautiful")).should eq "<p class=\"beautiful\">This is a <mark>beautiful</mark> morning, but also a <mark>beautiful</mark> day</p>"
-      view(&.highlight("<p>This is a beautiful <a href=\"http://example.com/beautiful\#top?what=beautiful%20morning&when=now+then\">morning</a>, but also a beautiful day</p>", "beautiful")).should eq "<p>This is a <mark>beautiful</mark> <a href=\"http://example.com/beautiful\#top?what=beautiful%20morning&when=now+then\">morning</a>, but also a <mark>beautiful</mark> day</p>"
-      view(&.highlight("<div>abc div</div>", "div", highlighter: "<b>\\1</b>")).should eq "<div>abc <b>div</b></div>"
+    it "escapes HTML by default" do
+      view(&.highlight("<span>wow</span>", "wow")).should eq %(&lt;span&gt;<mark>wow</mark>&lt;/span&gt;)
+    end
+
+    it "allows unescaped HTML" do
+      view(&.highlight("<p>This is a beautiful morning, but also a beautiful day</p>", "beautiful", escape: false)).should eq "<p>This is a <mark>beautiful</mark> morning, but also a <mark>beautiful</mark> day</p>"
+      view(&.highlight("<p>This is a <em>beautiful</em> morning, but also a beautiful day</p>", "beautiful", escape: false)).should eq "<p>This is a <em><mark>beautiful</mark></em> morning, but also a <mark>beautiful</mark> day</p>"
+      view(&.highlight("<p>This is a <em class=\"error\">beautiful</em> morning, but also a beautiful <span class=\"last\">day</span></p>", "beautiful", escape: false)).should eq "<p>This is a <em class=\"error\"><mark>beautiful</mark></em> morning, but also a <mark>beautiful</mark> <span class=\"last\">day</span></p>"
+      view(&.highlight("<p class=\"beautiful\">This is a beautiful morning, but also a beautiful day</p>", "beautiful", escape: false)).should eq "<p class=\"beautiful\">This is a <mark>beautiful</mark> morning, but also a <mark>beautiful</mark> day</p>"
+      view(&.highlight("<p>This is a beautiful <a href=\"http://example.com/beautiful\#top?what=beautiful%20morning&when=now+then\">morning</a>, but also a beautiful day</p>", "beautiful", escape: false)).should eq "<p>This is a <mark>beautiful</mark> <a href=\"http://example.com/beautiful\#top?what=beautiful%20morning&when=now+then\">morning</a>, but also a <mark>beautiful</mark> day</p>"
+      view(&.highlight("<div>abc div</div>", "div", highlighter: "<b>\\1</b>", escape: false)).should eq "<div>abc <b>div</b></div>"
     end
 
     it "highlights with block" do

--- a/spec/lucky/text_helpers/simple_format_spec.cr
+++ b/spec/lucky/text_helpers/simple_format_spec.cr
@@ -58,11 +58,18 @@ describe Lucky::TextHelpers do
         .should eq "<div>We want to put a wrapper...</div>\n\n<div>...right there.</div>"
     end
 
-    it "simple_formats without changing the text passed" do
-      text = "<b>Ok</b><script>code!</script>"
-      text_clone = text.dup
-      view.simple_format(text)
-      text.to_s.should eq text_clone
+    it "escapes html by default" do
+      text = "<b>Ok</b>"
+
+      view.tap(&.simple_format(text)).render
+        .should eq("<p>&lt;b&gt;Ok&lt;/b&gt;</p>")
+    end
+
+    it "allows raw HTML" do
+      text = "<b>Ok</b>"
+
+      view.tap(&.simple_format(text, escape: false)).render
+        .should eq("<p><b>Ok</b></p>")
     end
 
     it "simple_formats without modifying the html options" do

--- a/spec/lucky/text_helpers/truncate_spec.cr
+++ b/spec/lucky/text_helpers/truncate_spec.cr
@@ -29,6 +29,16 @@ describe Lucky::TextHelpers do
         .should eq "Hello Wor..."
     end
 
+    it "escapes the text by default" do
+      view.tap(&.truncate("<span>escape me</span>", length: 12)).render
+        .should eq "&lt;span&gt;esc..."
+    end
+
+    it "allows leaving the text unescaped" do
+      view.tap(&.truncate("<span>leave me as-is</span>", length: 12, escape: false)).render
+        .should eq "<span>lea..."
+    end
+
     it "truncates with default length of 30" do
       str = "This is a string that will go longer then the default truncate length of 30"
       view.tap(&.truncate(str)).render.should eq str[0...27] + "..."

--- a/src/lucky/page_helpers/html_text_helpers.cr
+++ b/src/lucky/page_helpers/html_text_helpers.cr
@@ -30,7 +30,7 @@ module Lucky::HTMLTextHelpers
   # ```html
   # "Four score and se...<a href="#">Read more</a>"
   # ```
-  def truncate(text : String, length : Int32 = 30, omission : String = "...", separator : String | Nil = nil, escape : Bool = false, blk : Nil | Proc = nil) : Nil
+  def truncate(text : String, length : Int32 = 30, omission : String = "...", separator : String | Nil = nil, escape : Bool = true, blk : Nil | Proc = nil) : Nil
     content = truncate_text(text, length, omission, separator)
     raw (escape ? HTML.escape(content) : content)
     blk.call if !blk.nil? && text.size > length

--- a/src/lucky/page_helpers/html_text_helpers.cr
+++ b/src/lucky/page_helpers/html_text_helpers.cr
@@ -16,7 +16,7 @@ module Lucky::HTMLTextHelpers
   # overridden to break on word boundaries by setting the separator to a space
   # `" "`. Keep in mind this, may cause your text to be truncated before your
   # `length` value if the `length` - `omission` is before the `separator`.
-  # * `escape` (default: false) weather or not to HTML escape the truncated
+  # * `escape` (default: true) weather or not to HTML escape the truncated
   # string.
   # * `blk` (default: nil) A block to run after the text has been truncated.
   # Often used to add an action to read more text, like a "Read more" link.
@@ -149,7 +149,9 @@ module Lucky::HTMLTextHelpers
   #
   # <p>baz</p>
   # ```
-  def simple_format(text : String, **html_options) : Nil
+  def simple_format(text : String, escape : Bool = true, **html_options) : Nil
+    text = escape ? HTML.escape(text) : text
+
     simple_format(text) do |formatted_text|
       para(html_options) do
         raw formatted_text

--- a/src/lucky/page_helpers/html_text_helpers.cr
+++ b/src/lucky/page_helpers/html_text_helpers.cr
@@ -70,7 +70,9 @@ module Lucky::HTMLTextHelpers
   # ```html
   # You're such a <strong>nice</strong> and <strong>attractive</strong> person.
   # ```
-  def highlight(text : String, phrases : Array(String | Regex), highlighter : Proc | String = "<mark>\\1</mark>") : Nil
+  def highlight(text : String, phrases : Array(String | Regex), highlighter : Proc | String = "<mark>\\1</mark>", escape : Bool = true) : Nil
+    text = escape ? HTML.escape(text) : text
+
     if text.blank? || phrases.all?(&.to_s.blank?)
       raw (text || "")
     else
@@ -91,18 +93,18 @@ module Lucky::HTMLTextHelpers
   # Exactly the same as the `highlight` that takes multiple phrases, but with a
   # singular `phrase` argument for readability.
   # ```
-  def highlight(text : String, phrases : Array(String | Regex), &block : String -> _) : Nil
-    highlight(text, phrases, highlighter: block)
+  def highlight(text : String, phrases : Array(String | Regex), escape : Bool = false, &block : String -> _) : Nil
+    highlight(text, phrases, highlighter: block, escape: escape)
   end
 
-  def highlight(text : String, phrase : String | Regex, highlighter : Proc | String = "<mark>\\1</mark>") : Nil
+  def highlight(text : String, phrase : String | Regex, highlighter : Proc | String = "<mark>\\1</mark>", escape : Bool = true) : Nil
     phrases = [phrase] of String | Regex
-    highlight(text, phrases, highlighter: highlighter)
+    highlight(text, phrases, highlighter: highlighter, escape: escape)
   end
 
-  def highlight(text : String, phrase : String | Regex, &block : String -> _) : Nil
+  def highlight(text : String, phrase : String | Regex, escape : Bool = true, &block : String -> _) : Nil
     phrases = [phrase] of String | Regex
-    highlight(text, phrases, highlighter: block)
+    highlight(text, phrases, highlighter: block, escape: escape)
   end
 
   # Wraps text in whatever you'd like based on line breaks


### PR DESCRIPTION
## Purpose

Safer output

I will make a patch release with these changes. It potentially breaks apps if they relied on unescaped text, but my guess is few people are doing that and it is better safe than sorry

### Impact

Since Lucky disallows reading cookies by default: https://github.com/luckyframework/lucky_cli/blob/4ec6de7cfc00be018f328ca8b7fd509cf9118c3d/src/web_app_skeleton/config/cookies.cr.ecr#L12-L13

This issue should have minimal security impact unless users use legacy browsers that do not accept the `http_only` cookie setting.

Either way, escaping by default is a much safer way to go since it is a second layer of protection, and makes it so people can't mess up your layout with renegade HTML