### PR TITLE
Fixing bug with generated pages

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -31,7 +31,7 @@ targets:
 dependencies:
   lucky_cli:
     github: luckyframework/lucky_cli
-    branch: pcs/crystal-0.35
+    version: ~> 0.22.0
   habitat:
     github: luckyframework/habitat
     version: ~> 0.4.1
@@ -40,7 +40,7 @@ dependencies:
     version: ~> 0.2.0
   avram:
     github: luckyframework/avram
-    branch: pcs/update-crystal-pg
+    version: ~> 0.15.0
   lucky_router:
     github: luckyframework/lucky_router
     version: ~> 0.2.0

--- a/tasks/gen/templates/page/{{page_filename}}.cr.ecr
+++ b/tasks/gen/templates/page/{{page_filename}}.cr.ecr
@@ -1,5 +1,5 @@
 class <%= @page_class %> < MainLayout
   def content
-    h1 "Modify this page at #{@output_path}"
+    h1 "Modify this page at <%= @output_path %>"
   end
 end


### PR DESCRIPTION
## Purpose
Fixes #1110 

## Description
The `@output_path` was using string interpolation, but since it's coming from the template, it should be an ECR tag. I'm not sure if we have a way to check this, but this looks more correct 😅 

On a side note, I couldn't run specs because I was getting issues with Dexter. I updated the versions since these are released now to get specs to run locally. 

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
