### PR TITLE
Rename `m` to `mount`, but keep signature

### DIFF
--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -27,7 +27,7 @@ brew upgrade lucky
 ### General updates
 
 - Update: `params.get` now strips white space. If you need the raw value, use `params.get_raw`.
-- Rename: `mount` to `m` in all pages that use components.
+- Rename: `mount` to `m` in all pages that use components. **Note: This was reverted in the next version**
 - Update: all mounted components to use new signature `mount(MyComponent.new(x: 1, y: 2))` -> `m(MyComponent, x: 1, y:2)`.
 - Remove: `Lucky::SessionHandler` and `Lucky::FlashHandler` from `src/app_server.cr`
 

--- a/spec/lucky/action_rendering_spec.cr
+++ b/spec/lucky/action_rendering_spec.cr
@@ -138,7 +138,7 @@ private class ComplexTestComponent < Lucky::BaseComponent
   def render
     text @title
     img src: asset("images/logo.png")
-    m(PlainTestComponent)
+    mount(PlainTestComponent)
   end
 end
 

--- a/spec/lucky/component_spec.cr
+++ b/spec/lucky/component_spec.cr
@@ -14,7 +14,7 @@ private class ComplexTestComponent < Lucky::BaseComponent
   def render
     text @title
     img src: asset("images/logo.png")
-    m(TestComponent)
+    mount(TestComponent)
   end
 end
 
@@ -36,11 +36,11 @@ private class TestMountPage
   include Lucky::HTMLPage
 
   def render
-    m(ComplexTestComponent, title: "passed_in_title")
-    m(ComponentWithBlockAndNoBlockArgs) do
+    mount(ComplexTestComponent, title: "passed_in_title")
+    mount(ComponentWithBlockAndNoBlockArgs) do
       text "Block without args"
     end
-    m(ComponentWithBlock, "Jane") do |name|
+    mount(ComponentWithBlock, "Jane") do |name|
       text name.upcase
     end
     view

--- a/src/lucky/mount_component.cr
+++ b/src/lucky/mount_component.cr
@@ -6,46 +6,10 @@ module Lucky::MountComponent
   # starts and ends.
   #
   # ```
-  # mount MyComponent.new
-  # ```
-  @[Deprecated("Use `#m` instead. Example: m(MyComponent, arg1: 123)")]
-  def mount(component : Lucky::BaseComponent) : Nil
-    print_component_comment(component.class) do
-      component.view(view).render
-    end
-  end
-
-  # Appends the `component` to the view. Takes a block, and yields the
-  # args passed to the component.
-  #
-  # When `Lucky::HTMLPage.settings.render_component_comments` is
-  # set to `true`, it will render HTML comments showing where the component
-  # starts and ends.
-  #
-  # ```
-  # mount MyComponent.new("jane") do |name|
-  #   text name.upcase
-  # end
-  # ```
-  @[Deprecated("Use `#m` instead. Example: m(MyComponent, arg1: 123) do/end")]
-  def mount(component : Lucky::BaseComponent) : Nil
-    print_component_comment(component.class) do
-      component.view(view).render do |*yield_args|
-        yield *yield_args
-      end
-    end
-  end
-
-  # Appends the `component` to the view.
-  #
-  # When `Lucky::HTMLPage.settings.render_component_comments` is
-  # set to `true`, it will render HTML comments showing where the component
-  # starts and ends.
-  #
-  # ```
   # m(MyComponent)
   # m(MyComponent, with_args: 123)
   # ```
+  @[Deprecated("Use `#mount` instead. Example: mount(MyComponent, arg1: 123)")]
   def m(component : Lucky::BaseComponent.class, *args, **named_args) : Nil
     print_component_comment(component) do
       component.new(*args, **named_args).view(view).render
@@ -64,7 +28,44 @@ module Lucky::MountComponent
   #   text name.upcase
   # end
   # ```
+  @[Deprecated("Use `#mount` instead. Example: mount(MyComponent, arg1: 123) do/end")]
   def m(component : Lucky::BaseComponent.class, *args, **named_args) : Nil
+    print_component_comment(component) do
+      component.new(*args, **named_args).view(view).render do |*yield_args|
+        yield *yield_args
+      end
+    end
+  end
+
+  # Appends the `component` to the view.
+  #
+  # When `Lucky::HTMLPage.settings.render_component_comments` is
+  # set to `true`, it will render HTML comments showing where the component
+  # starts and ends.
+  #
+  # ```
+  # mount(MyComponent)
+  # mount(MyComponent, with_args: 123)
+  # ```
+  def mount(component : Lucky::BaseComponent.class, *args, **named_args) : Nil
+    print_component_comment(component) do
+      component.new(*args, **named_args).view(view).render
+    end
+  end
+
+  # Appends the `component` to the view. Takes a block, and yields the
+  # args passed to the component.
+  #
+  # When `Lucky::HTMLPage.settings.render_component_comments` is
+  # set to `true`, it will render HTML comments showing where the component
+  # starts and ends.
+  #
+  # ```
+  # mount(MyComponent, name: "Jane") do |name|
+  #   text name.upcase
+  # end
+  # ```
+  def mount(component : Lucky::BaseComponent.class, *args, **named_args) : Nil
     print_component_comment(component) do
       component.new(*args, **named_args).view(view).render do |*yield_args|
         yield *yield_args

--- a/src/lucky/paginator/backend_helpers.cr
+++ b/src/lucky/paginator/backend_helpers.cr
@@ -22,7 +22,7 @@ module Lucky::Paginator::BackendHelpers
   #
   #   def content
   #     # Render 'users' like normal
-  #     m Lucky::Paginator::SimpleNav, @pages
+  #     mount Lucky::Paginator::SimpleNav, @pages
   #   end
   # end
   # ```
@@ -62,7 +62,7 @@ module Lucky::Paginator::BackendHelpers
   #
   #   def content
   #     # Render pagination links for the 'items' Array
-  #     m Lucky::Paginator::SimpleNav, @pages
+  #     mount Lucky::Paginator::SimpleNav, @pages
   #   end
   # end
   # ```

--- a/tasks/gen/templates/resource/components/{{folder_name}}/form_fields.cr.ecr
+++ b/tasks/gen/templates/resource/components/{{folder_name}}/form_fields.cr.ecr
@@ -3,7 +3,7 @@ class <%= pluralized_name %>::FormFields < BaseComponent
 
   def render
     <%- columns.each_with_index do |column, index| -%>
-    m Shared::Field, operation.<%= column.name %><% if index.zero? %>, &.text_input(autofocus: "true")<% end %>
+    mount Shared::Field, operation.<%= column.name %><% if index.zero? %>, &.text_input(autofocus: "true")<% end %>
     <%- end -%>
   end
 end

--- a/tasks/gen/templates/resource/pages/{{folder_name}}/edit_page.cr.ecr
+++ b/tasks/gen/templates/resource/pages/{{folder_name}}/edit_page.cr.ecr
@@ -12,7 +12,7 @@ class <%= pluralized_name %>::EditPage < MainLayout
   def render_<%= underscored_resource %>_form(op)
     form_for <%= pluralized_name %>::Update.with(@<%= underscored_resource %>.id) do
       # Edit fields in src/components/<%= folder_name %>/form_fields.cr
-      m <%= pluralized_name %>::FormFields, op
+      mount <%= pluralized_name %>::FormFields, op
 
       submit "Update", data_disable_with: "Updating..."
     end

--- a/tasks/gen/templates/resource/pages/{{folder_name}}/new_page.cr.ecr
+++ b/tasks/gen/templates/resource/pages/{{folder_name}}/new_page.cr.ecr
@@ -10,7 +10,7 @@ class <%= pluralized_name %>::NewPage < MainLayout
   def render_<%= underscored_resource %>_form(op)
     form_for <%= pluralized_name %>::Create do
       # Edit fields in src/components/<%= folder_name %>/form_fields.cr
-      m <%= pluralized_name %>::FormFields, op
+      mount <%= pluralized_name %>::FormFields, op
 
       submit "Save", data_disable_with: "Saving..."
     end


### PR DESCRIPTION
## Background and context
- Initial implementation was named `mount`, and had a signature of: `mount MyComponent.new(name: "Test")`
- Rename of `mount` -> `m` occurred, which also changed the method signature to: `m MyComponent, name: "Test"`
- #1221 opened after several issue discussions about which direction to take, deciding to revert the rename but maintain the new signature.

## Purpose
This PR renames `m` -> `mount`, retains the method signature as-is, and removes the old signature completely.

Closes #1221 

## Description
I believe I caught everything necessary. I used the regular expressions `\bm[\s(]+[A-Z]` to locate the items that needed to be changed. The only things I'd call out that need explicit review:
- I wasn't sure how to handle the old signature. Do we want deprecation of `m`, `mount` with the old signature, or do we just revert to `mount` with the new signature to get any confusion sorted during the next version bump?
- I wasn't sure whether updating the `UPGRADE.md` file was allowed, but it seemed prudent to let anyone migrating from 0.22 -> 0.23 know that they don't *really* need to rename `mount` -> `m`.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
