### PR TITLE
Allow Actions to render a Component

### DIFF
--- a/spec/lucky/action_rendering_spec.cr
+++ b/spec/lucky/action_rendering_spec.cr
@@ -126,6 +126,40 @@ class Rendering::File::Missing < TestAction
   end
 end
 
+private class PlainTestComponent < Lucky::BaseComponent
+  def render
+    h1 "Plain Component"
+  end
+end
+
+private class ComplexTestComponent < Lucky::BaseComponent
+  needs title : String
+
+  def render
+    text @title
+    img src: asset("images/logo.png")
+    m(PlainTestComponent)
+  end
+end
+
+class Rendering::PlainComponent < TestAction
+  get "/foo" do
+    component PlainTestComponent
+  end
+end
+
+class Rendering::ComplexComponent < TestAction
+  get "/foo" do
+    component ComplexTestComponent, title: "Getting Complex"
+  end
+end
+
+class Rendering::PlainComponentWithCustomStatus < TestAction
+  get "/foo" do
+    component PlainTestComponent, status: :partial_content
+  end
+end
+
 describe Lucky::Action do
   describe "rendering HTML pages" do
     it "render assigns" do
@@ -133,6 +167,28 @@ describe Lucky::Action do
 
       response.body.to_s.should contain "Anything"
       response.debug_message.to_s.should contain "Rendering::IndexPage"
+    end
+  end
+
+  describe "rendering Components" do
+    it "renders a simple component" do
+      response = Rendering::PlainComponent.new(build_context, params).call
+
+      response.body.to_s.should eq "<h1>Plain Component</h1>"
+    end
+
+    it "renders a complex component" do
+      response = Rendering::ComplexComponent.new(build_context, params).call
+
+      body = response.body.to_s
+      body.should contain "<h1>Plain Component</h1>"
+      body.should contain "Getting Complex"
+      body.should contain "images/logo-with-hash.png"
+    end
+
+    it "renders a component with a HTTP::Status" do
+      response = Rendering::PlainComponentWithCustomStatus.new(build_context, params).call
+      response.status.should eq 206
     end
   end
 

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -232,4 +232,23 @@ module Lucky::Renderable
   def xml(body, status : HTTP::Status) : Lucky::TextResponse
     xml(body, status: status.value)
   end
+
+  # Render a Component as an HTML response.
+  #
+  # ```
+  # get "/foo" do
+  #   component MyComponent, with: :args
+  # end
+  # ```
+  def component(comp : Lucky::BaseComponent.class, status : Int32? = nil, **named_args) : Lucky::TextResponse
+    send_text_response(
+      comp.new(**named_args).render_to_string,
+      "text/html",
+      status
+    )
+  end
+
+  def component(comp : Lucky::BaseComponent.class, status : HTTP::Status, **named_args) : Lucky::TextResponse
+    component(comp, status.value, **named_args)
+  end
 end


### PR DESCRIPTION
## Purpose
Fixes #1173 

## Description
This adds a new `component` method to Actions so we can render a component as a text response instead of an entire page.

```crystal
class Api::Cars::Index < ApiAction
  get "/cars" do
    cars = CarQuery.new
    component CarsListComponent, cars: cars
  end
end
```

```javascript
// some js

fetch("/api/cars").then(response => {
  response.text().then(html => {
    document.getElementById("cars-container").innerHTML = html
  })
})
```

We currently use this pattern in our apps as a way to load front end component asynchronously, but still allow us to write them in the Lucky DSL. We use it in conjunction with javascript, but I'm sure others could come up with other use cases 

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
