### PR TITLE
Replace references/generators for deprecated `mount` calls

### DIFF
--- a/src/lucky/paginator/backend_helpers.cr
+++ b/src/lucky/paginator/backend_helpers.cr
@@ -22,7 +22,7 @@ module Lucky::Paginator::BackendHelpers
   #
   #   def content
   #     # Render 'users' like normal
-  #     mount Lucky::Paginator::SimpleNav.new(@pages)
+  #     m Lucky::Paginator::SimpleNav, @pages
   #   end
   # end
   # ```
@@ -62,7 +62,7 @@ module Lucky::Paginator::BackendHelpers
   #
   #   def content
   #     # Render pagination links for the 'items' Array
-  #     mount Lucky::Paginator::SimpleNav.new(@pages)
+  #     m Lucky::Paginator::SimpleNav, @pages
   #   end
   # end
   # ```

--- a/tasks/gen/templates/resource/components/{{folder_name}}/form_fields.cr.ecr
+++ b/tasks/gen/templates/resource/components/{{folder_name}}/form_fields.cr.ecr
@@ -3,7 +3,7 @@ class <%= pluralized_name %>::FormFields < BaseComponent
 
   def render
     <%- columns.each_with_index do |column, index| -%>
-    mount Shared::Field.new(operation.<%= column.name %>)<% if index.zero? %>, &.text_input(autofocus: "true")<% end %>
+    m Shared::Field, operation.<%= column.name %><% if index.zero? %>, &.text_input(autofocus: "true")<% end %>
     <%- end -%>
   end
 end

--- a/tasks/gen/templates/resource/pages/{{folder_name}}/edit_page.cr.ecr
+++ b/tasks/gen/templates/resource/pages/{{folder_name}}/edit_page.cr.ecr
@@ -12,7 +12,7 @@ class <%= pluralized_name %>::EditPage < MainLayout
   def render_<%= underscored_resource %>_form(op)
     form_for <%= pluralized_name %>::Update.with(@<%= underscored_resource %>.id) do
       # Edit fields in src/components/<%= folder_name %>/form_fields.cr
-      mount <%= pluralized_name %>::FormFields.new(op)
+      m <%= pluralized_name %>::FormFields, op
 
       submit "Update", data_disable_with: "Updating..."
     end

--- a/tasks/gen/templates/resource/pages/{{folder_name}}/new_page.cr.ecr
+++ b/tasks/gen/templates/resource/pages/{{folder_name}}/new_page.cr.ecr
@@ -10,7 +10,7 @@ class <%= pluralized_name %>::NewPage < MainLayout
   def render_<%= underscored_resource %>_form(op)
     form_for <%= pluralized_name %>::Create do
       # Edit fields in src/components/<%= folder_name %>/form_fields.cr
-      mount <%= pluralized_name %>::FormFields.new(op)
+      m <%= pluralized_name %>::FormFields, op
 
       submit "Save", data_disable_with: "Saving..."
     end


### PR DESCRIPTION
## Purpose
Update deprecated `mount` generator code to generate code that doesn't immediately get flagged with deprecation warnings!

## Description
We recently deprecated `mount`, but the `lucky gen.resource.browser` CLI command still generates resources using it. This replaces all references to `mount` in the framework code with the new `m` call, aside from in the actual docblocks of the deprecated methods.

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
