### PR TITLE
Upgrade to Crystal 0.35.0

### DIFF
--- a/spec/lucky/pretty_log_formatter_spec.cr
+++ b/spec/lucky/pretty_log_formatter_spec.cr
@@ -71,12 +71,11 @@ end
 
 private def format(io, data : NamedTuple?, message : String = "", severity = Log::Severity::Info, exception : Exception? = nil)
   Log.with_context do
-    Log.context.set(local: data) if data
-
     entry = Log::Entry.new \
       source: "lucky-test",
       message: message,
       severity: severity,
+      data: Log::Metadata.build(data),
       exception: exception
 
     Lucky::PrettyLogFormatter.new(

--- a/spec/lucky/pretty_log_formatter_spec.cr
+++ b/spec/lucky/pretty_log_formatter_spec.cr
@@ -53,7 +53,7 @@ describe Lucky::PrettyLogFormatter do
 
   it "uses a yellow arrow for warnings and colors the first value" do
     io = IO::Memory.new
-    format(io, severity: Log::Severity::Warning, data: {first: "message", second: "message"})
+    format(io, severity: Log::Severity::Warn, data: {first: "message", second: "message"})
 
     io.to_s.chomp.should eq(" #{"▸".colorize.yellow} First #{"message".colorize.yellow.bold}. Second #{"message".colorize.bold}")
   end

--- a/spec/lucky/pretty_log_formatter_spec.cr
+++ b/spec/lucky/pretty_log_formatter_spec.cr
@@ -75,7 +75,7 @@ private def format(io, data : NamedTuple?, message : String = "", severity = Log
       source: "lucky-test",
       message: message,
       severity: severity,
-      data: Log::Metadata.build(data),
+      data: Log::Metadata.build(data || Log::Metadata.empty),
       exception: exception
 
     Lucky::PrettyLogFormatter.new(

--- a/spec/lucky/remote_ip_handler_spec.cr
+++ b/spec/lucky/remote_ip_handler_spec.cr
@@ -33,11 +33,11 @@ describe Lucky::RemoteIpHandler do
 
     it "returns the original remote_address" do
       request = HTTP::Request.new("GET", "/remote-ip", body: "", headers: HTTP::Headers.new)
-      request.remote_address = "255.255.255.255"
+      request.remote_address = Socket::IPAddress.new("255.255.255.255", 0)
       context = build_context(request)
 
       run_remote_ip_handler(context)
-      context.request.remote_address.should eq "255.255.255.255"
+      context.request.remote_address.should eq Socket::IPAddress.new("255.255.255.255", 0)
     end
   end
 end

--- a/spec/lucky/remote_ip_handler_spec.cr
+++ b/spec/lucky/remote_ip_handler_spec.cr
@@ -18,7 +18,7 @@ describe Lucky::RemoteIpHandler do
       context = build_context(request)
 
       run_remote_ip_handler(context)
-      context.request.remote_address.should eq "1.2.3.4"
+      context.request.remote_address.should eq Socket::IPAddress.new("1.2.3.4", 0)
     end
 
     it "returns nil if the X_FORWARDED_FOR is an empty string, and no default remote_address is found" do

--- a/spec/lucky/text_response_spec.cr
+++ b/spec/lucky/text_response_spec.cr
@@ -175,7 +175,7 @@ describe Lucky::TextResponse do
 
           context.response.headers["Content-Encoding"].should eq "gzip"
           expected_io = IO::Memory.new
-          Gzip::Writer.open(expected_io) { |gzw| gzw.print "some body" }
+          Compress::Gzip::Writer.open(expected_io) { |gzw| gzw.print "some body" }
           output.to_s.ends_with?(expected_io.to_s).should be_true
         end
       end

--- a/src/lucky/pretty_log_formatter.cr
+++ b/src/lucky/pretty_log_formatter.cr
@@ -40,7 +40,7 @@ struct Lucky::PrettyLogFormatter < Dexter::BaseFormatter
       arrow = "▸"
 
       case severity.value
-      when ::Log::Severity::Warning.value
+      when ::Log::Severity::Warn.value
         arrow.colorize.yellow
       when .>= ::Log::Severity::Error.value
         arrow.colorize.red
@@ -129,7 +129,7 @@ struct Lucky::PrettyLogFormatter < Dexter::BaseFormatter
     end
 
     private def printing_first_value_of_warning?
-      severity.value == ::Log::Severity::Warning.value && index.zero?
+      severity.value == ::Log::Severity::Warn.value && index.zero?
     end
   end
 end

--- a/src/lucky/pretty_log_formatter.cr
+++ b/src/lucky/pretty_log_formatter.cr
@@ -29,7 +29,7 @@ struct Lucky::PrettyLogFormatter < Dexter::BaseFormatter
     abstract def write : Nil
 
     def local_context
-      entry.data.as_h?
+      entry.data.as_h
     end
 
     private def add_arrow : Void

--- a/src/lucky/pretty_log_formatter.cr
+++ b/src/lucky/pretty_log_formatter.cr
@@ -29,7 +29,11 @@ struct Lucky::PrettyLogFormatter < Dexter::BaseFormatter
     abstract def write : Nil
 
     def local_context
-      entry.data.as_h
+      res = Hash(String, ::Log::Metadata::Value).new
+      entry.data.each do |key, value|
+        res[key.to_s] = value
+      end
+      res
     end
 
     private def add_arrow : Void

--- a/src/lucky/pretty_log_formatter.cr
+++ b/src/lucky/pretty_log_formatter.cr
@@ -29,7 +29,7 @@ struct Lucky::PrettyLogFormatter < Dexter::BaseFormatter
     abstract def write : Nil
 
     def local_context
-      entry.context["local"]?.try(&.as_h) || ::Log::Context.new.as_h
+      entry.context["local"]?.try(&.as_h) || ::Log::Metadata.new.as_h
     end
 
     private def add_arrow : Void

--- a/src/lucky/pretty_log_formatter.cr
+++ b/src/lucky/pretty_log_formatter.cr
@@ -29,7 +29,7 @@ struct Lucky::PrettyLogFormatter < Dexter::BaseFormatter
     abstract def write : Nil
 
     def local_context
-      entry.context["local"]?.try(&.as_h) || ::Log::Metadata.new.as_h
+      entry.data.as_h?
     end
 
     private def add_arrow : Void

--- a/src/lucky/text_response.cr
+++ b/src/lucky/text_response.cr
@@ -1,5 +1,5 @@
 {% if !flag?(:without_zlib) %}
-  require "gzip"
+  require "compress/gzip"
 {% end %}
 
 # Writes the *content_type*, *status*, and *body* to the *context* for text responses.
@@ -35,7 +35,7 @@ class Lucky::TextResponse < Lucky::Response
 
   private def gzip
     context.response.headers["Content-Encoding"] = "gzip"
-    context.response.output = Gzip::Writer.new(context.response.output, sync_close: true)
+    context.response.output = Compress::Gzip::Writer.new(context.response.output, sync_close: true)
   end
 
   private def should_gzip?

--- a/tasks/watch.cr
+++ b/tasks/watch.cr
@@ -151,7 +151,7 @@ module LuckySentry
 
     private def stop_all_processes
       @app_processes.each do |process|
-        process.kill unless process.terminated?
+        process.signal(:term) unless process.terminated?
       end
     end
 


### PR DESCRIPTION
These are some of the changes I've notice to upgrade to Crystal 0.35.

Probably the local data of log entries can be redesigned to avoid intermediate structures. For now I was focused on make the spec pass.

The rest of the changes are self explanatory. Feel free to close the PR and use it as input for a cleaner migration.

dexter, avram, lucky_cli will need to be updated also.

The crystal property in shards.yml should be bumped to crystal: 0.35.0