### PR TITLE
Infer route in action generators instead of using route macro

### DIFF
--- a/spec/tasks/gen/action_spec.cr
+++ b/spec/tasks/gen/action_spec.cr
@@ -37,7 +37,7 @@ describe Gen::Action do
 
       filename = "src/actions/users/announcements/index.cr"
       should_have_generated "#{valid_nested_action_name} < BrowserAction", inside: filename
-      should_have_generated " get \"/users/announcements\"", inside: filename
+      should_have_generated %(get "/users/announcements"), inside: filename
 
       io.to_s.should contain(valid_nested_action_name)
       io.to_s.should contain("/src/actions/users/announcements")

--- a/spec/tasks/gen/action_spec.cr
+++ b/spec/tasks/gen/action_spec.cr
@@ -37,6 +37,7 @@ describe Gen::Action do
 
       filename = "src/actions/users/announcements/index.cr"
       should_have_generated "#{valid_nested_action_name} < BrowserAction", inside: filename
+      should_have_generated " get \"/users/announcements\"", inside: filename
 
       io.to_s.should contain(valid_nested_action_name)
       io.to_s.should contain("/src/actions/users/announcements")
@@ -54,15 +55,10 @@ describe Gen::Action do
     end
   end
 
-  it "snake cases filenames of a camel case action" do
-    with_cleanup do
-      valid_camel_case_action_name = "Users::HostedEvents"
-      io = generate valid_camel_case_action_name, Gen::Action::Browser
+  it "fails if called with non-resourceful action name" do
+    io = generate "Users::HostedEvents", Gen::Action::Browser
 
-      should_have_generated valid_camel_case_action_name, inside: "src/actions/users/hosted_events.cr"
-      io.to_s.should contain(valid_camel_case_action_name)
-      io.to_s.should contain("/src/actions/users")
-    end
+    io.to_s.should contain "Could not infer route for Users::HostedEvents"
   end
 
   it "displays an error if given no arguments" do

--- a/spec/tasks/gen/resource_spec.cr
+++ b/spec/tasks/gen/resource_spec.cr
@@ -18,6 +18,14 @@ describe Gen::Resource::Browser do
           "./src/actions/users/update.cr": "class Users::Update < BrowserAction",
           "./src/actions/users/delete.cr": "class Users::Delete < BrowserAction"
         should_create_files_with_contents io,
+          "./src/actions/users/index.cr": "get \"/users\"",
+          "./src/actions/users/show.cr": "get \"/users/:user_id\"",
+          "./src/actions/users/new.cr": "get \"/users/new\"",
+          "./src/actions/users/create.cr": "post \"/users\"",
+          "./src/actions/users/edit.cr": "get \"/users/:user_id/edit\"",
+          "./src/actions/users/update.cr": "put \"/users/:user_id\"",
+          "./src/actions/users/delete.cr": "delete \"/users/:user_id\""
+        should_create_files_with_contents io,
           "./src/actions/users/show.cr": "html ShowPage, user: UserQuery.find(user_id)",
           "./src/actions/users/edit.cr": "user = UserQuery.find(user_id)",
           "./src/actions/users/update.cr": "user = UserQuery.find(user_id)",

--- a/spec/tasks/gen/resource_spec.cr
+++ b/spec/tasks/gen/resource_spec.cr
@@ -18,13 +18,13 @@ describe Gen::Resource::Browser do
           "./src/actions/users/update.cr": "class Users::Update < BrowserAction",
           "./src/actions/users/delete.cr": "class Users::Delete < BrowserAction"
         should_create_files_with_contents io,
-          "./src/actions/users/index.cr": "get \"/users\"",
-          "./src/actions/users/show.cr": "get \"/users/:user_id\"",
-          "./src/actions/users/new.cr": "get \"/users/new\"",
-          "./src/actions/users/create.cr": "post \"/users\"",
-          "./src/actions/users/edit.cr": "get \"/users/:user_id/edit\"",
-          "./src/actions/users/update.cr": "put \"/users/:user_id\"",
-          "./src/actions/users/delete.cr": "delete \"/users/:user_id\""
+          "./src/actions/users/index.cr": %(get "/users"),
+          "./src/actions/users/show.cr": %(get "/users/:user_id"),
+          "./src/actions/users/new.cr": %(get "/users/new"),
+          "./src/actions/users/create.cr": %(post "/users"),
+          "./src/actions/users/edit.cr": %(get "/users/:user_id/edit"),
+          "./src/actions/users/update.cr": %(put "/users/:user_id"),
+          "./src/actions/users/delete.cr": %(delete "/users/:user_id")
         should_create_files_with_contents io,
           "./src/actions/users/show.cr": "html ShowPage, user: UserQuery.find(user_id)",
           "./src/actions/users/edit.cr": "user = UserQuery.find(user_id)",

--- a/src/lucky/route_inferrer.cr
+++ b/src/lucky/route_inferrer.cr
@@ -6,7 +6,7 @@ class Lucky::RouteInferrer
   end
 
   def generate_inferred_route
-    "#{http_method} \"#{path}\""
+    %(#{http_method} "#{path}")
   end
 
   private def http_method

--- a/src/lucky/route_inferrer.cr
+++ b/src/lucky/route_inferrer.cr
@@ -1,0 +1,99 @@
+class Lucky::RouteInferrer
+  getter? nested_route
+  getter action_class_name
+
+  def initialize(@action_class_name : String, @nested_route : Bool = false)
+  end
+
+  def generate_inferred_route
+    "#{http_method} \"#{path}\""
+  end
+
+  private def http_method
+    case action_name
+    when "delete"
+      :delete
+    when "create"
+      :post
+    when "update"
+      :put
+    else
+      :get
+    end
+  end
+
+  private def path
+    "/" + all_pieces.join("/")
+  end
+
+  private def all_pieces
+    (namespace_pieces + parent_resource_pieces + resource_pieces).reject(&.empty?)
+  end
+
+  private def resource
+    action_pieces[-2]
+  end
+
+  private def action_name
+    action_pieces.last
+  end
+
+  private def namespace_pieces
+    _namespace_pieces = action_pieces.reject { |piece| piece == action_name || piece == resource }
+    if nested_route?
+      _namespace_pieces.reject { |piece| piece == parent_resource_name }
+    else
+      _namespace_pieces
+    end
+  end
+
+  private def resource_pieces
+    case action_name
+    when "index", "create"
+      [resource]
+    when "new"
+      [resource, "new"]
+    when "edit"
+      [resource, resource_id_param_name, "edit"]
+    when "show", "update", "delete"
+      [resource, resource_id_param_name]
+    else
+      resource_error
+    end
+  end
+
+  private def resource_id_param_name
+    ":#{Wordsmith::Inflector.singularize(resource)}_id"
+  end
+
+  private def resource_error
+    examples = "Users::Index # Index, Show, New, Create, Edit, Update, or Delete"
+
+    raise <<-ERROR
+      Could not infer route for #{action_class_name}
+
+      Got:
+        #{action_class_name} (missing a known resourceful action)
+
+      Expected something like:
+        #{examples}
+    ERROR
+  end
+
+  private def parent_resource_pieces
+    if nested_route?
+      singularized_param_name = ":#{Wordsmith::Inflector.singularize(parent_resource_name)}_id"
+      [parent_resource_name, singularized_param_name]
+    else
+      [] of String
+    end
+  end
+
+  private def parent_resource_name
+    action_pieces[-3]
+  end
+
+  private def action_pieces
+    action_class_name.split("::").map(&.underscore)
+  end
+end

--- a/tasks/gen/action/action_generator.cr
+++ b/tasks/gen/action/action_generator.cr
@@ -6,17 +6,18 @@ class Lucky::ActionTemplate < Teeplate::FileTree
   @name : String
   @action : String
   @inherit_from : String
+  @route : String
 
   directory "#{__DIR__}/../templates/action"
 
-  def initialize(@name, @action, @inherit_from)
+  def initialize(@name, @action, @inherit_from, @route)
   end
 end
 
 module Gen::ActionGenerator
   private def render_action_template(io, inherit_from : String)
     if valid?
-      Lucky::ActionTemplate.new(action_name, action, inherit_from).render(output_path)
+      Lucky::ActionTemplate.new(action_name, action, inherit_from, route).render(output_path)
       io.puts success_message
     else
       io.puts @error.colorize(:red)
@@ -24,7 +25,7 @@ module Gen::ActionGenerator
   end
 
   private def valid?
-    name_is_present && name_matches_format
+    name_is_present && name_matches_format && route_generated_from_action_name
   end
 
   private def name_is_present
@@ -35,6 +36,20 @@ module Gen::ActionGenerator
   private def name_matches_format
     @error = "That's not a valid Action. Example: lucky gen.action Users::Index"
     ARGV.first.includes?("::")
+  end
+
+  private def route_generated_from_action_name
+    route
+    true
+  rescue ex
+    @error = ex.message
+    false
+  end
+
+  @route : String?
+
+  private def route
+    @route ||= Lucky::RouteInferrer.new(action_class_name: action_name).generate_inferred_route
   end
 
   private def action_name

--- a/tasks/gen/resource/browser.cr
+++ b/tasks/gen/resource/browser.cr
@@ -174,4 +174,8 @@ class Lucky::ResourceTemplate < Teeplate::FileTree
   private def operation_class
     "Save#{resource}"
   end
+
+  private def route(action)
+    Lucky::RouteInferrer.new(action_class_name: "#{pluralized_name}::#{action}").generate_inferred_route
+  end
 end

--- a/tasks/gen/templates/action/{{action}}.cr.ecr
+++ b/tasks/gen/templates/action/{{action}}.cr.ecr
@@ -1,5 +1,5 @@
 class <%= @name %> < <%= @inherit_from %>
-  route do
+  <%= @route %> do
     plain_text "Render something in <%= @name %>"
   end
 end

--- a/tasks/gen/templates/resource/actions/{{folder_name}}/create.cr.ecr
+++ b/tasks/gen/templates/resource/actions/{{folder_name}}/create.cr.ecr
@@ -1,5 +1,5 @@
 class <%= pluralized_name %>::Create < BrowserAction
-  route do
+  <%= route("Create") %> do
     <%= operation_class %>.create(params) do |operation, <%= underscored_resource %>|
       if <%= underscored_resource %>
         flash.success = "The record has been saved"

--- a/tasks/gen/templates/resource/actions/{{folder_name}}/delete.cr.ecr
+++ b/tasks/gen/templates/resource/actions/{{folder_name}}/delete.cr.ecr
@@ -1,5 +1,5 @@
 class <%= pluralized_name %>::Delete < BrowserAction
-  route do
+  <%= route("Delete") %> do
     <%= query_class %>.find(<%= resource_id_method_name %>).delete
     flash.success = "Deleted the record"
     redirect Index

--- a/tasks/gen/templates/resource/actions/{{folder_name}}/edit.cr.ecr
+++ b/tasks/gen/templates/resource/actions/{{folder_name}}/edit.cr.ecr
@@ -1,5 +1,5 @@
 class <%= pluralized_name %>::Edit < BrowserAction
-  route do
+  <%= route("Edit") %> do
     <%= underscored_resource %> = <%= query_class %>.find(<%= resource_id_method_name %>)
     html EditPage,
       operation: <%= operation_class %>.new(<%= underscored_resource %>),

--- a/tasks/gen/templates/resource/actions/{{folder_name}}/index.cr.ecr
+++ b/tasks/gen/templates/resource/actions/{{folder_name}}/index.cr.ecr
@@ -1,5 +1,5 @@
 class <%= pluralized_name %>::Index < BrowserAction
-  route do
+  <%= route("Index") %> do
     html IndexPage, <%= pluralized_name.underscore %>: <%= query_class %>.new
   end
 end

--- a/tasks/gen/templates/resource/actions/{{folder_name}}/new.cr.ecr
+++ b/tasks/gen/templates/resource/actions/{{folder_name}}/new.cr.ecr
@@ -1,5 +1,5 @@
 class <%= pluralized_name %>::New < BrowserAction
-  route do
+  <%= route("New") %> do
     html NewPage, operation: <%= operation_class %>.new
   end
 end

--- a/tasks/gen/templates/resource/actions/{{folder_name}}/show.cr.ecr
+++ b/tasks/gen/templates/resource/actions/{{folder_name}}/show.cr.ecr
@@ -1,5 +1,5 @@
 class <%= pluralized_name %>::Show < BrowserAction
-  route do
+  <%= route("Show") %> do
     html ShowPage, <%= underscored_resource %>: <%= query_class %>.find(<%= resource_id_method_name %>)
   end
 end

--- a/tasks/gen/templates/resource/actions/{{folder_name}}/update.cr.ecr
+++ b/tasks/gen/templates/resource/actions/{{folder_name}}/update.cr.ecr
@@ -1,5 +1,5 @@
 class <%= pluralized_name %>::Update < BrowserAction
-  route do
+  <%= route("Update") %> do
     <%= underscored_resource %> = <%= query_class %>.find(<%= resource_id_method_name %>)
     <%= operation_class %>.update(<%= underscored_resource %>, params) do |operation, <%= underscored_resource %>|
       if operation.saved?


### PR DESCRIPTION
## Purpose

Fixes #1097 

## Description

Before we were utilizing the `route` macro in generated actions to infer the route at compile-time. This updates moves the route inferring into the generator.

```bash
$ lucky gen.action.browser Users::Index #=> route is GET /users
$ lucky gen.action.browser Users::Show #=> route is GET /users/:user_id
$ lucky gen.action.browser Users::Posts::Delete #=> route is DELETE /users/posts/:post_id
$ lucky gen.action.browser Users::GoOnline #=> fails because `GoOnline` is not a resourceful action

$ lucky gen.resource.browser User name:String #=> Creates all the routes with correct paths
```

Breaking Change:

- Generation of actions will fail if not ending with a resourceful action (Index, Show, etc.)

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
