### PR TITLE
Add multipart convenience argument to form_for helper.

### DIFF
--- a/spec/lucky/form_helpers_spec.cr
+++ b/spec/lucky/form_helpers_spec.cr
@@ -43,6 +43,18 @@ private class TestPage
       text "foo"
     end
   end
+
+  def form_with_multipart
+    form_for FormHelpers::Create, multipart: true do
+      text "foo"
+    end
+  end
+
+  def form_with_multipart_false
+    form_for FormHelpers::Create, multipart: false do
+      text "foo"
+    end
+  end
 end
 
 describe Lucky::FormHelpers do
@@ -85,6 +97,18 @@ describe Lucky::FormHelpers do
     form.should contain <<-HTML
     <form action="/form_helpers" method="get"><input type="hidden" name="#{Lucky::ProtectFromForgery::PARAM_KEY}" value="my_token"></form>
     HTML
+  end
+
+  it "converts the multipart argument" do
+    without_csrf_protection do
+      view(&.form_with_multipart).should contain <<-HTML
+      <form action="/form_helpers" method="post" enctype="multipart/form-data">foo</form>
+      HTML
+
+      view(&.form_with_multipart_false).should contain <<-HTML
+      <form action="/form_helpers" method="post">foo</form>
+      HTML
+    end
   end
 end
 

--- a/src/lucky/tags/form_helpers.cr
+++ b/src/lucky/tags/form_helpers.cr
@@ -4,8 +4,7 @@ module Lucky::FormHelpers
   end
 
   def form_for(route : Lucky::RouteHelper, **html_options) : Nil
-    form_options = {"action" => route.path, "method" => form_method(route)}
-    form merge_options(html_options, form_options) do
+    form build_form_options(route, html_options) do
       csrf_hidden_input if settings.include_csrf_tag
       method_override_input(route)
       yield
@@ -22,6 +21,16 @@ module Lucky::FormHelpers
     else
       "post"
     end
+  end
+
+  private def build_form_options(route, html_options) : Hash
+    options = merge_options(html_options, {
+      "action" => route.path,
+      "method" => form_method(route),
+    })
+    options["enctype"] = "multipart/form-data" if options.delete("multipart")
+
+    options
   end
 
   private def method_override_input(route) : Nil


### PR DESCRIPTION
## Purpose
Closes #1192.

## Description
Allows us to do:

```cr
form_for Project::Create, multipart: true do
  # ...
end
```

## Checklist
* [X] - An issue already exists detailing the issue/or feature request that this PR fixes
* [X] - All specs are formatted with `crystal tool format spec src`
* [X] - Inline documentation has been added and/or updated
* [X] - Lucky builds on docker with `./script/setup`
* [X] - All builds and specs pass on docker with `./script/test`
