### PR TITLE
Add query param to path even if default value is passed

### DIFF
--- a/spec/lucky/action_spec.cr
+++ b/spec/lucky/action_spec.cr
@@ -350,6 +350,10 @@ describe Lucky::Action do
       OptionalParams::Index.path(page: 7, with_default: "/other").should eq "/optional_params?page=7&with_default=%2Fother"
     end
 
+    it "is added to the path even if the value matches default" do
+      OptionalParams::Index.path(with_default: "default").should eq "/optional_params?with_default=default"
+    end
+
     it "is added as optional argument to the route" do
       OptionalParams::Index.route(page: 7).should eq Lucky::RouteHelper.new(:get, "/optional_params?page=7")
       OptionalParams::Index.route(page: 7, with_default: "/other").should eq Lucky::RouteHelper.new(:get, "/optional_params?page=7&with_default=%2Fother")

--- a/spec/lucky/action_spec.cr
+++ b/spec/lucky/action_spec.cr
@@ -350,8 +350,12 @@ describe Lucky::Action do
       OptionalParams::Index.path(page: 7, with_default: "/other").should eq "/optional_params?page=7&with_default=%2Fother"
     end
 
-    it "is added to the path even if the value matches default" do
+    it "is added to the path if the value matches default and is explicitly given" do
       OptionalParams::Index.path(with_default: "default").should eq "/optional_params?with_default=default"
+    end
+
+    it "is not added to the path param has default value but not given" do
+      OptionalParams::Index.path.should eq "/optional_params"
     end
 
     it "is added as optional argument to the route" do

--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -243,6 +243,7 @@ module Lucky::Routable
     end
 
     def self.route(
+    # required path variables
     {% for param in path_params %}
       {{ param.gsub(/:/, "").id }},
     {% end %}
@@ -253,13 +254,19 @@ module Lucky::Routable
     {% params_without_defaults = PARAM_DECLARATIONS.reject do |decl|
          params_with_defaults.includes? decl
        end %}
+
+    # params without a default value, could be nilable
     {% for param in params_without_defaults %}
       {% is_nilable_type = param.type.is_a?(Union) %}
       {{ param }}{% if is_nilable_type %} = nil{% end %},
     {% end %}
+
+    # params with a default value set are always nilable
     {% for param in params_with_defaults %}
       {{ param.var }} = nil,
     {% end %}
+
+    # optional path variables are nilable
     {% for param in optional_path_params %}
       {{ param.gsub(/^\?:/, "").id }} : String? = nil,
     {% end %}
@@ -275,6 +282,7 @@ module Lucky::Routable
       )
       query_params = {} of String => String
       {% for param in PARAM_DECLARATIONS %}
+        # add query param if given and not nil
         query_params["{{ param.var }}"] = {{ param.var }}.to_s unless {{ param.var }}.nil?
       {% end %}
       unless query_params.empty?


### PR DESCRIPTION
## Purpose

Fixes #1201 

When attempting to get a path, if you happened to pass in a value to a query param that matched the default value, it was not added to the resulting url.

## Description

This change removes all references to the default value of a param when building a path.

Here is a comparison of the route method output. It is formatted and has comments removed.

### Before

```crystal
def self.route(
  no_default : String,
  has_default : String = "default",
  has_nil_default : String | ::Nil = nil,
  anchor : String? = nil
) : Lucky::RouteHelper
  path = path_from_parts()
  query_params = {} of String => String
  param_is_default_or_nil = has_default == "default"
  unless param_is_default_or_nil
    query_params["has_default"] = has_default.to_s
  end
  param_is_default_or_nil = has_nil_default == nil
  unless param_is_default_or_nil
    query_params["has_nil_default"] = has_nil_default.to_s
  end
  param_is_default_or_nil = no_default == nil
  unless param_is_default_or_nil
    query_params["no_default"] = no_default.to_s
  end

  unless query_params.empty?
    path += "?#{HTTP::Params.encode(query_params)}"
  end

  anchor.try do |value|
    path += "#"
    path += URI.encode_www_form(value)
  end

  Lucky::RouteHelper.new :get, path
end
```

### After

```crystal
def self.route(
  no_default : String,
  has_default = nil,
  has_nil_default = nil,
  anchor : String? = nil
) : Lucky::RouteHelper
  path = path_from_parts()
  query_params = {} of String => String
  query_params["has_default"] = has_default.to_s unless has_default.nil?
  query_params["has_nil_default"] = has_nil_default.to_s unless has_nil_default.nil?
  query_params["no_default"] = no_default.to_s unless no_default.nil?
  
  unless query_params.empty?
    path += "?#{HTTP::Params.encode(query_params)}"
  end

  anchor.try do |value|
    path += "#"
    path += URI.encode_www_form(value)
  end

  Lucky::RouteHelper.new :get, path
end
```

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
