### PR TITLE
Add Lucky.root redirection to Dir.current through exception.

### DIFF
--- a/src/lucky.cr
+++ b/src/lucky.cr
@@ -23,4 +23,9 @@ require "./lucky/paginator/components/*"
 module Lucky
   Log              = ::Log.for("lucky")
   ContinuedPipeLog = Log.for("continued_pipe_log")
+
+  # Use Dir.current to return the root folder of your Lucky application.
+  def self.root
+    {% raise "Please use Crystal's 'Dir.current' to return the root folder of your Lucky application." %}
+  end
 end

--- a/src/lucky.cr
+++ b/src/lucky.cr
@@ -25,6 +25,10 @@ module Lucky
   ContinuedPipeLog = Log.for("continued_pipe_log")
 
   # Use Dir.current to return the root folder of your Lucky application.
+  #
+  # In some frameworks there is a method called `root` that returns the root directory of the project.
+  # In Crystal there is a built-in method for this: `Dir.current`. This method exists purely to help new users
+  # find `Dir.current`. If you call `Lucky.root` it will raise a compile-time error directing you to use `Dir.current`
   def self.root
     {% raise "Please use Crystal's 'Dir.current' to return the root folder of your Lucky application." %}
   end


### PR DESCRIPTION
## Purpose

Adds `Lucky.root` method which, when used in an application will raise a compile-time error redirecting users to leverage `Dir.current`. **Resolves #1198**.

## Description

Context can be found in #1198, including around the decision to make this a compile-time error.

No specs added since it's raised at compile-time, and not post-build.

_Not 100% sure about how this will look in code documentation with just the single comment, please let me know if I need to improve that._

_Didn't add a CHANGELOG entry since I didn't see an existing "UNRELEASED" section, but happy to help add that in._

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
