### PR TITLE
Faster String#squish

### DIFF
--- a/bench.cr
+++ b/bench.cr
@@ -1,21 +1,86 @@
 require "benchmark"
 
-text = <<-TEXT
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua
-TEXT
-
-string_text = text * 40_000
-io_text = IO::Memory.new(string_text)
-
-Benchmark.ips do |x|
-  x.report("string") do
-    io = IO::Memory.new
-
-    io.print(io_text.to_s)
+class String
+  # Original
+  def squish_regex : String
+    gsub(/[[:space:]]+/, " ").strip
   end
-  x.report("io") do
-    io = IO::Memory.new
 
-    io.print(io_text)
+  def squish_new : String
+    if ascii_only?
+      squish_ascii
+    else
+      squish_unicode
+    end
   end
+
+  def squish_simplified : String
+    squish_unicode
+  end
+
+  private def squish_ascii : String
+    String.build(size) do |str|
+      print_blank = false
+      each_char do |chr|
+        if chr.ascii_whitespace?
+          if print_blank
+            str << ' '
+            print_blank = false
+          end
+        else
+          print_blank = true
+          str << chr
+        end
+      end
+    end.strip
+  end
+
+  private def squish_unicode : String
+    String.build(size) do |str|
+      print_blank = false
+      each_char do |chr|
+        if chr.whitespace?
+          if print_blank
+            str << ' '
+            print_blank = false
+          end
+        else
+          print_blank = true
+          str << chr
+        end
+      end
+    end.strip
+  end
+end
+
+puts "Sanity check the return output is consistent:"
+example = " f f\u00A0\u00A0\u00A0f f \n \t \v\v \f\f 11111  a l0* あ\u00A0\u00A0\u00A0 "
+puts "String to squish " + example.inspect
+puts "regex: " + example.squish_regex.inspect
+puts "new: " + example.squish_new.inspect
+puts "simplified: " + example.squish_simplified.inspect
+
+# Original regex doesn't seem to work correctly with trailing unicode
+if example.squish_regex != example.squish_new
+  puts "WARN: regex version does not match:"
+  puts "Regex:  #{example.squish_regex.inspect}".ljust(50)
+  puts "Ours:  #{example.squish_new.inspect}".ljust(50)
+end
+
+puts
+puts "Benchmarking String#squish ..."
+puts
+example = " f f f f \n \t\r\r   11111  a l0* " * 20
+Benchmark.ips(warmup: 5, calculation: 10) do |x|
+  x.report("squish regex ascii-only whitespace (#{example.bytesize} bytes)") { example.squish_regex }
+  x.report("squish optimized ascii-only whitespace (#{example.bytesize} bytes)") { example.squish_new }
+  x.report("squish simplified ascii-only whitespace (#{example.bytesize} bytes)") { example.squish_simplified }
+end
+
+puts
+example = "あ\u00A0あ\u00A0\u00A0 \t  z  \n \r \r \t \v \f zzzz XXX  asdf    k ; ;, \u1680\u1680 " * 10
+Benchmark.ips(warmup: 5, calculation: 10) do |x|
+  x.report("squish regex w/ unicode whitespace (#{example.bytesize} bytes)") { example.squish_regex }
+  x.report("squish optimized w/ unicode whitespace (#{example.bytesize} bytes)") { example.squish_new }
+  x.report("squish simplified w/ unicode whitespace (#{example.bytesize} bytes)") { example.squish_simplified }
 end

--- a/spec/charms/string_spec.cr
+++ b/spec/charms/string_spec.cr
@@ -2,11 +2,10 @@ require "../spec_helper"
 
 describe "String charm" do
   describe "squish" do
-    it "squishes the text by removing newlines and extra whitespace" do
-      og_string = " foo   bar    \n   \t   boo"
+    it "squishes the text by removing ascii/unicode whitespace" do
+      og_string = "\u1680 \v\v\v\v\v\r\r\r\r hello foo bar\n\u00A0\t\t\u00A0\u1680\u1680   "
 
-      og_string.squish.should eq("foo bar boo")
-      og_string.should eq(" foo   bar    \n   \t   boo")
+      og_string.squish.should eq("hello foo bar")
     end
   end
 end

--- a/spec/charms/string_spec.cr
+++ b/spec/charms/string_spec.cr
@@ -2,6 +2,13 @@ require "../spec_helper"
 
 describe "String charm" do
   describe "squish" do
+    it "squishes the text by removing newlines and extra whitespace" do
+      og_string = " foo   bar    \n   \t   boo"
+
+      og_string.squish.should eq("foo bar boo")
+      og_string.should eq(" foo   bar    \n   \t   boo")
+    end
+
     it "squishes the text by removing ascii/unicode whitespace" do
       og_string = "\u1680 \v\v\v\v\v\r\r\r\r hello foo bar\n\u00A0\t\t\u00A0\u1680\u1680   "
 

--- a/src/charms/string_extensions.cr
+++ b/src/charms/string_extensions.cr
@@ -10,6 +10,45 @@ class String
   # replace newlines with a single space and convert mutiple spaces to just one
   # space.
   def squish : String
-    gsub(/[[:space:]]+/, " ").strip
+    if ascii_only?
+      squish_ascii
+    else
+      squish_unicode
+    end
+  end
+
+  # Optimized for ASCII using String#ascii_whitespace?
+  private def squish_ascii : String
+    String.build(size) do |str|
+      print_blank = false
+      each_char do |chr|
+        if chr.ascii_whitespace?
+          if print_blank
+            str << ' '
+            print_blank = false
+          end
+        else
+          print_blank = true
+          str << chr
+        end
+      end
+    end.strip
+  end
+
+  private def squish_unicode : String
+    String.build(size) do |str|
+      print_blank = false
+      each_char do |chr|
+        if chr.whitespace?
+          if print_blank
+            str << ' '
+            print_blank = false
+          end
+        else
+          print_blank = true
+          str << chr
+        end
+      end
+    end.strip
   end
 end


### PR DESCRIPTION
## Purpose
Resolves #1157 

## Description
Optimizes String#squish for both ascii and unicode text. There is some unavoidable (I think) duplication to optimize the ascii-only case. The change could be simplified to only use `Char#whitespace?` (which works for both ascii and unicode) but it's slower for ascii-only strings. However, it's still significantly faster than using a regular expression.

I replaced bench.cr with my benchmark per @jwoertink 's comment in the Github issue. It shows the difference using the ascii-only optimization (Char#ascii_whitespace? vs Char#whitespace?). Here are the results from my machine (2014 macbook):

```
     squish regex ascii-only whitespace (600 bytes)  42.17k ( 23.71µs) (± 1.57%)  5.92kB/op   8.97× slower
 squish optimized ascii-only whitespace (600 bytes) 378.22k (  2.64µs) (± 0.54%)  1.19kB/op        fastest
squish simplified ascii-only whitespace (600 bytes) 277.88k (  3.60µs) (± 1.24%)  1.19kB/op   1.36× slower

     squish regex w/ unicode whitespace (630 bytes)  63.52k ( 15.74µs) (± 0.95%)  4.48kB/op   3.39× slower
 squish optimized w/ unicode whitespace (630 bytes) 214.08k (  4.67µs) (± 1.42%)  1.41kB/op   1.01× slower
squish simplified w/ unicode whitespace (630 bytes) 215.32k (  4.64µs) (± 0.69%)  1.41kB/op        fastest
```
Lastly, there appears to be a unintended bugfix for consecutive unicode whitespace. The original regex doesn't appear to match them (libpcre issue?). The benchmark will show the difference if you run it locally.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
