### PR TITLE
WebSockets

### DIFF
--- a/src/lucky/web_socket.cr
+++ b/src/lucky/web_socket.cr
@@ -1,0 +1,9 @@
+module Lucky
+  class WebSocket < HTTP::WebSocketHandler
+    getter proc
+
+    def initialize(@action : Lucky::Action.class, &@proc : HTTP::WebSocket, HTTP::Server::Context -> Void)
+    end
+
+  end
+end

--- a/src/lucky/web_socket.cr
+++ b/src/lucky/web_socket.cr
@@ -4,6 +4,5 @@ module Lucky
 
     def initialize(@action : Lucky::Action.class, &@proc : HTTP::WebSocket, HTTP::Server::Context -> Void)
     end
-
   end
 end

--- a/src/lucky/web_socket_action.cr
+++ b/src/lucky/web_socket_action.cr
@@ -1,0 +1,19 @@
+abstract class Lucky::WebSocketAction < Lucky::Action
+  getter websocket : Lucky::WebSocket
+
+  def initialize(@context : HTTP::Server::Context, @route_params : Hash(String, String))
+    @websocket = Lucky::WebSocket.new(self.class) do |ws|
+      ws.on_message {|message| on_message(message) }
+      ws.on_close { on_close }
+      call(ws)
+    end
+  end
+
+  abstract def call(socket : Lucky::WebSocket)
+
+  def call
+    raise <<-ERROR
+    WebSocketAction must define `call(socket)`
+    ERROR
+  end
+end

--- a/src/lucky/web_socket_action.cr
+++ b/src/lucky/web_socket_action.cr
@@ -3,7 +3,7 @@ abstract class Lucky::WebSocketAction < Lucky::Action
 
   def initialize(@context : HTTP::Server::Context, @route_params : Hash(String, String))
     @websocket = Lucky::WebSocket.new(self.class) do |ws|
-      ws.on_message {|message| on_message(message) }
+      ws.on_message { |message| on_message(message) }
       ws.on_close { on_close }
       call(ws)
     end

--- a/src/lucky/web_socket_handler.cr
+++ b/src/lucky/web_socket_handler.cr
@@ -1,0 +1,26 @@
+class WebSocketHandler
+  include HTTP::Handler
+
+  def call(context : HTTP::Server::Context)
+    if ws_route_found?(context) && websocket_upgrade_request?(context)
+      websocket_action.payload.new(context, websocket_action.params).websocket.call(context)
+    else
+      call_next(context)
+    end
+  end
+
+  private def ws_route_found?(context)
+    !!websocket_action
+  end
+
+  memoize def websocket_action : LuckyRouter::Match(Lucky::Action.class)?
+    Lucky::Router.find_action(:ws, context.request.path)
+  end
+
+  private def websocket_upgrade_request?(context)
+    return unless upgrade = context.request.headers["Upgrade"]?
+    return unless upgrade.compare("websocket", case_insensitive: true) == 0
+
+    context.request.headers.includes_word?("Connection", "Upgrade")
+  end
+end


### PR DESCRIPTION
## Purpose
Fixes #554 

## Description
I wanted to get the discussion moving on how WebSockets might look in Lucky. The idea here would be that Lucky provides a very basic interface to using WebSockets from the backend, but it would be up to the developer to implement the client side portion on their own with whatever tools they know. 

This implementation tries to stick as close to current actions as we can while maintaining all of the type-safety features that Lucky gives us. It shouldn't feel like a ton of setup to get using. 

Imagine you just generated a fresh Lucky app with this in it (maybe the wizard asks if you need websockets?), here is code that would be in your generated app:

```crystal
# src/actions/web_socket_action.cr
class WebSocketAction < Lucky::WebSocketAction
  accepted_formats [:plain_text, :json], default: :plain_text

  # possibly some includes for authentic here?
end

# src/app_server.cr
def middleware : Array(HTTP::Handler)
    [
      Lucky::ForceSSLHandler.new,
      Lucky::HttpMethodOverrideHandler.new,
      Lucky::LogHandler.new,
      Lucky::ErrorHandler.new(action: Errors::Show),
      Lucky::RemoteIpHandler.new,
      Lucky::WebSocketHandler.new, # <-- this line added
      Lucky::RouteHandler.new,
      Lucky::StaticCompressionHandler.new("./public", file_ext: "gz", content_encoding: "gzip"),
      Lucky::StaticFileHandler.new("./public", fallthrough: false, directory_listing: false),
      Lucky::RouteNotFoundHandler.new,
    ] of HTTP::Handler
  end
```

Now for your code:

```crystal
class Chats::Index < WebSocketAction

  ws "/chat" do |socket|
    socket.send("Hi")
    # what should this return? maybe just `socket`?
  end

  def on_message(message)
    # you got a message
    # this may or may not work 🤔 
    websocket.send("I got your message")
  end

  def on_close
    # whatever you do when it closes
  end
end
```


## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [ ] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [ ] - Lucky builds on docker with `./script/setup`
* [ ] - All builds and specs pass on docker with `./script/test`
