### PR TITLE
Use data from Dexter

### DIFF
--- a/spec/lucky/pretty_log_formatter_spec.cr
+++ b/spec/lucky/pretty_log_formatter_spec.cr
@@ -71,11 +71,13 @@ end
 
 private def format(io, data : NamedTuple?, message : String = "", severity = Log::Severity::Info, exception : Exception? = nil)
   Log.with_context do
+    Log.context.set(local: data) if data
+
     entry = Log::Entry.new \
       source: "lucky-test",
       message: message,
       severity: severity,
-      data: Log::Metadata.build(data || Log::Metadata.empty),
+      data: Log::Metadata.build(Log::Metadata.empty),
       exception: exception
 
     Lucky::PrettyLogFormatter.new(

--- a/src/lucky/pretty_log_formatter.cr
+++ b/src/lucky/pretty_log_formatter.cr
@@ -30,9 +30,11 @@ struct Lucky::PrettyLogFormatter < Dexter::BaseFormatter
 
     def local_context
       res = Hash(String, ::Log::Metadata::Value).new
-      entry.data.each do |key, value|
+
+      entry.context[:local]?.try &.as_h.each do |key, value|
         res[key.to_s] = value
       end
+
       res
     end
 


### PR DESCRIPTION
Use the context data from Dexter. Eventually Dexter should use entry.data (and context) but it doesn't yet so we need to change this