### PR TITLE
Add documentation badges to top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 [![Version](https://img.shields.io/github/tag/luckyframework/lucky.svg?maxAge=360&label=version)](https://github.com/luckyframework/lucky/releases/latest)
 [![License](https://img.shields.io/github/license/luckyframework/lucky.svg)](https://github.com/luckyframework/lucky/blob/master/LICENSE)
 
+[![API Documentation Website](https://img.shields.io/website?down_color=red&down_message=Offline&label=API%20Documentation&up_message=Online&url=https%3A%2F%2Fluckyframework.github.io%2Flucky%2F)](https://luckyframework.github.io/lucky)
+[![Lucky Guides Website](https://img.shields.io/website?down_color=red&down_message=Offline&label=Lucky%20Guides&up_message=Online&url=https%3A%2F%2Fluckyframework.org%2Fguides)](https://luckyframework.org/guides)
+
 [![Discord](https://img.shields.io/discord/743896265057632256)](https://discord.gg/HeqJUcb)
 
 The goal: prevent bugs, forget about most performance issues, and spend more


### PR DESCRIPTION
## Purpose

I have had a lot of trouble remembering the API documentation URL, and thought that both that and the guides website might be helpful badges to have on the main README!

Since the changes are so minimal it was easier to make a PR than an issue for discussion, but if y'all like the idea I'm happy to basically duplicate this code (changing the API doc endpoint) for our other repos like Avram. My feelings won't be hurt if this PR is closed, either :) 

## Description

This PR leverages shields.io, which was already used in the README, to add uptime checks on both the Guides and API documentation, as well as clickable links to each. Here's what the README looks like with this change:

![Screen Shot 2020-09-21 at 1 39 27 PM](https://user-images.githubusercontent.com/6677875/93801405-f39bbb80-fc0f-11ea-8797-26ac83911acf.png)

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
