### PR TITLE
Updates lucky watch to emit to bin/

### DIFF
--- a/tasks/watch.cr
+++ b/tasks/watch.cr
@@ -206,9 +206,9 @@ class Watch < LuckyCli::Task
   switch :error_trace, "Show full error trace"
 
   def call
-    build_commands = ["crystal build ./src/start_server.cr"]
+    build_commands = ["crystal build ./src/start_server.cr -o bin/start_server"]
     build_commands[0] += " --error-trace" if error_trace?
-    run_commands = ["./start_server"]
+    run_commands = ["./bin/start_server"]
     files = ["./src/**/*.cr", "./src/**/*.ecr", "./config/**/*.cr", "./shard.lock"]
 
     process_runner = LuckySentry::ProcessRunner.new(


### PR DESCRIPTION
Crystal convention is to emit binaries to `./bin` and since lucky scripts are in `script/` now, I think moving this over will reduce clutter in a project root directory.

## Purpose
General cleanup

## Checklist
* ~[ ] - An issue already exists detailing the issue/or feature request that this PR fixes~
* ~[ ] - All specs are formatted with `crystal tool format spec src`~
* ~[ ] - Inline documentation has been added and/or updated~
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`

* [x] - lucky-cli has been updated: https://github.com/luckyframework/lucky_cli/pull/586