### PR TITLE
Rename canonical_link_tag to canonical_link.

### DIFF
--- a/spec/lucky/specialty_tags_spec.cr
+++ b/spec/lucky/specialty_tags_spec.cr
@@ -57,7 +57,7 @@ describe Lucky::SpecialtyTags do
   end
 
   it "renders canonical link tag" do
-    view(&.canonical_link_tag("https://it.is/here")).should contain <<-HTML
+    view(&.canonical_link("https://it.is/here")).should contain <<-HTML
     <link href="https://it.is/here" rel="canonical">
     HTML
   end

--- a/src/lucky/tags/specialty_tags.cr
+++ b/src/lucky/tags/specialty_tags.cr
@@ -44,7 +44,7 @@ module Lucky::SpecialtyTags
 
   # Generates a canonical link tag to specify the "canonical" or "preferred"
   # version of a page.
-  def canonical_link_tag(href : String) : Nil
+  def canonical_link(href : String) : Nil
     empty_tag "link", href: href, rel: "canonical"
   end
 


### PR DESCRIPTION
## Purpose
In continuation of #1181.

## Description
Renames `canonical_link_tag` to `canonical_link`.

## Checklist
* [X] - An issue already exists detailing the issue/or feature request that this PR fixes
* [X] - All specs are formatted with `crystal tool format spec src`
* [X] - Inline documentation has been added and/or updated
* [X] - Lucky builds on docker with `./script/setup`
* [X] - All builds and specs pass on docker with `./script/test`
