### PR TITLE
Keep flash messages during (multiple) redirects.

### DIFF
--- a/spec/lucky/action_redirect_spec.cr
+++ b/spec/lucky/action_redirect_spec.cr
@@ -73,6 +73,16 @@ describe Lucky::Action do
     context.response.headers["Turbolinks-Location"].should eq "/somewhere"
     context.cookies.deleted?(:_turbolinks_location).should be_true
   end
+
+  it "keeps flash messages for the next action" do
+    context = build_context_with_flash({success: "Keep me!"}.to_json)
+    action = RedirectAction.new(context, params)
+    response = action.redirect to: "/somewhere", status: 302
+    response.print
+
+    flash = Lucky::FlashStore.from_session(response.context.session)
+    flash.success.should eq("Keep me!")
+  end
 end
 
 private def should_redirect(action, to path, status)

--- a/spec/lucky/action_redirect_spec.cr
+++ b/spec/lucky/action_redirect_spec.cr
@@ -76,10 +76,10 @@ describe Lucky::Action do
 
   it "keeps flash messages for the next action" do
     context = build_context_with_flash({success: "Keep me!"}.to_json)
+
     action = RedirectAction.new(context, params)
     response = action.redirect to: "/somewhere", status: 302
     response.print
-
     flash = Lucky::FlashStore.from_session(response.context.session)
     flash.success.should eq("Keep me!")
   end

--- a/spec/lucky/cookies/flash_store_spec.cr
+++ b/spec/lucky/cookies/flash_store_spec.cr
@@ -47,6 +47,18 @@ describe Lucky::FlashStore do
     flash_store.success?.should be_nil
   end
 
+  describe "#recycle" do
+    it "carries messages for @now over to @next" do
+      next_hash = {} of String => String
+      now_hash = {"name" => "Paul"}
+      flash_store = build_flash_store(now: now_hash, next: next_hash)
+
+      flash_store.recycle.should be_nil
+      next_flash = JSON.parse(flash_store.to_json).as_h
+      next_flash["name"]?.should eq("Paul")
+    end
+  end
+
   describe "#each" do
     it "returns the list of key/value pairs" do
       flash_store = build_flash_store(next: {

--- a/spec/lucky/cookies/flash_store_spec.cr
+++ b/spec/lucky/cookies/flash_store_spec.cr
@@ -47,13 +47,13 @@ describe Lucky::FlashStore do
     flash_store.success?.should be_nil
   end
 
-  describe "#recycle" do
+  describe "#keep" do
     it "carries messages for @now over to @next" do
       next_hash = {} of String => String
       now_hash = {"name" => "Paul"}
       flash_store = build_flash_store(now: now_hash, next: next_hash)
 
-      flash_store.recycle.should be_nil
+      flash_store.keep.should be_nil
       next_flash = JSON.parse(flash_store.to_json).as_h
       next_flash["name"]?.should eq("Paul")
     end

--- a/spec/lucky/text_response_spec.cr
+++ b/spec/lucky/text_response_spec.cr
@@ -16,32 +16,32 @@ describe Lucky::TextResponse do
       end
 
       it "only keeps the flash for one request" do
-        context1 = build_context
+        context_1 = build_context
         now_json = {success: "Yay!"}.to_json
-        context1.session.set(Lucky::FlashStore::SESSION_KEY, now_json)
-        next_json = context1.flash.to_json
+        context_1.session.set(Lucky::FlashStore::SESSION_KEY, now_json)
+        next_json = context_1.flash.to_json
 
-        context1.flash.success.should eq("Yay!")
+        context_1.flash.success.should eq("Yay!")
 
-        print_response_with_body(context1)
+        print_response_with_body(context_1)
 
-        context2 = build_context
-        context2.session.set(Lucky::FlashStore::SESSION_KEY, next_json)
+        context_2 = build_context
+        context_2.session.set(Lucky::FlashStore::SESSION_KEY, next_json)
 
-        context2.flash.success.should eq("")
+        context_2.flash.success.should eq("")
       end
 
       it "keeps the flash for the next request" do
-        context1 = build_context
-        context1.flash.success = "Yay!"
-        next_json = context1.flash.to_json
+        context_1 = build_context
+        context_1.flash.success = "Yay!"
+        next_json = context_1.flash.to_json
 
-        print_response_with_body(context1)
+        print_response_with_body(context_1)
 
-        context2 = build_context
-        context2.session.set(Lucky::FlashStore::SESSION_KEY, next_json)
+        context_2 = build_context
+        context_2.session.set(Lucky::FlashStore::SESSION_KEY, next_json)
 
-        context2.flash.success.should eq("Yay!")
+        context_2.flash.success.should eq("Yay!")
       end
     end
 

--- a/src/lucky/cookies/flash_store.cr
+++ b/src/lucky/cookies/flash_store.cr
@@ -22,7 +22,7 @@ class Lucky::FlashStore
     raise Lucky::InvalidFlashJSONError.new(session.get?(SESSION_KEY))
   end
 
-  def keep : Void
+  def keep : Nil
     @next = @now
   end
 

--- a/src/lucky/cookies/flash_store.cr
+++ b/src/lucky/cookies/flash_store.cr
@@ -22,6 +22,10 @@ class Lucky::FlashStore
     raise Lucky::InvalidFlashJSONError.new(session.get?(SESSION_KEY))
   end
 
+  def recycle : Void
+    @next = @now
+  end
+
   private def all : Hash(String, String)
     @now.merge(@next)
   end

--- a/src/lucky/cookies/flash_store.cr
+++ b/src/lucky/cookies/flash_store.cr
@@ -22,7 +22,7 @@ class Lucky::FlashStore
     raise Lucky::InvalidFlashJSONError.new(session.get?(SESSION_KEY))
   end
 
-  def recycle : Void
+  def keep : Void
     @next = @now
   end
 

--- a/src/lucky/redirectable.cr
+++ b/src/lucky/redirectable.cr
@@ -60,6 +60,7 @@ module Lucky::Redirectable
   # ```
   # Note: It's recommended to use the method above that accepts a human friendly version of the status
   def redirect(to path : String, status : Int32 = 302) : Lucky::TextResponse
+    flash.recycle
     if ajax? && request.method != "GET"
       context.response.headers.add "Location", path
 

--- a/src/lucky/redirectable.cr
+++ b/src/lucky/redirectable.cr
@@ -60,7 +60,9 @@ module Lucky::Redirectable
   # ```
   # Note: It's recommended to use the method above that accepts a human friendly version of the status
   def redirect(to path : String, status : Int32 = 302) : Lucky::TextResponse
-    flash.recycle
+    # flash messages are not consumed here, so keep them for the next action
+    flash.keep
+
     if ajax? && request.method != "GET"
       context.response.headers.add "Location", path
 

--- a/src/lucky/tags/base_tags.cr
+++ b/src/lucky/tags/base_tags.cr
@@ -1,6 +1,6 @@
 module Lucky::BaseTags
   include Lucky::CheckTagContent
-  TAGS             = %i(a abbr address article aside b bdi body button code details dialog div dd dl dt em fieldset figcaption figure footer form h1 h2 h3 h4 h5 h6 head header html i iframe label li main mark menuitem meter nav ol option pre progress rp rt ruby s script section small span strong summary table template tbody td textarea th thead time title tr u ul video wbr)
+  TAGS             = %i(a abbr address article aside b bdi body button code details dialog div dd dl dt em fieldset figcaption figure footer form h1 h2 h3 h4 h5 h6 head header html i iframe label li main mark menuitem meter nav ol option pre progress rp rt ruby s script section small span strong summary table tbody td template textarea th thead time title tr u ul video wbr)
   RENAMED_TAGS     = {"para": "p", "select_tag": "select"}
   EMPTY_TAGS       = %i(img br hr input meta source)
   EMPTY_HTML_ATTRS = {} of String => String


### PR DESCRIPTION
## Purpose
Fixes #1162.

## Description
The `FlashStore#recycle` method from my proposal has been renamed to `FlashStore#keep`, but functionality is exactly the same. And I corrected a mistake I made with #1164 :blush:.

## Checklist
* [X] - An issue already exists detailing the issue/or feature request that this PR fixes
* [X] - All specs are formatted with `crystal tool format spec src`
* [X] - Inline documentation has been added and/or updated
* [X] - Lucky builds on docker with `./script/setup`
* [X] - All builds and specs pass on docker with `./script/test`
