### PR TITLE
Flash messages discarded unless kept

### DIFF
--- a/spec/lucky/cookies/flash_store_spec.cr
+++ b/spec/lucky/cookies/flash_store_spec.cr
@@ -133,15 +133,14 @@ describe Lucky::FlashStore do
       flash_store.set(:name, "Pauline")
 
       flash_store.get(:name).should eq("Pauline")
-      next_flash(flash_store)["name"]?.should eq("Pauline")
     end
 
-    it "is persisted into the next request" do
-      flash_store = build_flash_store({"success" => "Message saved!"})
+    it "is not persisted into the next request" do
+      flash_store = build_flash_store
 
       flash_store.set(:success, "Message saved again!")
 
-      next_flash(flash_store)["success"]?.should eq("Message saved again!")
+      next_flash(flash_store).should be_empty
     end
   end
 
@@ -161,23 +160,21 @@ describe Lucky::FlashStore do
       flash_store.get(:baker).should eq("Paul")
     end
 
-    it "does not affect the values for the next request" do
-      flash_store = build_flash_store({"cookie thief" => "Edward"})
+    it "works for kept messages" do
+      flash_store = build_flash_store
       flash_store.set("baker", "Paul")
+      flash_store.keep
 
-      flash_store.get(:baker)
-      flash_store.get("cookie thief")
-
-      next_flash = next_flash(flash_store)
-      next_flash["baker"]?.should eq("Paul")
-      next_flash["cookie thief"]?.should be_nil
+      flash_store.get(:baker).should eq("Paul")
+      next_flash(flash_store)["baker"]?.should eq("Paul")
     end
   end
 
   describe "#to_json" do
-    it "returns JSON for just the next request's flash messages" do
-      flash_store = build_flash_store({"current" => "should not carry over to next request"})
+    it "returns JSON for kept flash messages" do
+      flash_store = build_flash_store
       flash_store.set(:next, "should carry over")
+      flash_store.keep
 
       result = flash_store.to_json
 

--- a/spec/lucky/text_response_spec.cr
+++ b/spec/lucky/text_response_spec.cr
@@ -8,6 +8,7 @@ describe Lucky::TextResponse do
       it "writes the flash to the session" do
         context = build_context
         context.flash.success = "Yay!"
+        context.flash.keep
         flash_json = {success: "Yay!"}.to_json
 
         print_response_with_body(context)
@@ -34,6 +35,7 @@ describe Lucky::TextResponse do
       it "keeps the flash for the next request" do
         context_1 = build_context
         context_1.flash.success = "Yay!"
+        context_1.flash.keep
         next_json = context_1.flash.to_json
 
         print_response_with_body(context_1)

--- a/src/lucky/cookies/flash_store.cr
+++ b/src/lucky/cookies/flash_store.cr
@@ -14,8 +14,7 @@ class Lucky::FlashStore
   def from_session(session : Lucky::Session) : Lucky::FlashStore
     session.get?(SESSION_KEY).try do |json|
       JSON.parse(json).as_h.each do |key, value|
-        flashes[key.to_s] = value.to_s
-        discard << key.to_s
+        set(key, value.as_s)
       end
     end
     self
@@ -51,7 +50,7 @@ class Lucky::FlashStore
   end
 
   def set(key : Key, value : String) : String
-    discard.delete(key.to_s)
+    discard << key.to_s
     flashes[key.to_s] = value
   end
 


### PR DESCRIPTION
## Purpose

Fixes #1271 

## Description

Previously, flash messages written to the session by default and used in the next request. That led to seeing flashes twice if both requests rendered HTML. Now, we only pass flash messages onto the next request if `flash.keep` is called. Luckily, we call that when actions redirect https://github.com/luckyframework/lucky/blob/cff93b35f1cc8189b3c6f678dd53baaa089c191d/src/lucky/redirectable.cr#L122-L124

So, the two scenarios should be covered to avoid flash message duplicates. If flashes are set in an action that immediately renders HTML then they are discarded after, but if the action redirects the flash messages will carry over and continue carrying over until HTML is rendered.

I'm slightly wary of this because we are depending on code scattered across the library but I believe this is better than what we have right now.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
