### PR TITLE
Rename with_defaults to tag_defaults

### DIFF
--- a/spec/lucky/tag_defaults_spec.cr
+++ b/spec/lucky/tag_defaults_spec.cr
@@ -1,45 +1,45 @@
 require "../spec_helper"
 
-private class TestWithDefaultsPage
+private class TestTagDefaultsPage
   include Lucky::HTMLPage
 
   def render
-    with_defaults field: name_field, class: "form-control" do |html|
-      html.text_input
+    tag_defaults field: name_field, class: "form-control" do |tag_builder|
+      tag_builder.text_input
     end
 
-    with_defaults field: name_field, class: "form-control" do |html|
-      html.text_input placeholder: "Name please"
+    tag_defaults field: name_field, class: "form-control" do |tag_builder|
+      tag_builder.text_input placeholder: "Name please"
     end
 
-    with_defaults field: name_field, placeholder: "default" do |html|
-      html.text_input placeholder: "replace default"
+    tag_defaults field: name_field, placeholder: "default" do |tag_builder|
+      tag_builder.text_input placeholder: "replace default"
     end
 
-    with_defaults field: name_field, class: "default" do |html|
-      html.text_input append_class: "appended classes"
+    tag_defaults field: name_field, class: "default" do |tag_builder|
+      tag_builder.text_input append_class: "appended classes"
     end
 
-    with_defaults field: name_field, class: "default" do |html|
-      html.text_input replace_class: "replaced"
+    tag_defaults field: name_field, class: "default" do |tag_builder|
+      tag_builder.text_input replace_class: "replaced"
     end
 
     # No default 'class'
-    with_defaults field: name_field do |html|
-      html.text_input append_class: "appended-without-default"
+    tag_defaults field: name_field do |tag_builder|
+      tag_builder.text_input append_class: "appended-without-default"
     end
 
-    with_defaults field: name_field do |html|
-      html.text_input replace_class: "replaced-without-default"
+    tag_defaults field: name_field do |tag_builder|
+      tag_builder.text_input replace_class: "replaced-without-default"
     end
 
     # tags that have content
-    with_defaults class: "default" do |html|
-      html.div "text content"
+    tag_defaults class: "default" do |tag_builder|
+      tag_builder.div "text content"
     end
 
-    with_defaults class: "default" do |html|
-      html.div do
+    tag_defaults class: "default" do |tag_builder|
+      tag_builder.div do
         text "block content"
       end
     end
@@ -48,9 +48,9 @@ private class TestWithDefaultsPage
   end
 end
 
-describe "with_defaults" do
+describe "tag_defaults" do
   it "renders the component" do
-    contents = TestWithDefaultsPage.new(build_context).render.to_s
+    contents = TestTagDefaultsPage.new(build_context).render.to_s
 
     contents
       .should contain %(<input type="text" id="user_name" name="user:name" value="" class="form-control">)

--- a/src/lucky/html_builder.cr
+++ b/src/lucky/html_builder.cr
@@ -22,7 +22,7 @@ module Lucky::HTMLBuilder
   include Lucky::MountComponent
   include Lucky::HelpfulParagraphError
   include Lucky::RenderIfDefined
-  include Lucky::WithDefaults
+  include Lucky::TagDefaults
 
   abstract def view
 

--- a/src/lucky/tags/tag_defaults.cr
+++ b/src/lucky/tags/tag_defaults.cr
@@ -1,22 +1,22 @@
 # Set up defaults arguments for HTML tags.
 #
 # This is automatically included in Pages and Components.
-module Lucky::WithDefaults
+module Lucky::TagDefaults
   # This is typically used in components and helper methods to set up defaults for
   # reusable components.
   #
   # Example in a page or component:
   #
-  #    with_defaults field: form.email, class: "input" do |html|
-  #      html.email_input placeholder: "Email"
+  #    tag_defaults field: form.email, class: "input" do |tag_builder|
+  #      tag_builder.email_input placeholder: "Email"
   #    end
   #
   # Is the same as:
   #
   #     email_input field: form.email, class: "input", placeholder: "Email"
-  def with_defaults(**named_args)
-    OptionMerger.new(page_context: self, named_args: named_args).run do |html|
-      yield html
+  def tag_defaults(**named_args)
+    OptionMerger.new(page_context: self, named_args: named_args).run do |tag_builder|
+      yield tag_builder
     end
   end
 
@@ -41,16 +41,16 @@ module Lucky::WithDefaults
 
           Correct example:
 
-              with_defaults class: "default" do |html|
+              tag_defaults class: "default" do |tag_builder|
                 # Use 'replace_class' or 'append_class' here
-                html.div replace_class: "replaced"
+                tag_builder.div replace_class: "replaced"
               end
 
           Incorrect example:
 
-              with_defaults class: "default" do |html|
+              tag_defaults class: "default" do |tag_builder|
                 # Won't work with 'class'
-                html.div class: "replaced"
+                tag_builder.div class: "replaced"
               end
 
           -----------------


### PR DESCRIPTION
## Purpose
This PR aims to close #1252

I plan to open an accompanying PR for https://github.com/luckyframework/lucky_cli/issues/548 soon™️ 

## Description
Tackled in this PR:
- Renamed definition and spec file names
- Changed method call to `tag_defaults`, and yielded block to `tag_builder` everywhere
- Changed HtmlBuilder inclusion to reference new file name

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
