### PR TITLE
Adding the UrlHelpers include in to the HTMLBuilder

### DIFF
--- a/spec/lucky/url_helpers_spec.cr
+++ b/spec/lucky/url_helpers_spec.cr
@@ -160,7 +160,6 @@ end
 
 private class TestPage
   include Lucky::HTMLPage
-  include Lucky::UrlHelpers
 end
 
 class Pages::Index < TestAction

--- a/src/lucky/html_builder.cr
+++ b/src/lucky/html_builder.cr
@@ -16,6 +16,7 @@ module Lucky::HTMLBuilder
   include Lucky::NumberToCurrency
   include Lucky::TextHelpers
   include Lucky::HTMLTextHelpers
+  include Lucky::UrlHelpers
   include Lucky::TimeHelpers
   include Lucky::ForgeryProtectionHelpers
   include Lucky::MountComponent


### PR DESCRIPTION
## Purpose
Fixes #1218

## Description
Both pages and components include the `Lucky::HTMLBuilder` module. By including the `UrlHelpers` here, `current_page?` will be available in both pages and components. Before this you had to manually include the UrlHelpers to use the `current_page?` method.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
