### PR TITLE
Don't allow external referers in redirect_back unless allowed

### DIFF
--- a/spec/lucky/action_redirect_spec.cr
+++ b/spec/lucky/action_redirect_spec.cr
@@ -37,32 +37,59 @@ describe Lucky::Action do
     should_redirect(action, to: "/somewhere", status: 301)
   end
 
-  it "redirects back" do
-    request = build_request("POST")
-    request.headers["Referer"] = "https://www.example.com/coming/from"
-    action = RedirectAction.new(build_context(request), params)
-    action.redirect_back fallback: "/fallback"
-    should_redirect(action, to: "https://www.example.com/coming/from", status: 302)
+  describe "#redirect_back" do
+    it "redirects to referer if present" do
+      Lucky::RouteHelper.temp_config(base_uri: "example.com") do
+        request = build_request("POST")
+        request.headers["Referer"] = "https://www.example.com/coming/from"
+        action = RedirectAction.new(build_context(request), params)
+        action.redirect_back fallback: "/fallback"
+        should_redirect(action, to: "https://www.example.com/coming/from", status: 302)
+      end
+    end
 
-    action = RedirectAction.new(build_context, params)
-    action.redirect_back fallback: "/fallback"
-    should_redirect(action, to: "/fallback", status: 302)
+    it "redirects to fallback if referer missing" do
+      request = build_request("POST")
+      action = RedirectAction.new(build_context(request), params)
+      action.redirect_back fallback: "/fallback"
+      should_redirect(action, to: "/fallback", status: 302)
 
-    action = RedirectAction.new(build_context, params)
-    action.redirect_back fallback: RedirectAction.route
-    should_redirect(action, to: RedirectAction.path, status: 302)
+      action = RedirectAction.new(build_context, params)
+      action.redirect_back fallback: RedirectAction.route
+      should_redirect(action, to: RedirectAction.path, status: 302)
 
-    action = RedirectAction.new(build_context, params)
-    action.redirect_back fallback: RedirectAction
-    should_redirect(action, to: RedirectAction.path, status: 302)
+      action = RedirectAction.new(build_context, params)
+      action.redirect_back fallback: RedirectAction
+      should_redirect(action, to: RedirectAction.path, status: 302)
 
-    action = RedirectAction.new(build_context, params)
-    action.redirect_back fallback: RedirectAction, status: HTTP::Status::MOVED_PERMANENTLY
-    should_redirect(action, to: RedirectAction.path, status: 301)
+      action = RedirectAction.new(build_context, params)
+      action.redirect_back fallback: RedirectAction, status: HTTP::Status::MOVED_PERMANENTLY
+      should_redirect(action, to: RedirectAction.path, status: 301)
 
-    action = RedirectAction.new(build_context, params)
-    action.redirect_back fallback: RedirectAction, status: 301
-    should_redirect(action, to: RedirectAction.path, status: 301)
+      action = RedirectAction.new(build_context, params)
+      action.redirect_back fallback: RedirectAction, status: 301
+      should_redirect(action, to: RedirectAction.path, status: 301)
+    end
+
+    it "redirects to fallback if referer is external" do
+      Lucky::RouteHelper.temp_config(base_uri: "example.com") do
+        request = build_request("POST")
+        request.headers["Referer"] = "https://www.external.com/coming/from"
+        action = RedirectAction.new(build_context(request), params)
+        action.redirect_back fallback: "/fallback"
+        should_redirect(action, to: "/fallback", status: 302)
+      end
+    end
+
+    it "redirects to referer if referer is external and allowed" do
+      Lucky::RouteHelper.temp_config(base_uri: "example.com") do
+        request = build_request("POST")
+        request.headers["Referer"] = "https://www.external.com/coming/from"
+        action = RedirectAction.new(build_context(request), params)
+        action.redirect_back fallback: "/fallback", allow_external: true
+        should_redirect(action, to: "https://www.external.com/coming/from", status: 302)
+      end
+    end
   end
 
   it "turbolinks redirects after a XHR POST form submission" do

--- a/spec/lucky/action_redirect_spec.cr
+++ b/spec/lucky/action_redirect_spec.cr
@@ -39,13 +39,11 @@ describe Lucky::Action do
 
   describe "#redirect_back" do
     it "redirects to referer if present" do
-      Lucky::RouteHelper.temp_config(base_uri: "example.com") do
-        request = build_request("POST")
-        request.headers["Referer"] = "https://www.example.com/coming/from"
-        action = RedirectAction.new(build_context(request), params)
-        action.redirect_back fallback: "/fallback"
-        should_redirect(action, to: "https://www.example.com/coming/from", status: 302)
-      end
+      request = build_request("POST")
+      request.headers["Referer"] = "https://example.com/coming/from"
+      action = RedirectAction.new(build_context(request), params)
+      action.redirect_back fallback: "/fallback"
+      should_redirect(action, to: "https://example.com/coming/from", status: 302)
     end
 
     it "redirects to fallback if referer missing" do
@@ -72,23 +70,19 @@ describe Lucky::Action do
     end
 
     it "redirects to fallback if referer is external" do
-      Lucky::RouteHelper.temp_config(base_uri: "example.com") do
-        request = build_request("POST")
-        request.headers["Referer"] = "https://www.external.com/coming/from"
-        action = RedirectAction.new(build_context(request), params)
-        action.redirect_back fallback: "/fallback"
-        should_redirect(action, to: "/fallback", status: 302)
-      end
+      request = build_request("POST")
+      request.headers["Referer"] = "https://external.com/coming/from"
+      action = RedirectAction.new(build_context(request), params)
+      action.redirect_back fallback: "/fallback"
+      should_redirect(action, to: "/fallback", status: 302)
     end
 
     it "redirects to referer if referer is external and allowed" do
-      Lucky::RouteHelper.temp_config(base_uri: "example.com") do
-        request = build_request("POST")
-        request.headers["Referer"] = "https://www.external.com/coming/from"
-        action = RedirectAction.new(build_context(request), params)
-        action.redirect_back fallback: "/fallback", allow_external: true
-        should_redirect(action, to: "https://www.external.com/coming/from", status: 302)
-      end
+      request = build_request("POST")
+      request.headers["Referer"] = "https://external.com/coming/from"
+      action = RedirectAction.new(build_context(request), params)
+      action.redirect_back fallback: "/fallback", allow_external: true
+      should_redirect(action, to: "https://external.com/coming/from", status: 302)
     end
   end
 

--- a/spec/support/context_helper.cr
+++ b/spec/support/context_helper.cr
@@ -9,6 +9,7 @@ module ContextHelper
   ) : HTTP::Request
     headers = HTTP::Headers.new
     headers.add("Content-Type", content_type)
+    headers.add("Host", "example.com")
     if fixed_length
       body = HTTP::FixedLengthContent.new(IO::Memory.new(body), body.size)
     end

--- a/src/lucky/redirectable.cr
+++ b/src/lucky/redirectable.cr
@@ -70,7 +70,7 @@ module Lucky::Redirectable
   # ```
   #
   # External referers are ignored by default.
-  # It is determined by comparing the referer header to the base uri specified in `config/route_helper.cr`.
+  # It is determined by comparing the referer header to the request host.
   # They can be explicitly allowed if necessary
   #
   # redirect_back fallback: "/home", allow_external: true
@@ -156,7 +156,7 @@ module Lucky::Redirectable
 
   private def allowed_host?(referer : String)
     if referer_host = URI.parse(referer).host
-      referer_host.ends_with?(Lucky::RouteHelper.settings.base_uri)
+      referer_host == request.host
     else
       false
     end


### PR DESCRIPTION
## Purpose

Fixes #1199 

## Description

As `redirect_back` worked before, any URL put in the Referer header would have worked. This is not the ideal situation because it could potentially send users somewhere outside the website they are on and leak information or provide a less than ideal experience. This change defaults `redirect_back` to not allow redirecting to external sites but can be configured to allow it if desired.

I heavily referenced [Rails' implementation](https://github.com/rails/rails/blob/97c3a5605bacd62e5a01872dfe5e5976cd982115/actionpack/lib/action_controller/metal/redirecting.rb#L90) for this.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
