### PR TITLE
Add redirect_back functionality

### DIFF
--- a/spec/lucky/action_redirect_spec.cr
+++ b/spec/lucky/action_redirect_spec.cr
@@ -37,6 +37,30 @@ describe Lucky::Action do
     should_redirect(action, to: "/somewhere", status: 301)
   end
 
+  it "redirects back" do
+    request = build_request("POST")
+    request.headers["Referer"] = "https://www.example.com/coming/from"
+    action = RedirectAction.new(build_context(request), params)
+    action.redirect_back fallback: "/fallback"
+    should_redirect(action, to: "https://www.example.com/coming/from", status: 302)
+
+    action = RedirectAction.new(build_context, params)
+    action.redirect_back fallback: "/fallback"
+    should_redirect(action, to: "/fallback", status: 302)
+
+    action = RedirectAction.new(build_context, params)
+    action.redirect_back fallback: RedirectAction.route
+    should_redirect(action, to: RedirectAction.path, status: 302)
+
+    action = RedirectAction.new(build_context, params)
+    action.redirect_back fallback: RedirectAction
+    should_redirect(action, to: RedirectAction.path, status: 302)
+
+    action = RedirectAction.new(build_context, params)
+    action.redirect_back fallback: RedirectAction, status: 301
+    should_redirect(action, to: RedirectAction.path, status: 301)
+  end
+
   it "turbolinks redirects after a XHR POST form submission" do
     request = build_request("POST")
     request.headers["Accept"] = "text/javascript, application/javascript, application/ecmascript, application/x-ecmascript, */*; q=0.01"

--- a/spec/lucky/action_redirect_spec.cr
+++ b/spec/lucky/action_redirect_spec.cr
@@ -57,6 +57,10 @@ describe Lucky::Action do
     should_redirect(action, to: RedirectAction.path, status: 302)
 
     action = RedirectAction.new(build_context, params)
+    action.redirect_back fallback: RedirectAction, status: HTTP::Status::MOVED_PERMANENTLY
+    should_redirect(action, to: RedirectAction.path, status: 301)
+
+    action = RedirectAction.new(build_context, params)
     action.redirect_back fallback: RedirectAction, status: 301
     should_redirect(action, to: RedirectAction.path, status: 301)
   end

--- a/src/lucky/redirectable.cr
+++ b/src/lucky/redirectable.cr
@@ -24,6 +24,46 @@
 # method that takes a `String`. However, it's recommended you pass a
 # `Lucky::Action` class if possible because it guarantees runtime safety.
 module Lucky::Redirectable
+  # Redirect back with a `Lucky::Action` fallback
+  #
+  # ```crystal
+  # redirect_back fallback: Users::Index
+  # ```
+  def redirect_back(fallback : Lucky::Action.class, status = 302)
+    redirect_back fallback.route, status
+  end
+
+  # Redirect back with a `Lucky::RouteHelper` fallback
+  #
+  # ```crystal
+  # redirect_back fallback: Users::Show.with(user.id)
+  # ```
+  def redirect_back(fallback : Lucky::RouteHelper, status = 302)
+    redirect_back fallback.path, status
+  end
+
+  # Redirects the browser to the page that issued the request (the referrer)
+  # if possible, otherwise redirects to the provided default fallback
+  # location.
+  #
+  # The referrer information is pulled from the 'Referer' header on
+  # the request. This is an optional header, and if the request
+  # is missing this header the *fallback* will be used.
+  #
+  # ```crystal
+  # redirect_back fallback: "/users"
+  # ```
+  #
+  # A redirect status can be specified
+  #
+  # ```crystal
+  # redirect_back fallback: "/home", status: 301
+  # ```
+  def redirect_back(fallback : String, status = 302)
+    referer = request.headers["Referer"]?
+    redirect to: (referer || fallback), status: status
+  end
+
   # Redirect using a `Lucky::RouteHelper`
   #
   # ```crystal

--- a/src/lucky/redirectable.cr
+++ b/src/lucky/redirectable.cr
@@ -29,8 +29,8 @@ module Lucky::Redirectable
   # ```crystal
   # redirect_back fallback: Users::Index
   # ```
-  def redirect_back(fallback : Lucky::Action.class, status = 302)
-    redirect_back fallback.route, status
+  def redirect_back(*, fallback : Lucky::Action.class, status = 302)
+    redirect_back fallback: fallback.route, status: status
   end
 
   # Redirect back with a `Lucky::RouteHelper` fallback
@@ -38,8 +38,8 @@ module Lucky::Redirectable
   # ```crystal
   # redirect_back fallback: Users::Show.with(user.id)
   # ```
-  def redirect_back(fallback : Lucky::RouteHelper, status = 302)
-    redirect_back fallback.path, status
+  def redirect_back(*, fallback : Lucky::RouteHelper, status = 302)
+    redirect_back fallback: fallback.path, status: status
   end
 
   # Redirect back with a human friendly status
@@ -47,8 +47,8 @@ module Lucky::Redirectable
   # ```crystal
   # redirect_back fallback: "/users", status: HTTP::Status::MOVED_PERMANENTLY
   # ```
-  def redirect_back(fallback : String, status : HTTP::Status)
-    redirect_back fallback, status.value
+  def redirect_back(*, fallback : String, status : HTTP::Status)
+    redirect_back fallback: fallback, status: status.value
   end
 
   # Redirects the browser to the page that issued the request (the referrer)
@@ -68,7 +68,7 @@ module Lucky::Redirectable
   # ```crystal
   # redirect_back fallback: "/home", status: 301
   # ```
-  def redirect_back(fallback : String, status : Int32 = 302)
+  def redirect_back(*, fallback : String, status : Int32 = 302)
     referer = request.headers["Referer"]?
     redirect to: (referer || fallback), status: status
   end

--- a/src/lucky/redirectable.cr
+++ b/src/lucky/redirectable.cr
@@ -42,6 +42,15 @@ module Lucky::Redirectable
     redirect_back fallback.path, status
   end
 
+  # Redirect back with a human friendly status
+  #
+  # ```crystal
+  # redirect_back fallback: "/users", status: HTTP::Status::MOVED_PERMANENTLY
+  # ```
+  def redirect_back(fallback : String, status : HTTP::Status)
+    redirect_back fallback, status.value
+  end
+
   # Redirects the browser to the page that issued the request (the referrer)
   # if possible, otherwise redirects to the provided default fallback
   # location.
@@ -59,7 +68,7 @@ module Lucky::Redirectable
   # ```crystal
   # redirect_back fallback: "/home", status: 301
   # ```
-  def redirect_back(fallback : String, status = 302)
+  def redirect_back(fallback : String, status : Int32 = 302)
     referer = request.headers["Referer"]?
     redirect to: (referer || fallback), status: status
   end


### PR DESCRIPTION
## Purpose

Fixes #1158 

`redirect_back` allows an action to send the user back to where they made the request from. This is really useful in situations like submitting a lead form where the app might have it in several locations but the app doesn't need to take them anywhere in particular after they submit it. Rather than sending the user to a specific place after submitting the form, we can now send them back to where they originally submitted it.

This was largely taken from Rails. [source](https://github.com/rails/rails/blob/97c3a5605bacd62e5a01872dfe5e5976cd982115/actionpack/lib/action_controller/metal/redirecting.rb#L90)

### Sidenote

If you look at the Rails code, there is functionality around limiting Referer redirects in some situations using the `allow_other_hosts` named argument. If it is set to `false` then it will not redirect to a Referer header that has a different host than the request host. So, if the app is running at `example.com`, it will not redirect to a Referer header of `differenturl.com` when set to false. While this might be useful, I didn't want to copy it over just to copy it.

## Description

Usage looks like:
```crystal
class NewsletterSignupsCreate < BrowserAction
  post "/newsletter/signup" do
    # do the signup code
    redirect_back fallback: Home::Index
  end
end
```

It's important that the fallback is required because the `Referer` header is not guaranteed so we need to send the user somewhere.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`