### PR TITLE
Fixing action route methods when a prefix exists.

### DIFF
--- a/spec/lucky/action_redirect_spec.cr
+++ b/spec/lucky/action_redirect_spec.cr
@@ -8,6 +8,14 @@ class RedirectAction < TestAction
   end
 end
 
+class ActionWithPrefix < TestAction
+  route_prefix "/prefix"
+
+  get "/redirect_test2" do
+    plain_text "does not matter"
+  end
+end
+
 describe Lucky::Action do
   it "redirects" do
     action = RedirectAction.new(build_context, params)
@@ -21,6 +29,10 @@ describe Lucky::Action do
     action = RedirectAction.new(build_context, params)
     action.redirect to: RedirectAction
     should_redirect(action, to: RedirectAction.path, status: 302)
+
+    action = RedirectAction.new(build_context, params)
+    action.redirect to: ActionWithPrefix
+    should_redirect(action, to: "/prefix/redirect_test2", status: 302)
   end
 
   it "redirects with custom status" do

--- a/spec/lucky/action_spec.cr
+++ b/spec/lucky/action_spec.cr
@@ -149,10 +149,19 @@ class OptionalRouteParams::Index < TestAction
   end
 end
 
+class Tests::ActionWithPrefix < TestAction
+  route_prefix "/prefix"
+
+  get "/so_custom" do
+    plain_text "doesn't matter"
+  end
+end
+
 describe Lucky::Action do
   it "has a url helper" do
     Lucky::RouteHelper.temp_config(base_uri: "example.com") do
       Tests::Index.url.should eq "example.com/tests"
+      Tests::ActionWithPrefix.url.should eq "example.com/prefix/so_custom"
     end
   end
 
@@ -194,6 +203,7 @@ describe Lucky::Action do
       Tests::Update.with("test-id").should eq Lucky::RouteHelper.new(:put, "/tests/test-id")
       Tests::Create.path.should eq "/tests"
       Tests::Create.route.should eq Lucky::RouteHelper.new(:post, "/tests")
+      Tests::ActionWithPrefix.path.should eq "/prefix/so_custom"
     end
 
     it "escapes path params" do

--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -191,6 +191,7 @@ module Lucky::Routable
   macro add_route(method, path, action)
     Lucky::Router.add({{ method }}, {{ ROUTE_SETTINGS[:prefix] + path }}, {{ @type.name.id }})
 
+    {% path = ROUTE_SETTINGS[:prefix] + path %}
     {% path_parts = path.split('/').reject(&.empty?) %}
     {% path_params = path_parts.select(&.starts_with?(':')) %}
     {% optional_path_params = path_parts.select(&.starts_with?("?:")) %}


### PR DESCRIPTION
## Purpose
Fixes #1281

## Description
This PR fixes calling action route methods like `SomeAction.route` or `SomeAction.path` to include the prefix when a prefix exists. We were already doing route matching, but missing the route helpers.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
