### PR TITLE
Inline render_html_page to change compilation error

### DIFF
--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -44,33 +44,9 @@ module Lucky::Renderable
   # end
   # ```
   macro html(page_class = nil, **assigns)
+    {% page_class = page_class || "#{@type.name}Page".id %}
     validate_page_class!({{ page_class }})
 
-    render_html_page(
-      {{ page_class = page_class || "#{@type.name}Page".id }},
-      {% if assigns.empty? %}
-        {} of String => String
-      {% else %}
-        {{ assigns }}
-      {% end %}
-    )
-  end
-
-  # :nodoc:
-  macro validate_page_class!(page_class)
-    {% if page_class && page_class.resolve? %}
-      {% ancestors = page_class.resolve.ancestors %}
-
-      {% if ancestors.includes?(Lucky::Action) %}
-        {% page_class.raise "You accidentally rendered an action (#{page_class}) instead of an HTMLPage in the #{@type.name} action. Did you mean #{page_class}Page?" %}
-      {% elsif !ancestors.includes?(Lucky::HTMLPage) %}
-        {% page_class.raise "Couldn't render #{page_class} in #{@type.name} because it is not an HTMLPage" %}
-      {% end %}
-    {% end %}
-  end
-
-  # :nodoc:
-  macro render_html_page(page_class, assigns)
     # Found in {{ @type.name }}
     view = {{ page_class }}.new(
       context: context,
@@ -88,6 +64,17 @@ module Lucky::Renderable
       debug_message: log_message(view),
       enable_cookies: enable_cookies?
     )
+  end
+
+  # :nodoc:
+  macro validate_page_class!(page_class)
+    {% ancestors = page_class.resolve.ancestors %}
+
+    {% if ancestors.includes?(Lucky::Action) %}
+      {% page_class.raise "You accidentally rendered an action (#{page_class}) instead of an HTMLPage in the #{@type.name} action. Did you mean #{page_class}Page?" %}
+    {% elsif !ancestors.includes?(Lucky::HTMLPage) %}
+      {% page_class.raise "Couldn't render #{page_class} in #{@type.name} because it is not an HTMLPage" %}
+    {% end %}
   end
 
   # Disable cookies


### PR DESCRIPTION
## Purpose

No connected issue

## Description

### Before

<img width="849" alt="CleanShot 2020-12-28 at 13 20 01@2x" src="https://user-images.githubusercontent.com/17329408/103235223-86cf4600-490f-11eb-8737-67033116207a.png">

### After

<img width="807" alt="CleanShot 2020-12-28 at 13 20 17@2x" src="https://user-images.githubusercontent.com/17329408/103235233-8a62cd00-490f-11eb-96ec-7282a352cb25.png">

Notice in the "Before" that the first code reference was a macro and not the usage site that caused the error. By removing the `render_html_page` we actually see the usage site in the error which will help people track down issues.

That macro was extracted [here](https://github.com/luckyframework/lucky/commit/3c1af65d46e6953c241c19232b74ed5cee424d58) but you'll notice that this PR achieves the same level of DRY-ness without the separate macro.

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
