### PR TITLE
Adding the optional routing in the to core

### DIFF
--- a/spec/lucky/action_route_params_spec.cr
+++ b/spec/lucky/action_route_params_spec.cr
@@ -2,18 +2,33 @@ require "../spec_helper"
 
 include ContextHelper
 
-private class TestAction < TestAction
+private class TestParamAction < TestAction
   get "/test/:param_1/:param_2" do
+    plain_text "test"
+  end
+end
+
+private class TestOptionalParamAction < TestAction
+  get "/complex_posts/:required/?:optional_1/?:optional_2" do
     plain_text "test"
   end
 end
 
 describe "Automatically generated param helpers" do
   it "generates helpers for all route params" do
-    action = TestAction.new(build_context, {"param_1" => "param_1_value", "param_2" => "param_2_value"})
+    action = TestParamAction.new(build_context, {"param_1" => "param_1_value", "param_2" => "param_2_value"})
     action.param_1.should eq "param_1_value"
     action.param_2.should eq "param_2_value"
     typeof(action.param_1).should eq String
     typeof(action.param_2).should eq String
+  end
+
+  it "generates helpers for optional route params" do
+    action = TestOptionalParamAction.new(build_context, {"required" => "1", "optional_1" => "2"})
+    action.required.should eq "1"
+    action.optional_1.should eq "2"
+    action.optional_2.should eq nil
+    typeof(action.optional_1).should eq String?
+    typeof(action.optional_2).should eq String?
   end
 end

--- a/spec/lucky/action_spec.cr
+++ b/spec/lucky/action_spec.cr
@@ -143,6 +143,12 @@ class ParamsWithDefaultParamsLast < TestAction
   end
 end
 
+class OptionalRouteParams::Index < TestAction
+  get "/complex_posts/:required/?:optional_1/?:optional_2" do
+    plain_text "test"
+  end
+end
+
 describe Lucky::Action do
   it "has a url helper" do
     Lucky::RouteHelper.temp_config(base_uri: "example.com") do
@@ -160,6 +166,14 @@ describe Lucky::Action do
     it "returns url with (required) path params" do
       Lucky::RouteHelper.temp_config(base_uri: "example.com") do
         Tests::Edit.url_without_query_params(1).should eq "example.com/tests/1/edit"
+      end
+    end
+
+    it "returns url with optional path params" do
+      Lucky::RouteHelper.temp_config(base_uri: "example.com") do
+        OptionalRouteParams::Index.url_without_query_params(1).should eq "example.com/complex_posts/1"
+        OptionalRouteParams::Index.url_without_query_params(1, 2).should eq "example.com/complex_posts/1/2"
+        OptionalRouteParams::Index.url_without_query_params(1, 2, 3).should eq "example.com/complex_posts/1/2/3"
       end
     end
   end
@@ -207,6 +221,20 @@ describe Lucky::Action do
       assert_route_added? Lucky::Route.new :trace, "/so_custom", CustomRoutes::Trace
       assert_route_added? Lucky::Route.new :delete, "/so_custom", CustomRoutes::Delete
       assert_route_added? Lucky::Route.new :options, "/so_custom", CustomRoutes::Match
+    end
+
+    it "works with optional routing paths" do
+      route = OptionalRouteParams::Index.with(required: "1")
+      route.should eq Lucky::RouteHelper.new(:get, "/complex_posts/1")
+      route.path.should eq "/complex_posts/1"
+
+      route2 = OptionalRouteParams::Index.with(required: "1", optional_1: "2")
+      route2.should eq Lucky::RouteHelper.new(:get, "/complex_posts/1/2")
+      route2.path.should eq "/complex_posts/1/2"
+
+      route3 = OptionalRouteParams::Index.with(required: "1", optional_1: "2", optional_2: "3")
+      route3.should eq Lucky::RouteHelper.new(:get, "/complex_posts/1/2/3")
+      route3.path.should eq "/complex_posts/1/2/3"
     end
   end
 

--- a/spec/lucky/router_spec.cr
+++ b/spec/lucky/router_spec.cr
@@ -15,4 +15,12 @@ describe Lucky::Router do
     Lucky::Router.find_action(:head, "/test").should_not be_nil
     Lucky::Router.find_action("head", "/test").should_not be_nil
   end
+
+  it "finds the route with an optional parts" do
+    Lucky::Router.add :get, "/complex_posts/:required/?:optional_1/?:optional_2", Lucky::Action
+
+    Lucky::Router.find_action(:get, "/complex_posts/1/2/3").should_not be_nil
+    Lucky::Router.find_action(:get, "/complex_posts/1/2").should_not be_nil
+    Lucky::Router.find_action(:get, "/complex_posts/1").should_not be_nil
+  end
 end


### PR DESCRIPTION
## Purpose
Optional path params were added in to the router https://github.com/luckyframework/lucky_router/pull/18 but there was never a test done to see if Lucky core needed any updates. I added a spec to see if we needed to do anything, and it doesn't look like it.

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
