### PR TITLE
Update Lucky gen.model to accept nilable types

### DIFF
--- a/spec/tasks/gen/model_spec.cr
+++ b/spec/tasks/gen/model_spec.cr
@@ -31,7 +31,7 @@ describe Gen::Model do
       Gen::Migration.silence_output do
         io = IO::Memory.new
         model_name = "ContactInfo"
-        ARGV.push(model_name, "name:String", "contacted_at:Time")
+        ARGV.push(model_name, "name:String", "notes:String?", "contacted_at:Time")
 
         Gen::Model.new.call(io)
 
@@ -39,11 +39,15 @@ describe Gen::Model do
           "./src/models/contact_info.cr": "table"
         should_create_files_with_contents io,
           "./src/models/contact_info.cr": "column name : String",
-          "./src/operations/save_contact_info.cr": "# permit_columns name, contacted_at"
+          "./src/operations/save_contact_info.cr": "# permit_columns name, notes, contacted_at"
+        should_create_files_with_contents io,
+          "./src/models/contact_info.cr": "column notes : String?"
         should_create_files_with_contents io,
           "./src/models/contact_info.cr": "class ContactInfo < BaseModel",
           "./src/operations/save_contact_info.cr": "class SaveContactInfo < ContactInfo::SaveOperation",
           "./src/queries/contact_info_query.cr": "class ContactInfoQuery < ContactInfo::BaseQuery"
+        should_generate_migration named: "create_contact_infos.cr",
+          with: "add notes : String?"
         should_generate_migration named: "create_contact_infos.cr",
           with: "add contacted_at : Time"
       end
@@ -56,8 +60,9 @@ describe Gen::Model do
         bad_int_column = "int_column:integer"
         bad_text_column = "text_column:text"
         good_string_column = "good_column:String"
+        good_optional_string_column = "good_optional_column:String?"
         io = IO::Memory.new
-        ARGV.push("ModelName", bad_int_column, bad_text_column, good_string_column)
+        ARGV.push("ModelName", bad_int_column, bad_text_column, good_string_column, good_optional_string_column)
 
         Gen::Model.new.call(io)
 
@@ -66,6 +71,7 @@ describe Gen::Model do
         io.to_s.should contain(bad_int_column)
         io.to_s.should contain(bad_text_column)
         io.to_s.should_not contain(good_string_column)
+        io.to_s.should_not contain(good_optional_string_column)
       end
     end
 

--- a/spec/tasks/gen/resource_spec.cr
+++ b/spec/tasks/gen/resource_spec.cr
@@ -7,7 +7,7 @@ describe Gen::Resource::Browser do
   it "generates actions, model, operation and query" do
     with_cleanup do
       Gen::Migration.silence_output do
-        io = generate Gen::Resource::Browser, "User", "name:String", "signed_up:Time"
+        io = generate Gen::Resource::Browser, "User", "name:String", "notes:String?", "signed_up:Time"
 
         should_create_files_with_contents io,
           "./src/actions/users/index.cr": "class Users::Index < BrowserAction",
@@ -33,9 +33,11 @@ describe Gen::Resource::Browser do
           "./src/queries/user_query.cr": "class UserQuery < User::BaseQuery",
           "./src/operations/save_user.cr": "class SaveUser < User::SaveOperation"
         should_create_files_with_contents io,
-          "./src/operations/save_user.cr": "permit_columns name, signed_up"
+          "./src/operations/save_user.cr": "permit_columns name, notes, signed_up"
         should_generate_migration named: "create_users.cr"
+        should_generate_migration named: "create_users.cr", with: "add name : String"
         should_generate_migration named: "create_users.cr", with: "add signed_up : Time"
+        should_generate_migration named: "create_users.cr", with: "add notes : String?"
         io.to_s.should contain "at: #{"/users".colorize.green}"
       end
     end
@@ -47,8 +49,9 @@ describe Gen::Resource::Browser do
         bad_int_column = "int_column:integer"
         bad_text_column = "text_column:text"
         good_string_column = "good_column:String"
+        good_optional_string_column = "good_optional_column:String?"
         io = IO::Memory.new
-        ARGV.push("ModelName", bad_int_column, bad_text_column, good_string_column)
+        ARGV.push("ModelName", bad_int_column, bad_text_column, good_string_column, good_optional_string_column)
 
         Gen::Model.new.call(io)
 
@@ -57,6 +60,7 @@ describe Gen::Resource::Browser do
         io.to_s.should contain(bad_int_column)
         io.to_s.should contain(bad_text_column)
         io.to_s.should_not contain(good_string_column)
+        io.to_s.should_not contain(good_optional_string_column)
       end
     end
 

--- a/tasks/gen/mixins/migration_with_columns.cr
+++ b/tasks/gen/mixins/migration_with_columns.cr
@@ -46,7 +46,7 @@ module Gen::Mixins::MigrationWithColumns
     column_definitions.reject! do |column_definition|
       column_parts = parse_definition(column_definition)
       column_name = column_parts.first
-      column_type = column_parts.last
+      column_type = column_parts.last.strip("?")
       column_parts.size == 2 &&
         column_name == column_name.underscore &&
         SUPPORTED_TYPES.includes?(column_type)

--- a/tasks/gen/model.cr
+++ b/tasks/gen/model.cr
@@ -27,7 +27,7 @@ class Gen::Model < LuckyCli::Task
 
     Example:
 
-      lucky gen.model Project title:String completed:Bool priority:Int32
+      lucky gen.model Project title:String description:String? completed:Bool priority:Int32
     TEXT
   end
 

--- a/tasks/gen/resource/browser.cr
+++ b/tasks/gen/resource/browser.cr
@@ -26,7 +26,7 @@ class Gen::Resource::Browser < LuckyCli::Task
 
     Example:
 
-      lucky gen.resource.browser Project title:String completed:Bool priority:Int32
+      lucky gen.resource.browser Project title:String description:String? completed:Bool priority:Int32
     TEXT
   end
 


### PR DESCRIPTION
## Purpose
Closes #1217 
Allows users to generate models and browser resources with optional (nilable) columns like `lucky gen.model User name:String notes:String?`.

## Description
- Updated gen.model test to capture generating a model with a nilable column.
- Updated gen.resource.browser to capture generating a resource with a nilable column.
- Updated the migration with columns mixin to strip `?` from types before comparing to allowed list.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
