### PR TITLE
Add LuckyDiff links to UPGRADE_NOTES

### DIFF
--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -1,5 +1,7 @@
 ## Upgrading from 0.21 to 0.22
 
+For a full diff of necessary changes, please see [LuckyDiff](https://luckydiff.com?from=0.21.0&to=0.22.0).
+
 - Upgrade Lucky CLI (homebrew)
 
 ```
@@ -22,6 +24,8 @@ brew upgrade lucky
 - Run `shards update`
 
 ## Upgrading from 0.20 to 0.21
+
+For a full diff of necessary changes, please see [LuckyDiff](https://luckydiff.com?from=0.20.0&to=0.21.0).
 
 - Upgrade Lucky CLI (homebrew)
 
@@ -78,6 +82,8 @@ Log.dexter.info { {path: @context.request.path} }
 
 ## Upgrading from 0.19 to 0.20
 
+For a full diff of necessary changes, please see [LuckyDiff](https://luckydiff.com?from=0.19.0&to=0.20.0).
+
 - Update `.crystal-version` file to `0.34.0`
 - Upgrade to crystal 0.34.0
 - Upgrade Lucky CLI (homebrew)
@@ -132,6 +138,8 @@ brew upgrade lucky
 
 ## Upgrading from 0.18 to 0.19
 
+For a full diff of necessary changes, please see [LuckyDiff](https://luckydiff.com?from=0.18.0&to=0.19.0).
+
 - Update `.crystal-version` file to `0.33.0`
 - Upgrade to crystal 0.33.0
 - Upgrade Lucky CLI (homebrew)
@@ -170,6 +178,8 @@ brew upgrade lucky
 * Make [these changes](https://github.com/luckyframework/lucky_cli/commit/8bc002ab51cb13e67f515c4de977766f96825a18#diff-83ca1a783e82ef6f0d38f400b7c1eaa1) to `config/server.cr` to gzip text responses.
 
 ## Upgrading from 0.17 to 0.18
+
+For a full diff of necessary changes, please see [LuckyDiff](https://luckydiff.com?from=0.17.0&to=0.18.0).
 
 - Upgrade to crystal 0.31.1
 - Upgrade Lucky CLI (homebrew)


### PR DESCRIPTION
## Purpose
As requested by @paulcsmith in Gitter, this adds some helper text to each `UPGRADE_NOTES` entry that's currently supported by [LuckyDiff](https://luckydiff.com) to provide an alternative upgrade path using the diff from that site directly.

Repository is located here: https://github.com/stephendolan/lucky_diff

## Description
Please review the language and positioning and feel free to edit directly. This is just a starting point, and definitely don't want to make it sound official if that's the vibe it gives off currently.

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [ x] - All specs are formatted with `crystal tool format spec src`
* [ x] - Inline documentation has been added and/or updated
* [ x] - Lucky builds on docker with `./script/setup`
* [ x] - All builds and specs pass on docker with `./script/test`
