### PR TITLE
removes @ from various page templates

### DIFF
--- a/tasks/gen/templates/resource/pages/{{folder_name}}/edit_page.cr.ecr
+++ b/tasks/gen/templates/resource/pages/{{folder_name}}/edit_page.cr.ecr
@@ -1,16 +1,16 @@
 class <%= pluralized_name %>::EditPage < MainLayout
   needs operation : <%= operation_class %>
   needs <%= underscored_resource %> : <%= resource %>
-  quick_def page_title, "Edit <%= resource %> with id: #{@<%= underscored_resource %>.id}"
+  quick_def page_title, "Edit <%= resource %> with id: #{<%= underscored_resource %>.id}"
 
   def content
     link "Back to all <%= pluralized_name %>", <%= pluralized_name %>::Index
-    h1 "Edit <%= resource %> with id: #{@<%= underscored_resource %>.id}"
-    render_<%= underscored_resource %>_form(@operation)
+    h1 "Edit <%= resource %> with id: #{<%= underscored_resource %>.id}"
+    render_<%= underscored_resource %>_form(operation)
   end
 
   def render_<%= underscored_resource %>_form(op)
-    form_for <%= pluralized_name %>::Update.with(@<%= underscored_resource %>.id) do
+    form_for <%= pluralized_name %>::Update.with(<%= underscored_resource %>.id) do
       # Edit fields in src/components/<%= folder_name %>/form_fields.cr
       mount <%= pluralized_name %>::FormFields, op
 

--- a/tasks/gen/templates/resource/pages/{{folder_name}}/index_page.cr.ecr
+++ b/tasks/gen/templates/resource/pages/{{folder_name}}/index_page.cr.ecr
@@ -10,7 +10,7 @@ class <%= pluralized_name %>::IndexPage < MainLayout
 
   def render_<%= pluralized_name.underscore %>
     ul do
-      @<%= pluralized_name.underscore %>.each do |<%= underscored_resource %>|
+      <%= pluralized_name.underscore %>.each do |<%= underscored_resource %>|
         li do
           link <%= underscored_resource %>.<%= columns.first.name %>, <%= pluralized_name %>::Show.with(<%= underscored_resource %>)
         end

--- a/tasks/gen/templates/resource/pages/{{folder_name}}/new_page.cr.ecr
+++ b/tasks/gen/templates/resource/pages/{{folder_name}}/new_page.cr.ecr
@@ -4,7 +4,7 @@ class <%= pluralized_name %>::NewPage < MainLayout
 
   def content
     h1 "New <%= resource %>"
-    render_<%= underscored_resource %>_form(@operation)
+    render_<%= underscored_resource %>_form(operation)
   end
 
   def render_<%= underscored_resource %>_form(op)

--- a/tasks/gen/templates/resource/pages/{{folder_name}}/show_page.cr.ecr
+++ b/tasks/gen/templates/resource/pages/{{folder_name}}/show_page.cr.ecr
@@ -1,20 +1,20 @@
 class <%= pluralized_name %>::ShowPage < MainLayout
   needs <%= underscored_resource %> : <%= resource %>
-  quick_def page_title, "<%= resource %> with id: #{@<%= underscored_resource %>.id}"
+  quick_def page_title, "<%= resource %> with id: #{<%= underscored_resource %>.id}"
 
   def content
     link "Back to all <%= pluralized_name %>", <%= pluralized_name %>::Index
-    h1 "<%= resource %> with id: #{@<%= underscored_resource %>.id}"
+    h1 "<%= resource %> with id: #{<%= underscored_resource %>.id}"
     render_actions
     render_<%= underscored_resource %>_fields
   end
 
   def render_actions
     section do
-      link "Edit", <%= pluralized_name %>::Edit.with(@<%= underscored_resource %>.id)
+      link "Edit", <%= pluralized_name %>::Edit.with(<%= underscored_resource %>.id)
       text " | "
       link "Delete",
-        <%= pluralized_name %>::Delete.with(@<%= underscored_resource %>.id),
+        <%= pluralized_name %>::Delete.with(<%= underscored_resource %>.id),
         data_confirm: "Are you sure?"
     end
   end
@@ -24,7 +24,7 @@ class <%= pluralized_name %>::ShowPage < MainLayout
       <%- columns.each do |column| -%>
       li do
         text "<%= column.name %>: "
-        strong @<%= underscored_resource %>.<%= column.name %>.to_s
+        strong <%= underscored_resource %>.<%= column.name %>.to_s
       end
       <%- end -%>
     end


### PR DESCRIPTION
## Purpose
removes @ from various page templates

## Description
See #1230

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - ~~All specs are formatted with `crystal tool format spec src`~~
* [x] - ~~Inline documentation has been added and/or updated~~
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
