### PR TITLE
[DO NOT MERGE] BaseComponents do not take in arbitrary initialize arguments

### DIFF
--- a/src/lucky/html_builder.cr
+++ b/src/lucky/html_builder.cr
@@ -64,7 +64,9 @@ module Lucky::HTMLBuilder
           {% has_default = value || value == false || value == nil %}
           @{{ var.id }} : {{ type }}{% if has_default %} = {{ value }}{% end %},
         {% end %}
-        **unused_exposures
+        {% unless @type < Lucky::BaseComponent %}
+          **unused_exposures
+        {% end %}
         )
       end
     {% end %}


### PR DESCRIPTION
## Purpose

Fixes #805 

## Description

Components will now fail to compile if passed arguments that it does not expect to have. This is different than pages which can still be passed anything and will ignore it.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
