### PR TITLE
Update resource generator to avoid shadowing outer variable

### DIFF
--- a/tasks/gen/templates/resource/actions/{{folder_name}}/update.cr.ecr
+++ b/tasks/gen/templates/resource/actions/{{folder_name}}/update.cr.ecr
@@ -1,13 +1,13 @@
 class <%= pluralized_name %>::Update < BrowserAction
   <%= route("Update") %> do
     <%= underscored_resource %> = <%= query_class %>.find(<%= resource_id_method_name %>)
-    <%= operation_class %>.update(<%= underscored_resource %>, params) do |operation, <%= underscored_resource %>|
+    <%= operation_class %>.update(<%= underscored_resource %>, params) do |operation, updated_<%= underscored_resource %>|
       if operation.saved?
         flash.success = "The record has been updated"
-        redirect Show.with(<%= underscored_resource %>.id)
+        redirect Show.with(updated_<%= underscored_resource %>.id)
       else
         flash.failure = "It looks like the form is not valid"
-        html EditPage, operation: operation, <%= underscored_resource %>: <%= underscored_resource %>
+        html EditPage, operation: operation, <%= underscored_resource %>: updated_<%= underscored_resource %>
       end
     end
   end


### PR DESCRIPTION
## Purpose

When running `gen.browser.resource`, the `Update` action created will shadow the outer variable in the block yielded from the operation. This was identified by Ameba, which threw this error:
`[W] Lint/ShadowingOuterLocalVar: Shadowing outer local variable`

## Description

For example, take `gen.browser.resource Topic label:String`.

**Before**
```crystal
class Topics::Update < BrowserAction
  route do
    topic = TopicQuery.find(topic_id)
    SaveTopic.update(topic, params) do |operation, topic|
      if operation.saved?
        flash.success = "The record has been updated"
        redirect Show.with(topic.id)
      else
        flash.failure = "It looks like the form is not valid"
        html EditPage, operation: operation, topic: topic
      end
    end
  end
end
```

**After**

```crystal
class Topics::Update < BrowserAction
  route do
    topic = TopicQuery.find(topic_id)
    SaveTopic.update(topic, params) do |operation, updated_topic|
      if operation.saved?
        flash.success = "The record has been updated"
        redirect Show.with(updated_topic.id)
      else
        flash.failure = "It looks like the form is not valid"
        html EditPage, operation: operation, topic: updated_topic
      end
    end
  end
end
```

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
