### PR TITLE
Lucky::FlashStore refactor

### DIFF
--- a/spec/lucky/cookies/flash_store_spec.cr
+++ b/spec/lucky/cookies/flash_store_spec.cr
@@ -1,19 +1,14 @@
 require "../../spec_helper"
 
-include ContextHelper
-
 describe Lucky::FlashStore do
   describe ".from_session" do
     it "creates a flash store from the json in a session" do
-      context = build_context_with_flash({"some_key" => "some_value"}.to_json)
-
-      flash_store = Lucky::FlashStore.from_session context.session
+      flash_store = Lucky::FlashStore.from_session(build_session({"some_key" => "some_value"}))
 
       flash_store.get("some_key").should eq "some_value"
     end
 
     it "raises an error when flash JSON is invalid" do
-      context = build_context_with_flash("not_valid_json=invalid")
       message = <<-MESSAGE
       The flash messages (stored as JSON) failed to parse in a JSON parser.
       Here's what it tries to parse:
@@ -22,46 +17,65 @@ describe Lucky::FlashStore do
       MESSAGE
 
       expect_raises(Lucky::InvalidFlashJSONError, message) do
-        Lucky::FlashStore.from_session context.session
+        Lucky::FlashStore.from_session(build_invalid_session)
       end
+    end
+
+    it "does not persist values from session into the next request" do
+      flash_store = Lucky::FlashStore.from_session(build_session({"some_key" => "some_value"}))
+
+      next_flash(flash_store).should be_empty
     end
   end
 
-  it "has shortcuts" do
-    flash_store = Lucky::FlashStore.new
+  context "shortcuts" do
+    it "has failure" do
+      flash_store = Lucky::FlashStore.new
 
-    flash_store.failure = "Failure"
-    flash_store.info = "Info"
-    flash_store.success = "Success"
+      flash_store.failure?.should be_nil
+      flash_store.failure = "Failure"
+      flash_store.failure.should eq("Failure")
+      flash_store.failure?.should eq("Failure")
+      flash_store.get(:failure).should eq("Failure")
+    end
 
-    flash_store.failure.should eq("Failure")
-    flash_store.info.should eq("Info")
-    flash_store.success.should eq("Success")
-  end
+    it "has info" do
+      flash_store = Lucky::FlashStore.new
 
-  it "has nilable shortcuts" do
-    flash_store = Lucky::FlashStore.new
+      flash_store.info?.should be_nil
+      flash_store.info = "Info"
+      flash_store.info.should eq("Info")
+      flash_store.info?.should eq("Info")
+      flash_store.get(:info).should eq("Info")
+    end
 
-    flash_store.failure?.should be_nil
-    flash_store.info?.should be_nil
-    flash_store.success?.should be_nil
+    it "has success" do
+      flash_store = Lucky::FlashStore.new
+
+      flash_store.success?.should be_nil
+      flash_store.success = "Success"
+      flash_store.success.should eq("Success")
+      flash_store.success?.should eq("Success")
+      flash_store.get(:success).should eq("Success")
+    end
   end
 
   describe "#keep" do
-    it "carries messages for @now over to @next" do
-      next_hash = {} of String => String
-      now_hash = {"name" => "Paul"}
-      flash_store = build_flash_store(now: now_hash, next: next_hash)
+    it "carries messages over set from session and set during current request" do
+      flash_store = build_flash_store({"name" => "Paul"})
+      flash_store.set(:info, "Success")
 
       flash_store.keep.should be_nil
-      next_flash = JSON.parse(flash_store.to_json).as_h
+      next_flash = next_flash(flash_store)
+
       next_flash["name"]?.should eq("Paul")
+      next_flash["info"]?.should eq("Success")
     end
   end
 
   describe "#each" do
     it "returns the list of key/value pairs" do
-      flash_store = build_flash_store(next: {
+      flash_store = build_flash_store({
         "some_key"  => "some_value",
         "other_key" => "other_value",
       })
@@ -76,9 +90,7 @@ describe Lucky::FlashStore do
 
   describe "#any?" do
     it "returns true if there are key/value pairs" do
-      flash_store = build_flash_store(next: {
-        "some_key" => "some_value",
-      })
+      flash_store = build_flash_store({"some_key" => "some_value"})
 
       flash_store.any?.should be_true
     end
@@ -92,9 +104,7 @@ describe Lucky::FlashStore do
 
   describe "#empty?" do
     it "returns false if there are key/value pairs" do
-      flash_store = build_flash_store(next: {
-        "some_key" => "some_value",
-      })
+      flash_store = build_flash_store({"some_key" => "some_value"})
 
       flash_store.empty?.should be_false
     end
@@ -103,16 +113,6 @@ describe Lucky::FlashStore do
       flash_store = build_flash_store
 
       flash_store.empty?.should be_true
-    end
-  end
-
-  describe "#all" do
-    it "prefers values from @next over @now" do
-      next_hash = {"name" => "Paul"}
-      now_hash = {"name" => "Edward"}
-      flash_store = build_flash_store(now: now_hash, next: next_hash)
-
-      flash_store.get("name").should eq("Paul")
     end
   end
 
@@ -126,59 +126,90 @@ describe Lucky::FlashStore do
       flash_store.get("name").should eq("Paul")
       flash_store.get("dungeons").should eq("dragons")
     end
+
+    it "overwrites exsiting values" do
+      flash_store = build_flash_store({"name" => "Paul"})
+
+      flash_store.set(:name, "Pauline")
+
+      flash_store.get(:name).should eq("Pauline")
+      next_flash(flash_store)["name"]?.should eq("Pauline")
+    end
+
+    it "is persisted into the next request" do
+      flash_store = build_flash_store({"success" => "Message saved!"})
+
+      flash_store.set(:success, "Message saved again!")
+
+      next_flash(flash_store)["success"]?.should eq("Message saved again!")
+    end
   end
 
   describe "#get" do
-    it "retrieves values from both @now and @next" do
-      next_hash = {"baker" => "Paul"}
-      now_hash = {"cookie theif" => "Edward"}
-      flash_store = build_flash_store(now: now_hash, next: next_hash)
+    it "retrieves values from session and set during current request" do
+      flash_store = build_flash_store({"cookie thief" => "Edward"})
+      flash_store.set(:baker, "Paul")
 
       flash_store.get("baker").should eq("Paul")
-      flash_store.get("cookie theif").should eq("Edward")
+      flash_store.get("cookie thief").should eq("Edward")
     end
 
     it "retrieves for both symbols and strings" do
-      hash = {"baker" => "Paul", "theif" => "Edward"}
-      flash_store = build_flash_store(now: hash)
+      flash_store = build_flash_store({"baker" => "Paul"})
 
       flash_store.get("baker").should eq("Paul")
-      flash_store.get(:theif).should eq("Edward")
+      flash_store.get(:baker).should eq("Paul")
+    end
+
+    it "does not affect the values for the next request" do
+      flash_store = build_flash_store({"cookie thief" => "Edward"})
+      flash_store.set("baker", "Paul")
+
+      flash_store.get(:baker)
+      flash_store.get("cookie thief")
+
+      next_flash = next_flash(flash_store)
+      next_flash["baker"]?.should eq("Paul")
+      next_flash["cookie thief"]?.should be_nil
     end
   end
 
   describe "#to_json" do
-    it "returns JSON for just the next requests flash messages" do
-      now_hash = {not: :present}
-      next_hash = {name: "Paul"}
-      flash_store = build_flash_store(now: now_hash, next: next_hash)
+    it "returns JSON for just the next request's flash messages" do
+      flash_store = build_flash_store({"current" => "should not carry over to next request"})
+      flash_store.set(:next, "should carry over")
 
-      flash_store.to_json.should eq(next_hash.to_json)
+      result = flash_store.to_json
+
+      result.should eq({next: "should carry over"}.to_json)
     end
   end
 
   describe "#clear" do
     it "clears out all flash messages" do
-      now_hash = {not: :present}
-      next_hash = {name: "Paul"}
-      flash_store = build_flash_store(now: now_hash, next: next_hash)
+      flash_store = build_flash_store
+      flash_store.set(:name, "Paul")
 
-      flash_store.get(:name).should eq "Paul"
       flash_store.clear
-      flash_store.get?(:name).should eq nil
+
+      flash_store.get?(:name).should be_nil
+      next_flash(flash_store).should be_empty
     end
   end
 end
 
-private def build_flash_store(
-  now = {} of String => String,
-  next next_hash = {} of String => String
-)
-  session = Lucky::Session.new
-  session.set(Lucky::FlashStore::SESSION_KEY, now.to_json)
-  Lucky::FlashStore.from_session(session).tap do |flash_store|
-    next_hash.each do |key, value|
-      flash_store.set(key, value)
-    end
-  end
+private def build_flash_store(session_values = {} of String => String)
+  Lucky::FlashStore.from_session(build_session(session_values))
+end
+
+private def build_session(values = {} of String => String)
+  Lucky::Session.new.tap(&.set(Lucky::FlashStore::SESSION_KEY, values.to_json))
+end
+
+private def build_invalid_session
+  Lucky::Session.new.tap(&.set(Lucky::FlashStore::SESSION_KEY, "not_valid_json=invalid"))
+end
+
+private def next_flash(flash_store : Lucky::FlashStore) : Hash(String, JSON::Any)
+  JSON.parse(flash_store.to_json).as_h
 end


### PR DESCRIPTION
## Purpose

Related to https://github.com/luckyframework/lucky/issues/1271

## Description

This does not change any behavior of the `Lucky::FlashStore`. All it does is change the internals to prepare for changes coming up. The main thing is that we remove the independent hashes of `@now` and `@next` in favor of a single `@flashes` hash with a list of `@discards` to know which items in the hash aren't passed along into the next request.

This prepares the code for two things:

- Refactoring for the `Lucky::FlashStore` to be an `Enumerable` that delegates to the `@flashes` instead of having to coordinate the two lists
- Updating the API to provide a way to set flashes that should be shown only in the current request and not the next one (for #1271)

This refactor was inspired by Rails' [implementation](https://github.com/rails/rails/blob/master/actionpack/lib/action_dispatch/middleware/flash.rb)

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
