### PR TITLE
Add disable_cookies macro.

### DIFF
--- a/spec/lucky/action_cookies_and_sessions_spec.cr
+++ b/spec/lucky/action_cookies_and_sessions_spec.cr
@@ -25,30 +25,52 @@ class FlashCookies::Index < TestAction
   end
 end
 
+class CookiesDisabled::Index < TestAction
+  disable_cookies
+
+  get "/no_cookies" do
+    cookies.set :my_cookie, "cookie"
+
+    plain_text ""
+  end
+end
+
 describe Lucky::Action do
-  describe "reading set cookies and sessions" do
-    it "can set and read cookies" do
-      response = Cookies::Index.new(build_context, params).call
+  context "with cookies enabled" do
+    describe "reading set cookies and sessions" do
+      it "can set and read cookies" do
+        response = Cookies::Index.new(build_context, params).call
 
-      response.context.cookies.get("my_cookie").should eq("cookie")
-      response.context.session.get("my_session").should eq("session")
-      response.body.should eq "cookie - session"
+        response.enable_cookies.should be_true
+        response.context.cookies.get("my_cookie").should eq("cookie")
+        response.context.session.get("my_session").should eq("session")
+        response.body.should eq "cookie - session"
+      end
+    end
+
+    describe "reading a cookie value that isn't there" do
+      it "will initialize the cookies object and not crash" do
+        response = PreCookies::Index.new(build_context, params).call
+
+        response.body.should eq ""
+      end
+    end
+
+    describe "setting and reading the flash" do
+      it "will initialize the cookies object and not crash" do
+        response = FlashCookies::Index.new(build_context, params).call
+
+        response.body.should eq "You did it!"
+      end
     end
   end
 
-  describe "reading a cookie value that isn't there" do
-    it "will initialize the cookies object and not crash" do
-      response = PreCookies::Index.new(build_context, params).call
+  context "with cookies disabled" do
+    it "does not set a cookies header" do
+      response = CookiesDisabled::Index.new(build_context, params).call
+      response.print
 
-      response.body.should eq ""
-    end
-  end
-
-  describe "setting and reading the flash" do
-    it "will initialize the cookies object and not crash" do
-      response = FlashCookies::Index.new(build_context, params).call
-
-      response.body.should eq "You did it!"
+      response.context.response.headers.has_key?("Set-Cookie").should be_false
     end
   end
 end

--- a/spec/lucky/text_response_spec.cr
+++ b/spec/lucky/text_response_spec.cr
@@ -132,6 +132,15 @@ describe Lucky::TextResponse do
         header.should contain("Secure")
         header.should contain("HttpOnly")
       end
+
+      it "allows for cookies to be disabled" do
+        context = build_context
+        context.session.set(:email, "test@example.com")
+
+        print_response_with_body(context, enable_cookies: false)
+
+        context.response.headers.has_key?("Set-Cookie").should be_false
+      end
     end
 
     context "status" do
@@ -205,7 +214,14 @@ private def print_response_with_body(
   context : HTTP::Server::Context,
   body = "",
   status = 200,
-  content_type = "text/html"
+  content_type = "text/html",
+  enable_cookies = true
 )
-  Lucky::TextResponse.new(context, content_type, body, status: status).print
+  Lucky::TextResponse.new(
+    context,
+    content_type,
+    body,
+    status: status,
+    enable_cookies: enable_cookies
+  ).print
 end

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -85,7 +85,31 @@ module Lucky::Renderable
       "text/html",
       view.perform_render,
       debug_message: log_message(view),
+      enable_cookies: enable_cookies?
     )
+  end
+
+  # Disable cookies
+  #
+  # When `disable_cookies` is used, no `Set-Cookie` header will be written to
+  # the response.
+  #
+  # ```crystal
+  # class Events::Show < ApiAction
+  #   disable_cookies
+  #
+  #   get "/events/:id" do
+  #     ...
+  #   end
+  # end
+  # ```
+  #
+  macro disable_cookies
+    DISABLE_COOKIES = true
+  end
+
+  private def enable_cookies?
+    !{{@type.constant :DISABLE_COOKIES}}
   end
 
   private def log_message(view) : String
@@ -188,7 +212,13 @@ module Lucky::Renderable
     content_type : String,
     status : Int32? = 100
   ) : Lucky::TextResponse
-    Lucky::TextResponse.new(context, content_type, body, status: status)
+    Lucky::TextResponse.new(
+      context,
+      content_type,
+      body,
+      status: status,
+      enable_cookies: enable_cookies?
+    )
   end
 
   def plain_text(body : String, status : Int32? = nil) : Lucky::TextResponse

--- a/src/lucky/text_response.cr
+++ b/src/lucky/text_response.cr
@@ -10,19 +10,22 @@
 class Lucky::TextResponse < Lucky::Response
   DEFAULT_STATUS = 200
 
-  getter context, content_type, body, debug_message
+  getter context, content_type, body, debug_message, enable_cookies
 
   def initialize(@context : HTTP::Server::Context,
                  @content_type : String,
                  @body : String | IO,
                  @status : Int32? = nil,
-                 @debug_message : String? = nil)
+                 @debug_message : String? = nil,
+                 @enable_cookies : Bool = true)
   end
 
   def print : Nil
-    write_flash
-    write_session
-    write_cookies
+    if enable_cookies
+      write_flash
+      write_session
+      write_cookies
+    end
     context.response.content_type = content_type
     context.response.status_code = status
     gzip if should_gzip?


### PR DESCRIPTION
## Purpose
Implements #1178.

## Description
When used, the `Set-Cookie` header will not be written to the response headers.

```cr
class Events::Show < ApiAction
  disable_cookies

  get "/events/:id" do
    ...
  end
end
```

## Checklist
* [X] - An issue already exists detailing the issue/or feature request that this PR fixes
* [X] - All specs are formatted with `crystal tool format spec src`
* [X] - Inline documentation has been added and/or updated
* [X] - Lucky builds on docker with `./script/setup`
* [X] - All builds and specs pass on docker with `./script/test`
