### PR TITLE
Using native CLI args with built-in tasks

### DIFF
--- a/spec/tasks/exec_spec.cr
+++ b/spec/tasks/exec_spec.cr
@@ -3,7 +3,7 @@ require "../spec_helper"
 describe Lucky::Exec do
   it "runs the editor" do
     with_test_template do
-      Lucky::Exec.new.call(["--once", "--editor", %(echo '5 + 5' >)])
+      Lucky::Exec.new.print_help_or_call(args: ["--once", "--editor", %(echo '5 + 5' >)])
 
       newest_code.should eq <<-CODE
       5 + 5


### PR DESCRIPTION
## Purpose
Starts to close #1247 

## Description
This PR starts work to move all built-in tasks to use the native CLI args. Currently I was able to do `watch` and `exec` which cleans up the code quite a bit without changing the UX up.

* [x] - exec task
* [x] - watch task
* [ ] - security_key task
* [ ] - page
* [ ] - model
* [ ] - component
* [ ] - action
* [ ] - resource


However, the task that use the positional_args like `gen.model` or `gen.page`, etc... are quite a bit more difficult. With how they are built, they will require https://github.com/luckyframework/lucky_cli/pull/557 to make the error message a little nicer, but that still won't fully fix all the issues. The biggest part is how error messages are handled. Since nice error messages are a major part of Lucky, we need to really consider how this will work. It may even require a refactor on how the CLI arg methods are implemented to allow for custom error handling. 

For example the current `Gen::Page` task has

```crystal
  def call(io : IO = STDOUT)
    if error
      io.puts error.colorize(:red)
    else
      Lucky::PageTemplate.new(page_filename, page_class, output_path).render(output_path)
      io.puts success_message
    end
  end
```

which will run the task, then validate the usage, then print out a nice friendly message. Where as the new implementation would look like:

```crystal
 def call
    Lucky::PageTemplate.new(page_filename, page_class, output_path).render(output_path)
    output.puts success_message # provided that lucky_cli PR is merged
   end
```

This is a lot cleaner, but in this case the validation happens BEFORE `call` is ran. If validation fails, an exception is raised instead. Since the exception is derived in the code, the user doesn't have any way to customize it.

```crystal
 positional_arg :page_class,
                 "The name of the Page class. e.g. Users::IndexPage",
                 format: /^[A-Z].*(?::*)Page$/,
                 example: "Users::IndexPage", # this comes from the lucky_cli PR
                 # We'd need something like these? 
                 invalid_error_message: "custom here",
                 missing_error_message: "other custom here"

# or maybe the whole thing looks like? 🤷 
positional_arg ModelClassNameCliArg.new
positional_arg ModelColumnArgs.new
```

Also keep in mind that there's no telling how many `positional_arg` could be defined in a single task.


## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
