### PR TITLE
Add support for glob params

### DIFF
--- a/spec/lucky/action_route_params_spec.cr
+++ b/spec/lucky/action_route_params_spec.cr
@@ -14,6 +14,18 @@ private class TestOptionalParamAction < TestAction
   end
 end
 
+private class TestGlobAction < TestAction
+  get "/complex_posts/*" do
+    plain_text "test"
+  end
+end
+
+private class TestNamedGlobAction < TestAction
+  get "/complex_posts/*:leftover" do
+    plain_text "test"
+  end
+end
+
 describe "Automatically generated param helpers" do
   it "generates helpers for all route params" do
     action = TestParamAction.new(build_context, {"param_1" => "param_1_value", "param_2" => "param_2_value"})
@@ -30,5 +42,25 @@ describe "Automatically generated param helpers" do
     action.optional_2.should eq nil
     typeof(action.optional_1).should eq String?
     typeof(action.optional_2).should eq String?
+  end
+
+  it "generates helper for unnamed glob" do
+    action = TestGlobAction.new(build_context, {"glob" => "globbed/path"})
+    action.glob.should eq "globbed/path"
+
+    action = TestGlobAction.new(build_context, {} of String => String)
+    action.glob.should be_nil
+
+    typeof(action.glob).should eq String?
+  end
+
+  it "generates helper for named glob" do
+    action = TestNamedGlobAction.new(build_context, {"leftover" => "globbed/path"})
+    action.leftover.should eq "globbed/path"
+
+    action = TestNamedGlobAction.new(build_context, {} of String => String)
+    action.leftover.should be_nil
+
+    typeof(action.leftover).should eq String?
   end
 end


### PR DESCRIPTION
## Purpose

Fixes #1292

## Description

Adds support for route globbing that was added to LuckyRouter in https://github.com/luckyframework/lucky_router/commit/e21fca194cd20445d7b0a16f6b01350e16039a8e.

There are several invalid states being checked with compilation errors:

- More than one glob is defined
- Glob is not at the end of the path
- Glob has dashes in the name
- Glob doesn't start with `*:` or isn't exactly `*`

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
