### PR TITLE
Allow model to be generated with JSON::Any column type

### DIFF
--- a/spec/tasks/gen/model_spec.cr
+++ b/spec/tasks/gen/model_spec.cr
@@ -77,7 +77,7 @@ describe Gen::Model do
 
     it "displays an error when given a more complex type" do
       io = IO::Memory.new
-      ARGV.push("Alphabet", "a:JSON::Any")
+      ARGV.push("Alphabet", "a:BigDecimal")
 
       Gen::Model.new.call(io)
 

--- a/spec/tasks/gen/resource_spec.cr
+++ b/spec/tasks/gen/resource_spec.cr
@@ -66,7 +66,7 @@ describe Gen::Resource::Browser do
 
     it "displays an error when given a more complex type" do
       io = IO::Memory.new
-      ARGV.push("Alphabet", "a:JSON::Any")
+      ARGV.push("Alphabet", "a:BigDecimal")
 
       Gen::Model.new.call(io)
 

--- a/tasks/gen/mixins/migration_with_columns.cr
+++ b/tasks/gen/mixins/migration_with_columns.cr
@@ -1,5 +1,5 @@
 module Gen::Mixins::MigrationWithColumns
-  SUPPORTED_TYPES = {"Bool", "Float64", "Int16", "Int32", "Int64", "String", "Time", "UUID"}
+  SUPPORTED_TYPES = {"Bool", "Float64", "Int16", "Int32", "Int64", "String", "Time", "UUID", "JSON::Any"}
 
   def create_migration
     Avram::Migrator::MigrationGenerator.new(


### PR DESCRIPTION
## Purpose

Fixes #1311 

## Description

This allows users to generate models and resources through the cli with a `JSON::Any` column type

```bash
lucky gen.model Post title:String content:String settings:JSON::Any
```

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
