### PR TITLE
Allow reading from UploadedFile#tempfile

### DIFF
--- a/spec/lucky/uploaded_file_spec.cr
+++ b/spec/lucky/uploaded_file_spec.cr
@@ -14,6 +14,10 @@ describe Lucky::UploadedFile do
     it "returns the tempfile" do
       uploaded_file.tempfile.should be_a(File)
     end
+
+    it "can be read" do
+      uploaded_file.tempfile.gets_to_end.should eq("welcome file contents")
+    end
   end
 
   describe "#metadata" do

--- a/src/lucky/uploaded_file.cr
+++ b/src/lucky/uploaded_file.cr
@@ -13,7 +13,8 @@ class Lucky::UploadedFile
   # be assigned the body of the HTTP::FormData::Part
   def initialize(part : HTTP::FormData::Part)
     @name = part.name
-    @tempfile = File.tempfile(part.name) do |tempfile|
+    @tempfile = File.tempfile(part.name)
+    File.open(@tempfile.path, "w") do |tempfile|
       IO.copy(part.body, tempfile)
     end
     @metadata =


### PR DESCRIPTION
## Purpose

Fixes #1301

## Description

Before, the tempfile was closed once the content was written to it. Now it can be read from.

I saw this in Amber's file class https://github.com/amberframework/amber/blob/58eea3e147ba384fe4cb7c5f0a63da61b357e356/src/amber/router/file.cr#L15-L18

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
