### PR TITLE
Provide helpful error when dashes are used in path variables

### DIFF
--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -196,6 +196,9 @@ module Lucky::Routable
     {% optional_path_params = path_parts.select(&.starts_with?("?:")) %}
 
     {% for param in path_params %}
+      {% if param.includes?("-") %}
+        {% param.raise "Path variables must only use underscores. Use #{param.gsub(/-/, "_")} instead of #{param}." %}
+      {% end %}
       {% part = param.gsub(/:/, "").id %}
       def {{ part }} : String
         params.get(:{{ part }})
@@ -203,6 +206,9 @@ module Lucky::Routable
     {% end %}
 
     {% for param in optional_path_params %}
+      {% if param.includes?("-") %}
+        {% param.raise "Optional path variables must only use underscores. Use #{param.gsub(/-/, "_")} instead of #{param}." %}
+      {% end %}
       {% part = param.gsub(/^\?:/, "").id %}
       def {{ part }} : String?
         params.get?(:{{ part }})


### PR DESCRIPTION
## Purpose

The error message given when using a dash in a path variable is unhelpful to solving the issue. Changing the message allows users to fix the issue. 

Fixes #1235 

## Description

### Before

```
There was a problem expanding macro 'add_route'

Code in macro 'match'

 5 | add_route(:get, "/test/:param-1/:param_2", TestParamAction)
     ^
Called macro defined in src/lucky/routable.cr:191:3

 191 | macro add_route(method, path, action)

Which expanded to:

 >  7 |     
 >  8 |       
 >  9 |       def param-1 : String
                      ^
Error: unexpected token: -1
```

### After

```
Showing last frame. Use --error-trace for full trace.

There was a problem expanding macro 'get'

Code in spec/lucky/action_route_params_spec.cr:6:3

 6 | get "/test/:param-1/:param_2" do
     ^
Called macro defined in macro 'macro_4475664912'

 19 | macro get(path)

Which expanded to:

 > 1 | match(:get, "/test/:param-1/:param_2") do
       ^
Error: Path variables must only use underscores. Use ":param_1" instead of ":param-1".
```

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [ ] - Lucky builds on docker with `./script/setup`
* [ ] - All builds and specs pass on docker with `./script/test`
