### PR TITLE
Fix: set default status to nil in send_text_resonse.

### DIFF
--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -212,7 +212,7 @@ module Lucky::Renderable
   def send_text_response(
     body : String,
     content_type : String,
-    status : Int32? = 100
+    status : Int32? = nil
   ) : Lucky::TextResponse
     Lucky::TextResponse.new(
       context,


### PR DESCRIPTION
## Purpose
FIxes #1213 

## Description
I'm sorry for the inconvenience. :)

## Checklist
* [X] - An issue already exists detailing the issue/or feature request that this PR fixes
* [X] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [X] - Lucky builds on docker with `./script/setup`
* [X] - All builds and specs pass on docker with `./script/test`
