### PR TITLE
rename the name variable on custom tags to tag_name.

### DIFF
--- a/spec/lucky/custom_tags_spec.cr
+++ b/spec/lucky/custom_tags_spec.cr
@@ -25,8 +25,8 @@ describe Lucky::CustomTags do
       .to_s.should contain "<foo-tag></foo-tag>"
     view(&.tag("foo-tag", class: "my-class"))
       .to_s.should contain %(<foo-tag class="my-class"></foo-tag>)
-    view(&.tag("foo-tag", attrs: [:ng_strict_di], ng_app: "ngAppStrictDemo"))
-      .to_s.should contain %(<foo-tag ng-app="ngAppStrictDemo" ng-strict-di></foo-tag>)
+    view(&.tag("foo-tag", attrs: [:ng_strict_di], ng_app: "ngAppStrictDemo", name: "JSApp"))
+      .to_s.should contain %(<foo-tag ng-app="ngAppStrictDemo" name="JSApp" ng-strict-di></foo-tag>)
 
     view do |page|
       page.tag("foo-tag") do

--- a/src/lucky/tags/custom_tags.cr
+++ b/src/lucky/tags/custom_tags.cr
@@ -3,7 +3,7 @@ module Lucky::CustomTags
   EMPTY_HTML_ATTRS = {} of String => String
 
   def tag(
-    name : String,
+    tag_name : String,
     content : Lucky::AllowedInTags | String? = "",
     options = EMPTY_HTML_ATTRS,
     attrs : Array(Symbol) = [] of Symbol,
@@ -11,37 +11,37 @@ module Lucky::CustomTags
   ) : Nil
     merged_options = merge_options(other_options, options)
 
-    tag(name, attrs, merged_options) do
+    tag(tag_name, attrs, merged_options) do
       text content
     end
   end
 
-  def tag(name : String, content : String | Lucky::AllowedInTags) : Nil
+  def tag(tag_name : String, content : String | Lucky::AllowedInTags) : Nil
     tag(EMPTY_HTML_ATTRS) do
       text content
     end
   end
 
-  def tag(name : String, &block) : Nil
+  def tag(tag_name : String, &block) : Nil
     tag(EMPTY_HTML_ATTRS) do
       yield
     end
   end
 
-  def tag(name : String, attrs : Array(Symbol) = [] of Symbol, options = EMPTY_HTML_ATTRS, **other_options, &block) : Nil
+  def tag(tag_name : String, attrs : Array(Symbol) = [] of Symbol, options = EMPTY_HTML_ATTRS, **other_options, &block) : Nil
     merged_options = merge_options(other_options, options)
     tag_attrs = build_tag_attrs(merged_options)
     boolean_attrs = build_boolean_attrs(attrs)
-    view << "<#{name}" << tag_attrs << boolean_attrs << ">"
+    view << "<#{tag_name}" << tag_attrs << boolean_attrs << ">"
     check_tag_content!(yield)
-    view << "</#{name}>"
+    view << "</#{tag_name}>"
   end
 
   # Outputs a custom tag with no tag closing.
   # `empty_tag("br")` => `<br>`
-  def empty_tag(name : String, options = EMPTY_HTML_ATTRS, **other_options) : Nil
+  def empty_tag(tag_name : String, options = EMPTY_HTML_ATTRS, **other_options) : Nil
     merged_options = merge_options(other_options, options)
     tag_attrs = build_tag_attrs(merged_options)
-    view << "<#{name}" << tag_attrs << ">"
+    view << "<#{tag_name}" << tag_attrs << ">"
   end
 end


### PR DESCRIPTION
## Purpose
Fixes #1307

## Description

If you're building a front-end app and need your custom tags to take a `name` prop, this would conflict with the custom tag's `name` argument.

```crystal
tag("widget", name: "Alert")

#=> Error: argument 'name' already specified
```

This PR fixes it by changing the argument to `tag_name`.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
