### PR TITLE
Add method to capture samesite for cookies and return the cookie

### DIFF
--- a/spec/charms/cookie_spec.cr
+++ b/spec/charms/cookie_spec.cr
@@ -12,6 +12,7 @@ describe HTTP::Cookie do
         .domain("luckyframework.org")
         .secure(true)
         .http_only(true)
+        .samesite(:lax)
 
       cookie.should be_a(HTTP::Cookie)
       cookie.name.should eq("session_id")

--- a/spec/charms/cookie_spec.cr
+++ b/spec/charms/cookie_spec.cr
@@ -22,6 +22,7 @@ describe HTTP::Cookie do
       cookie.domain.should eq("luckyframework.org")
       cookie.secure.should be_true
       cookie.http_only.should be_true
+      cookie.samesite.to_s.should eq "Lax"
     end
   end
 

--- a/src/charms/cookie.cr
+++ b/src/charms/cookie.cr
@@ -37,4 +37,9 @@ class HTTP::Cookie
     self.http_only = value
     self
   end
+
+  def samesite(value : HTTP::Cookie::SameSite) : HTTP::Cookie
+    self.samesite = value
+    self
+  end
 end


### PR DESCRIPTION
## Purpose
Fixes #1176

## Description
```crystal
Lucky::CookieJar.configure do |settings|
  settings.on_set = ->(cookie : HTTP::Cookie) {
    cookie.secure(Lucky::ForceSSLHandler.settings.enabled)
    cookie.http_only(true)
    cookie.samesite(:strict)
  }
end
```

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
