### PR TITLE
add uuid helper

### DIFF
--- a/spec/lucky/link_helpers_spec.cr
+++ b/spec/lucky/link_helpers_spec.cr
@@ -83,6 +83,13 @@ describe Lucky::LinkHelpers do
     HTML
   end
 
+  it "renders a link with uuid" do
+    uuid = UUID.random
+    view(&.link uuid to: LinkHelpers::Index).should contain <<-HTML
+    <a href="/link_helpers">#{uuid}</a>
+    HTML
+  end
+
   it "renders a link with a special data attribute" do
     view(&.link(to: LinkHelpers::Index, "data-is-useless": true)).should contain <<-HTML
     <a href="/link_helpers" data-is-useless="true"></a>

--- a/src/lucky/tags/link_helpers.cr
+++ b/src/lucky/tags/link_helpers.cr
@@ -1,4 +1,8 @@
 module Lucky::LinkHelpers
+  def link(text : UUID, to : Lucky::RouteHelper, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
+    a text.to_s, merge_options(html_options, link_to_href(to)), attrs
+  end
+
   def link(text, to : Lucky::RouteHelper, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
     a text, merge_options(html_options, link_to_href(to)), attrs
   end


### PR DESCRIPTION
## Purpose
When using UUID as a primary key there are some scaffolds that do not work.

## Description
This adds a helper that makes it so the scaffolds work with a UUID.  I could add to_s to the text but I dont know if adding an extra call is what would be best for a generic helper.
