### PR TITLE
Use HTTP::Status description for logging

### DIFF
--- a/spec/lucky/pretty_log_formatter_spec.cr
+++ b/spec/lucky/pretty_log_formatter_spec.cr
@@ -15,7 +15,7 @@ describe Lucky::PrettyLogFormatter do
       io = IO::Memory.new
       format(io, {status: 200, duration: "1.4ms"})
 
-      io.to_s.chomp.should start_with(" #{"▸".colorize.dim} Sent #{"200 Ok".colorize.bold} (1.4ms)")
+      io.to_s.chomp.should start_with(" #{"▸".colorize.dim} Sent #{"200 OK".colorize.bold} (1.4ms)")
     end
   end
 

--- a/src/lucky/logger_helpers.cr
+++ b/src/lucky/logger_helpers.cr
@@ -1,7 +1,7 @@
 module Lucky::LoggerHelpers
   def self.colored_http_status(status_code : Int32) : String
     http_status = HTTP::Status.from_value?(status_code)
-    status_name = Wordsmith::Inflector.humanize(http_status.try(&.description) || "")
+    status_name = http_status.try(&.description) || ""
     message = "#{status_code} #{status_name}".colorize.bold
 
     case status_code

--- a/src/lucky/logger_helpers.cr
+++ b/src/lucky/logger_helpers.cr
@@ -1,6 +1,7 @@
 module Lucky::LoggerHelpers
   def self.colored_http_status(status_code : Int32) : String
-    status_name = Wordsmith::Inflector.humanize(HTTP::Status.from_value?(status_code) || "")
+    http_status = HTTP::Status.from_value?(status_code)
+    status_name = Wordsmith::Inflector.humanize(http_status.try(&.description) || "")
     message = "#{status_code} #{status_name}".colorize.bold
 
     case status_code


### PR DESCRIPTION
## Purpose

Fixes https://github.com/luckyframework/lucky/issues/1306

## Description

We were logging out an enum, but that enum has a description method that gives us a more human readable message.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
