### PR TITLE
a few missing updates from the last release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:0.34.0
+FROM crystallang/crystal:0.35.0
 WORKDIR /data
 
 RUN apt-get update && \

--- a/shard.yml
+++ b/shard.yml
@@ -1,7 +1,7 @@
 name: lucky
-version: 0.21.0
+version: 0.22.0
 
-crystal: 0.34.0
+crystal: 0.35.0
 
 authors:
   - Paul Smith <paulcsmith0218@gmail.com>

--- a/src/lucky/version.cr
+++ b/src/lucky/version.cr
@@ -1,3 +1,3 @@
 module Lucky
-  VERSION = "0.21.0"
+  VERSION = "0.22.0"
 end


### PR DESCRIPTION
Since 0.22 was technically never merged in because of how we do our releases, a few things go missed. The Docker setup and tests run and pass again. 
