### PR TITLE
Support html tags without content or block

### DIFF
--- a/spec/lucky/base_tags_spec.cr
+++ b/spec/lucky/base_tags_spec.cr
@@ -25,6 +25,7 @@ describe Lucky::BaseTags do
     view(&.para(42)).should contain "<p>42</p>"
     view(&.para(MySpecialClass.new)).should contain "<p>it works</p>"
     view(&.para(1_i64)).should contain "<p>1</p>"
+    view(&.para({"class" => "empty-content"})).should contain "<p class=\"empty-content\"></p>"
     view(&.hr).should contain "<hr>"
   end
 

--- a/src/lucky/tags/base_tags.cr
+++ b/src/lucky/tags/base_tags.cr
@@ -27,6 +27,10 @@ module Lucky::BaseTags
       end
     end
 
+    def {{method_name.id}}(options = EMPTY_HTML_ATTRS, **other_options) : Nil
+      {{ method_name.id }}("", options, **other_options)
+    end
+
     def {{method_name.id}}(content : String | Lucky::AllowedInTags) : Nil
       {{method_name.id}}(EMPTY_HTML_ATTRS) do
         text content


### PR DESCRIPTION
## Purpose

Fixes #1263 

## Description

Allows creating an empty tag without supplying a content string or block

```crystal
div class: "empty-div" #=> <div class="empty-div"></div>
```

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
