### PR TITLE
Remove broken Lucky::CustomTags#tag overloads

### DIFF
--- a/src/lucky/tags/custom_tags.cr
+++ b/src/lucky/tags/custom_tags.cr
@@ -16,18 +16,6 @@ module Lucky::CustomTags
     end
   end
 
-  def tag(tag_name : String, content : String | Lucky::AllowedInTags) : Nil
-    tag(EMPTY_HTML_ATTRS) do
-      text content
-    end
-  end
-
-  def tag(tag_name : String, &block) : Nil
-    tag(EMPTY_HTML_ATTRS) do
-      yield
-    end
-  end
-
   def tag(tag_name : String, attrs : Array(Symbol) = [] of Symbol, options = EMPTY_HTML_ATTRS, **other_options, &block) : Nil
     merged_options = merge_options(other_options, options)
     tag_attrs = build_tag_attrs(merged_options)


### PR DESCRIPTION
## Purpose

Fixes #1392 

## Description

The overloads never seemed to work. Both of the overloads are covered by the other two defined overloads.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
