### PR TITLE
Fix ForceSSLHandler not returning HSTS header over HTTPS

### DIFF
--- a/spec/lucky/force_ssl_handler_spec.cr
+++ b/spec/lucky/force_ssl_handler_spec.cr
@@ -4,48 +4,9 @@ require "http/server"
 include ContextHelper
 
 describe Lucky::ForceSSLHandler do
-  context "if using ssl" do
-    it "does nothing" do
-      context = build_context
-      context.request.headers["X-Forwarded-Proto"] = "https"
-
-      run_force_ssl_handler context
-
-      context.response.status_code.should eq 200
-      context.response.headers["Location"]?.should be_nil
-    end
-  end
-
-  context "if not using ssl" do
-    it "redirects to ssl version of the request" do
-      context = build_context(path: "/path")
-      context.request.headers["X-Forwarded-Proto"] = "http"
-      context.request.headers["Host"] = "example.com"
-
-      run_force_ssl_handler context
-
-      context.response.status_code.should eq 308
-      context.response.headers["Location"].should eq "https://example.com/path"
-    end
-
-    it "redirects using custom status" do
-      context = build_context(path: "/path")
-      context.request.headers["X-Forwarded-Proto"] = "http"
-      context.request.headers["Host"] = "example.com"
-
-      Lucky::ForceSSLHandler.temp_config(redirect_status: 302) do
-        run_force_ssl_handler context
-      end
-
-      context.response.status_code.should eq 302
-      context.response.headers["Location"].should eq "https://example.com/path"
-    end
-
-    it "does nothing if handler is disabled" do
-      context = build_context(path: "/path")
-      context.request.headers["X-Forwarded-Proto"] = "http"
-      context.request.headers["Host"] = "example.com"
-
+  context "when the handler is disabled" do
+    it "simply serves the request" do
+      context = build_ssl_context(ssl: false)
       Lucky::ForceSSLHandler.temp_config(enabled: false) do
         run_force_ssl_handler context
       end
@@ -53,24 +14,61 @@ describe Lucky::ForceSSLHandler do
       context.response.status_code.should eq 200
       context.response.headers["Location"]?.should be_nil
     end
+  end
 
-    it "allows setting Strict-Transport-Security" do
-      context = build_context(path: "/path")
+  context "when the handler is enabled" do
+    context "when the request is using SSL" do
+      context "when HSTS is not configured" do
+        it "simply serves the request" do
+          context = build_ssl_context(ssl: true)
+          run_force_ssl_handler context
 
-      with_strict_transport_security({max_age: 180.days, include_subdomains: false}) do
-        run_force_ssl_handler context
-        context.response.headers["Strict-Transport-Security"].should eq "max-age=15552000"
+          context.response.status_code.should eq 200
+          context.response.headers["Location"]?.should be_nil
+        end
       end
 
-      with_strict_transport_security({max_age: 180.days, include_subdomains: true}) do
+      context "when HSTS is configured" do
+        it "adds an appropriate Strict-Transport-Security header to the response" do
+          context = build_ssl_context(ssl: true)
+          with_strict_transport_security({max_age: 180.days, include_subdomains: false}) do
+            run_force_ssl_handler context
+            context.response.headers["Strict-Transport-Security"].should eq "max-age=15552000"
+          end
+
+          context = build_ssl_context(ssl: true)
+          with_strict_transport_security({max_age: 180.days, include_subdomains: true}) do
+            run_force_ssl_handler context
+            context.response.headers["Strict-Transport-Security"].should eq "max-age=15552000; includeSubDomains"
+          end
+
+          context = build_ssl_context(ssl: true)
+          # Should work with Time::MonthSpan, which is returned when using 'year'
+          with_strict_transport_security({max_age: 1.year, include_subdomains: false}) do
+            run_force_ssl_handler context
+            context.response.headers["Strict-Transport-Security"].should eq "max-age=31104000"
+          end
+        end
+      end
+    end
+
+    context "when the request is not using SSL" do
+      it "redirects to an SSL version of the request" do
+        context = build_ssl_context(ssl: false)
         run_force_ssl_handler context
-        context.response.headers["Strict-Transport-Security"].should eq "max-age=15552000; includeSubDomains"
+
+        context.response.status_code.should eq 308
+        context.response.headers["Location"].should eq "https://example.com/path"
       end
 
-      # Should work with Time::MonthSpan, which is returned when using 'year'
-      with_strict_transport_security({max_age: 1.year, include_subdomains: false}) do
-        run_force_ssl_handler context
-        context.response.headers["Strict-Transport-Security"].should eq "max-age=31104000"
+      it "redirects using custom status" do
+        context = build_ssl_context(ssl: false)
+        Lucky::ForceSSLHandler.temp_config(redirect_status: 302) do
+          run_force_ssl_handler context
+        end
+
+        context.response.status_code.should eq 302
+        context.response.headers["Location"].should eq "https://example.com/path"
       end
     end
   end
@@ -86,4 +84,11 @@ private def run_force_ssl_handler(context)
   handler = Lucky::ForceSSLHandler.new
   handler.next = ->(_ctx : HTTP::Server::Context) {}
   handler.call(context)
+end
+
+private def build_ssl_context(ssl : Bool) : HTTP::Server::Context
+  build_context(path: "/path").tap do |context|
+    context.request.headers["X-Forwarded-Proto"] = ssl ? "https" : "http"
+    context.request.headers["Host"] = "example.com"
+  end
 end

--- a/src/lucky/force_ssl_handler.cr
+++ b/src/lucky/force_ssl_handler.cr
@@ -33,7 +33,10 @@ class Lucky::ForceSSLHandler
   end
 
   def call(context)
-    if secure?(context) || disabled?
+    if disabled?
+      call_next(context)
+    elsif secure?(context)
+      add_transport_header_if_enabled(context)
       call_next(context)
     else
       redirect_to_secure_version(context)
@@ -50,7 +53,6 @@ class Lucky::ForceSSLHandler
 
   private def redirect_to_secure_version(context : HTTP::Server::Context)
     context.response.status_code = settings.redirect_status
-    add_transport_header_if_enabled(context)
     context.response.headers["Location"] =
       "https://#{context.request.host}#{context.request.resource}"
   end


### PR DESCRIPTION
Resolves https://github.com/luckyframework/lucky/issues/1267.

Basically, I'm just moving the call to `add_transport_header_if_enabled` to the other code path.

I refactored the `ForceSSLHandler` specs while I was at it. I added a `build_ssl_context` helper - I'm not sure if that conforms to the preferred code style.

Feedback for improvements very welcome!

Cheers

## Checklist

* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
