### PR TITLE
Support multiple form data values for a key

### DIFF
--- a/src/lucky/form_data.cr
+++ b/src/lucky/form_data.cr
@@ -1,0 +1,45 @@
+class Lucky::FormData
+  getter params = MultiValueStorage(String).new
+  getter files = MultiValueStorage(Lucky::UploadedFile).new
+
+  def add(part : HTTP::FormData::Part)
+    case part.headers
+    when .includes_word?("Content-Disposition", "filename")
+      files.add(part.name, Lucky::UploadedFile.new(part))
+    else
+      params.add(part.name, part.body.gets_to_end)
+    end
+  end
+
+  # Simpler, generic implementation of HTTP::Params
+  class MultiValueStorage(T)
+    include Enumerable({String, T})
+
+    private getter storage : Hash(String, Array(T))
+
+    def initialize
+      @storage = {} of String => Array(T)
+    end
+
+    def ==(other : self)
+      self.storage == other.storage
+    end
+
+    def []?(key : String) : T?
+      storage[key]?.try(&.first?)
+    end
+
+    def add(key : String, value : T)
+      storage[key] ||= [] of T
+      storage[key] << value
+    end
+
+    def each
+      storage.each do |name, values|
+        values.each do |value|
+          yield({name, value})
+        end
+      end
+    end
+  end
+end

--- a/src/lucky/form_data.cr
+++ b/src/lucky/form_data.cr
@@ -21,10 +21,6 @@ class Lucky::FormData
       @storage = {} of String => Array(T)
     end
 
-    def ==(other : self)
-      self.storage == other.storage
-    end
-
     def []?(key : String) : T?
       storage[key]?.try(&.first?)
     end

--- a/src/lucky/form_data_parser.cr
+++ b/src/lucky/form_data_parser.cr
@@ -11,7 +11,7 @@ class Lucky::FormDataParser
     form_data = Lucky::FormData.new
     boundary = MIME::Multipart.parse_boundary(request.headers["Content-Type"]).to_s
 
-    HTTP::FormData.parse(body_io, boundary.to_s) do |part|
+    HTTP::FormData.parse(body_io, boundary) do |part|
       form_data.add(part)
     end
     form_data

--- a/src/lucky/form_data_parser.cr
+++ b/src/lucky/form_data_parser.cr
@@ -1,0 +1,19 @@
+# :nodoc:
+class Lucky::FormDataParser
+  getter body : String
+  getter request : HTTP::Request
+
+  def initialize(@body, @request)
+  end
+
+  def form_data : Lucky::FormData
+    body_io = IO::Memory.new(body)
+    form_data = Lucky::FormData.new
+    boundary = MIME::Multipart.parse_boundary(request.headers["Content-Type"]).to_s
+
+    HTTP::FormData.parse(body_io, boundary.to_s) do |part|
+      form_data.add(part)
+    end
+    form_data
+  end
+end


### PR DESCRIPTION
## Purpose

Related to https://github.com/luckyframework/lucky/issues/1380

## Description

This does not change the API of `Lucky::Params` at all. This only updates our form data storage to be more like `HTTP::Params` which acts like a hash with a single value but actually stores the values in a list and provides specific methods to access that list.

This does **NOT** provide the API to access the list of form data values since we don't need it yet. Future changes implementing support for multiple values in `Lucky::Params` will need to add it.

I did not add any specs as I consider this a refactor.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
