### PR TITLE
Adding specs for the has_key_for? method

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -40,7 +40,8 @@ dependencies:
     version: ~> 0.2.0
   avram:
     github: luckyframework/avram
-    version: ~> 0.17.0
+    branch: master
+    #version: ~> 0.17.0
   lucky_router:
     github: luckyframework/lucky_router
     version: ~> 0.3.0

--- a/spec/lucky/params_spec.cr
+++ b/spec/lucky/params_spec.cr
@@ -3,6 +3,30 @@ require "../spec_helper"
 include ContextHelper
 include MultipartHelper
 
+private class TestOperationWithDefaultParamKey < Avram::Operation
+  attribute title : String
+
+  def run
+  end
+end
+
+private class TestOperationWithCustomParamKey < Avram::Operation
+  param_key :test_op
+  attribute title : String
+
+  def run
+  end
+end
+
+private class User < Avram::Model
+  table do
+    column name : String
+  end
+end
+
+private class SaveUser < User::SaveOperation
+end
+
 describe Lucky::Params do
   describe "#from_query" do
     it "returns the HTTP::Params for the query params" do
@@ -596,6 +620,56 @@ describe Lucky::Params do
 
       params = Lucky::Params.new(request).to_h
       params.should eq({"filter" => {"name" => "euphonium"}, "page" => "1", "per" => "50"})
+    end
+  end
+
+  describe "#has_key_for?" do
+    it "returns true for the Operation with the proper key" do
+      request = build_request body: "", content_type: ""
+      request.query = "test_operation_with_default_param_key:title=Test"
+      params = Lucky::Params.new(request)
+
+      params.has_key_for?(TestOperationWithDefaultParamKey).should be_true
+    end
+
+    it "returns true for the Operation with a custom key" do
+      request = build_request body: "", content_type: ""
+      request.query = "test_op:title=Test"
+      params = Lucky::Params.new(request)
+
+      params.has_key_for?(TestOperationWithCustomParamKey).should be_true
+    end
+
+    it "returns false for the Operation with the improper key" do
+      request = build_request body: "", content_type: ""
+      request.query = "bad_key:title=Test"
+      params = Lucky::Params.new(request)
+
+      params.has_key_for?(TestOperationWithDefaultParamKey).should be_false
+    end
+
+    it "returns false for the Operation with no key" do
+      request = build_request body: "", content_type: ""
+      request.query = "title=Test"
+      params = Lucky::Params.new(request)
+
+      params.has_key_for?(TestOperationWithDefaultParamKey).should be_false
+    end
+
+    it "returns true for the SaveOperation with the proper key" do
+      request = build_request body: "", content_type: ""
+      request.query = "user:name=Test"
+      params = Lucky::Params.new(request)
+
+      params.has_key_for?(SaveUser).should be_true
+    end
+
+    it "returns false for the SaveOperation with the improper key" do
+      request = build_request body: "", content_type: ""
+      request.query = "author:name=Test"
+      params = Lucky::Params.new(request)
+
+      params.has_key_for?(SaveUser).should be_false
     end
   end
 end

--- a/src/lucky/params.cr
+++ b/src/lucky/params.cr
@@ -320,6 +320,10 @@ class Lucky::Params
     end
   end
 
+  def has_key_for?(operation : Avram::Operation.class | Avram::SaveOperation.class) : Bool
+    nested?(operation.param_key).any?
+  end
+
   private def nested_json_params(nested_key : String) : Hash(String, String)
     nested_params = {} of String => String
     nested_key_json = parsed_json[nested_key]? || JSON.parse("{}")

--- a/src/lucky/params.cr
+++ b/src/lucky/params.cr
@@ -320,10 +320,6 @@ class Lucky::Params
     end
   end
 
-  def has_key_for?(operation : Avram::Operation.class | Avram::SaveOperation.class) : Bool
-    nested?(operation.param_key).any?
-  end
-
   private def nested_json_params(nested_key : String) : Hash(String, String)
     nested_params = {} of String => String
     nested_key_json = parsed_json[nested_key]? || JSON.parse("{}")


### PR DESCRIPTION
## Purpose
This is to accompany https://github.com/luckyframework/avram/pull/500

## Description
This adds in specs for the new `params.has_key_for?` method. Though the method is defined in Avram, we can't accurately write specs for it in Avram since a user's `params` will actually be `Lucky::Params`. In this case, it's closer to "real world" tests.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
