### PR TITLE
Remove extra  quote from missing parameter error

### DIFF
--- a/src/lucky/errors.cr
+++ b/src/lucky/errors.cr
@@ -157,7 +157,7 @@ module Lucky
     end
 
     def message : String
-      "Missing parameter: '#{param_name}''"
+      "Missing parameter: '#{param_name}'"
     end
 
     def renderable_status : Int32


### PR DESCRIPTION
This removes the extra single quote at the end of the "Missing parameter" error.
