### PR TITLE
Add Lucky::FlashStore#now for setting flash on current request

### DIFF
--- a/spec/lucky/cookies/flash_store_spec.cr
+++ b/spec/lucky/cookies/flash_store_spec.cr
@@ -196,6 +196,29 @@ describe Lucky::FlashStore do
       next_flash(flash_store).should be_empty
     end
   end
+
+  describe "#discard" do
+    it "marks a flash message to be discarded so that it isn't passed to the next request" do
+      flash_store = build_flash_store
+      flash_store.set(:name, "Paul")
+
+      flash_store.discard(:name)
+
+      flash_store.get(:name).should eq("Paul")
+      next_flash(flash_store).should be_empty
+    end
+  end
+
+  describe "#now" do
+    it "allows adding flash messages that are not serialized to the next request" do
+      flash_store = build_flash_store
+
+      flash_store.now.info = "hello"
+
+      flash_store.get(:info).should eq("hello")
+      next_flash(flash_store).should be_empty
+    end
+  end
 end
 
 private def build_flash_store(session_values = {} of String => String)

--- a/src/lucky/cookies/flash_store.cr
+++ b/src/lucky/cookies/flash_store.cr
@@ -1,65 +1,106 @@
-class Lucky::FlashStore
-  SESSION_KEY = "_flash"
-  alias Key = String | Symbol
+module Lucky
+  module FlashInteractions
+    alias Key = String | Symbol
 
-  private getter flashes = {} of String => String
-  private getter discard = [] of String
+    abstract def set(key : Key, value : String) : String
+    abstract def get(key : Key) : String
+    abstract def get?(key : Key) : String?
 
-  delegate any?, each, empty?, to: flashes
+    {% for shortcut in [:failure, :info, :success] %}
+      def {{ shortcut.id }} : String
+        get?(:{{ shortcut.id }}) || ""
+      end
 
-  def self.from_session(session : Lucky::Session) : Lucky::FlashStore
-    new.from_session(session)
+      def {{ shortcut.id }}? : String?
+        get?(:{{ shortcut.id }})
+      end
+
+      def {{ shortcut.id }}=(message : String)
+        set(:{{ shortcut.id }}, message)
+      end
+    {% end %}
   end
 
-  def from_session(session : Lucky::Session) : Lucky::FlashStore
-    session.get?(SESSION_KEY).try do |json|
-      JSON.parse(json).as_h.each do |key, value|
-        flashes[key.to_s] = value.to_s
-        discard << key.to_s
+  class FlashStore
+    include FlashInteractions
+    SESSION_KEY = "_flash"
+
+    private getter flashes = {} of String => String
+    private getter discard = Set(String).new
+
+    delegate any?, each, empty?, to: flashes
+
+    def self.from_session(session : Lucky::Session) : Lucky::FlashStore
+      new.from_session(session)
+    end
+
+    def from_session(session : Lucky::Session) : Lucky::FlashStore
+      session.get?(SESSION_KEY).try do |json|
+        JSON.parse(json).as_h.each do |key, value|
+          flashes[key.to_s] = value.to_s
+          discard << key.to_s
+        end
+      end
+      self
+    rescue e : JSON::ParseException
+      raise Lucky::InvalidFlashJSONError.new(session.get?(SESSION_KEY))
+    end
+
+    def set(key : Key, value : String) : String
+      discard.delete(key.to_s)
+      flashes[key.to_s] = value
+    end
+
+    def get(key : Key) : String
+      flashes[key.to_s]
+    end
+
+    def get?(key : Key) : String?
+      flashes[key.to_s]?
+    end
+
+    def keep : Nil
+      discard.clear
+    end
+
+    def to_json : String
+      flashes.reject(discard.to_a).to_json
+    end
+
+    def clear : Nil
+      flashes.clear
+      discard.clear
+    end
+
+    def discard(key : Key) : Nil
+      discard << key.to_s
+    end
+
+    def now : FlashNow
+      FlashNow.new(self)
+    end
+
+    struct FlashNow
+      include FlashInteractions
+
+      private getter flash_store : FlashStore
+
+      def initialize(@flash_store)
+      end
+
+      def set(key : Key, value : String) : String
+        flash_store.set(key, value)
+        flash_store.discard(key)
+        value
+      end
+
+      def get(key : Key) : String
+        flash_store.get(key)
+      end
+
+      def get?(key : Key) : String?
+        flash_store.get?(key)
       end
     end
-    self
-  rescue e : JSON::ParseException
-    raise Lucky::InvalidFlashJSONError.new(session.get?(SESSION_KEY))
-  end
-
-  def keep : Nil
-    discard.clear
-  end
-
-  {% for shortcut in [:failure, :info, :success] %}
-    def {{ shortcut.id }} : String
-      get?(:{{ shortcut.id }}) || ""
-    end
-
-    def {{ shortcut.id }}? : String?
-      get?(:{{ shortcut.id }})
-    end
-
-    def {{ shortcut.id }}=(message : String)
-      set(:{{ shortcut.id }}, message)
-    end
-  {% end %}
-
-  def to_json : String
-    flashes.reject(discard).to_json
-  end
-
-  def clear : Nil
-    flashes.clear
-    discard.clear
-  end
-
-  def set(key : Key, value : String) : String
-    discard.delete(key.to_s)
-    flashes[key.to_s] = value
-  end
-
-  def get(key : Key) : String
-    flashes[key.to_s]
-  end
-
-  def get?(key : Key) : String?
-    flashes[key.to_s]?
   end
 end


### PR DESCRIPTION
## Purpose

Fixes https://github.com/luckyframework/lucky/issues/1271

## Description

While this does not "solve" this problem brought up in the connected issue, this provides a way to safely accomplish one of the needs that caused it.

The problem could be caused by setting a flash on a route connected to an HTML page. The flash would render on that page and then render on the next page as well if it also rendered HTML. The "bug" that caused this problem was that the `Lucky::FlashStore` implementation lacked any functionality around setting flash messages that only rendered on the current request and not the next one as well. I added one new method to help with this issue.

The old way:

```crystal
class Users::Index < BrowserAction
  get "/users" do
    # this flash would render twice if the user went to another page that rendered HTML
    flash.info = "There has been an update while you were gone"
    html Users::IndexPage, users: UserQuery.new
  end
end
```

The new way:

```crystal
class Users::Index < BrowserAction
  get "/users" do
    # This flash will only render on this request
    flash.now.info = "There has been an update while you were gone"
    html Users::IndexPage, users: UserQuery.new
  end
end
```

This same "bug" can still be done since there's nothing stopping users from setting a flash without calling `#now` first when they should. It will be up to clear documentation to inform users when they should use `flash.info` and `flash.now.info`.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
