### PR TITLE
fixing references to duplicate routes in the specs

### DIFF
--- a/spec/lucky/action_rendering_spec.cr
+++ b/spec/lucky/action_rendering_spec.cr
@@ -38,19 +38,19 @@ class Rendering::JSON::WithStatus < TestAction
 end
 
 class Rendering::JSON::WithSymbolStatus < TestAction
-  get "/foo" do
+  get "/foo2" do
     json({name: "Paul"}, status: :created)
   end
 end
 
 class Rendering::HeadOnly < TestAction
-  get "/foo" do
+  get "/foo3" do
     head status: 204
   end
 end
 
 class Rendering::HeadOnly::WithSymbolStatus < TestAction
-  get "/foo" do
+  get "/foo4" do
     head status: :no_content
   end
 end
@@ -62,31 +62,31 @@ class Rendering::Text::Index < TestAction
 end
 
 class Rendering::Text::WithStatus < TestAction
-  get "/foo" do
+  get "/foo5" do
     plain_text "Anything", status: 201
   end
 end
 
 class Rendering::Text::WithSymbolStatus < TestAction
-  get "/foo" do
+  get "/foo6" do
     plain_text "Anything", status: :created
   end
 end
 
 class Rendering::Xml::Index < TestAction
-  get "/foo" do
+  get "/foo7" do
     xml "<anything />"
   end
 end
 
 class Rendering::Xml::WithStatus < TestAction
-  get "/foo" do
+  get "/foo8" do
     xml "<anything />", status: 418
   end
 end
 
 class Rendering::Xml::WithSymbolStatus < TestAction
-  get "/foo" do
+  get "/foo9" do
     xml "<anything />", status: :im_a_teapot
   end
 end
@@ -98,13 +98,13 @@ class Rendering::File < TestAction
 end
 
 class Rendering::File::Inline < TestAction
-  get "/foo" do
+  get "/foo10" do
     file "spec/fixtures/lucky_logo.png", disposition: "inline"
   end
 end
 
 class Rendering::File::CustomFilename < TestAction
-  get "/foo" do
+  get "/foo11" do
     file "spec/fixtures/lucky_logo.png",
       disposition: "attachment",
       filename: "custom.png"
@@ -112,7 +112,7 @@ class Rendering::File::CustomFilename < TestAction
 end
 
 class Rendering::File::CustomContentType < TestAction
-  get "/foo" do
+  get "/foo12" do
     file "spec/fixtures/plain_text",
       disposition: "attachment",
       filename: "custom.html",
@@ -121,7 +121,7 @@ class Rendering::File::CustomContentType < TestAction
 end
 
 class Rendering::File::Missing < TestAction
-  get "/foo" do
+  get "/foo13" do
     file "new_file_who_dis"
   end
 end
@@ -143,19 +143,19 @@ private class ComplexTestComponent < Lucky::BaseComponent
 end
 
 class Rendering::PlainComponent < TestAction
-  get "/foo" do
+  get "/foo14" do
     component PlainTestComponent
   end
 end
 
 class Rendering::ComplexComponent < TestAction
-  get "/foo" do
+  get "/foo15" do
     component ComplexTestComponent, title: "Getting Complex"
   end
 end
 
 class Rendering::PlainComponentWithCustomStatus < TestAction
-  get "/foo" do
+  get "/foo16" do
     component PlainTestComponent, status: :partial_content
   end
 end

--- a/spec/lucky/action_route_params_spec.cr
+++ b/spec/lucky/action_route_params_spec.cr
@@ -9,19 +9,19 @@ private class TestParamAction < TestAction
 end
 
 private class TestOptionalParamAction < TestAction
-  get "/complex_posts/:required/?:optional_1/?:optional_2" do
+  get "/test-complex_posts/:required/?:optional_1/?:optional_2" do
     plain_text "test"
   end
 end
 
 private class TestGlobAction < TestAction
-  get "/complex_posts/*" do
+  get "/test-complex_posts_glob/*" do
     plain_text "test"
   end
 end
 
 private class TestNamedGlobAction < TestAction
-  get "/complex_posts/*:leftover" do
+  get "/test-complex_posts_named_glob/*:leftover" do
     plain_text "test"
   end
 end

--- a/spec/lucky/action_spec.cr
+++ b/spec/lucky/action_spec.cr
@@ -154,7 +154,7 @@ end
 class Tests::ActionWithPrefix < TestAction
   route_prefix "/prefix"
 
-  get "/so_custom" do
+  get "/so_custom2" do
     plain_text "doesn't matter"
   end
 end
@@ -163,7 +163,7 @@ describe Lucky::Action do
   it "has a url helper" do
     Lucky::RouteHelper.temp_config(base_uri: "example.com") do
       Tests::Index.url.should eq "example.com/tests"
-      Tests::ActionWithPrefix.url.should eq "example.com/prefix/so_custom"
+      Tests::ActionWithPrefix.url.should eq "example.com/prefix/so_custom2"
     end
   end
 
@@ -205,7 +205,7 @@ describe Lucky::Action do
       Tests::Update.with("test-id").should eq Lucky::RouteHelper.new(:put, "/tests/test-id")
       Tests::Create.path.should eq "/tests"
       Tests::Create.route.should eq Lucky::RouteHelper.new(:post, "/tests")
-      Tests::ActionWithPrefix.path.should eq "/prefix/so_custom"
+      Tests::ActionWithPrefix.path.should eq "/prefix/so_custom2"
     end
 
     it "escapes path params" do

--- a/spec/lucky/infer_page_spec.cr
+++ b/spec/lucky/infer_page_spec.cr
@@ -12,7 +12,7 @@ class Rendering::CustomPage
 end
 
 class Rendering::Foo < TestAction
-  get "/foo" do
+  get "/rendering-foo" do
     html Rendering::CustomPage, title: "EditPage", arg2: "testing_multiple_args"
   end
 end

--- a/spec/lucky/router_spec.cr
+++ b/spec/lucky/router_spec.cr
@@ -2,25 +2,25 @@ require "../spec_helper"
 
 describe Lucky::Router do
   it "routes based on the method name and path" do
-    Lucky::Router.add :get, "/test", Lucky::Action
+    Lucky::Router.add :get, "/router-test1", Lucky::Action
 
-    Lucky::Router.find_action(:get, "/test").should_not be_nil
-    Lucky::Router.find_action("get", "/test").should_not be_nil
-    Lucky::Router.find_action(:post, "/test").should be_nil
+    Lucky::Router.find_action(:get, "/router-test1").should_not be_nil
+    Lucky::Router.find_action("get", "/router-test1").should_not be_nil
+    Lucky::Router.find_action(:post, "/router-test1").should be_nil
   end
 
   it "finds the associated get route by a head method" do
-    Lucky::Router.add :get, "/test", Lucky::Action
+    Lucky::Router.add :get, "/router-test2", Lucky::Action
 
-    Lucky::Router.find_action(:head, "/test").should_not be_nil
-    Lucky::Router.find_action("head", "/test").should_not be_nil
+    Lucky::Router.find_action(:head, "/router-test2").should_not be_nil
+    Lucky::Router.find_action("head", "/router-test2").should_not be_nil
   end
 
   it "finds the route with an optional parts" do
-    Lucky::Router.add :get, "/complex_posts/:required/?:optional_1/?:optional_2", Lucky::Action
+    Lucky::Router.add :get, "/complex_path/:required/?:optional_a/?:optional_b", Lucky::Action
 
-    Lucky::Router.find_action(:get, "/complex_posts/1/2/3").should_not be_nil
-    Lucky::Router.find_action(:get, "/complex_posts/1/2").should_not be_nil
-    Lucky::Router.find_action(:get, "/complex_posts/1").should_not be_nil
+    Lucky::Router.find_action(:get, "/complex_path/1/2/3").should_not be_nil
+    Lucky::Router.find_action(:get, "/complex_path/1/2").should_not be_nil
+    Lucky::Router.find_action(:get, "/complex_path/1").should_not be_nil
   end
 end

--- a/spec/lucky/secure_headers_spec.cr
+++ b/spec/lucky/secure_headers_spec.cr
@@ -5,7 +5,7 @@ include ContextHelper
 class FrameGuardRoutes::WithSameorigin < TestAction
   include Lucky::SecureHeaders::SetFrameGuard
 
-  get "/so_custom" do
+  get "/secure_path1" do
     plain_text "test"
   end
 
@@ -17,7 +17,7 @@ end
 class FrameGuardRoutes::WithDeny < TestAction
   include Lucky::SecureHeaders::SetFrameGuard
 
-  get "/so_custom" do
+  get "/secure_path2" do
     plain_text "test"
   end
 
@@ -29,7 +29,7 @@ end
 class FrameGuardRoutes::WithURL < TestAction
   include Lucky::SecureHeaders::SetFrameGuard
 
-  get "/so_custom" do
+  get "/secure_path3" do
     plain_text "test"
   end
 
@@ -41,7 +41,7 @@ end
 class FrameGuardRoutes::WithBadValue < TestAction
   include Lucky::SecureHeaders::SetFrameGuard
 
-  get "/so_custom" do
+  get "/secure_path4" do
     plain_text "test"
   end
 
@@ -53,7 +53,7 @@ end
 class XSSGuardRoutes::Index < TestAction
   include Lucky::SecureHeaders::SetXSSGuard
 
-  get "/so_custom" do
+  get "/secure_path5" do
     plain_text "test"
   end
 end
@@ -61,7 +61,7 @@ end
 class SniffGuardRoutes::Index < TestAction
   include Lucky::SecureHeaders::SetSniffGuard
 
-  get "/so_custom" do
+  get "/secure_path6" do
     plain_text "test"
   end
 end

--- a/spec/lucky/verify_accepts_format_spec.cr
+++ b/spec/lucky/verify_accepts_format_spec.cr
@@ -16,7 +16,7 @@ end
 private class ActionWithImplicitDefault < Lucky::Action
   accepted_formats [:html]
 
-  get "/test" do
+  get "/test2" do
     plain_text "yay"
   end
 
@@ -24,7 +24,7 @@ private class ActionWithImplicitDefault < Lucky::Action
 end
 
 private class ActionThatAcceptsAnyFormat < Lucky::Action
-  get "/test" do
+  get "/test3" do
     plain_text "yay"
   end
 
@@ -34,7 +34,7 @@ end
 private class ActionWithUnrecognizedFormat < Lucky::Action
   accepted_formats [:wut_is_this]
 
-  get "/test" do
+  get "/test4" do
     plain_text "not yay"
   end
 


### PR DESCRIPTION
## Purpose
Needed for #1364 

## Description
The next router update will throw exceptions if you define a duplicate route. This PR just removes the duplications.

