### PR TITLE
Fix Avram::PermittedAttribute usages

### DIFF
--- a/spec/lucky/input_helpers_spec.cr
+++ b/spec/lucky/input_helpers_spec.cr
@@ -19,7 +19,7 @@ class InputTestForm
   end
 
   def eula(value : String)
-    Avram::PermittedAttribute(String?).new(
+    Avram::PermittedAttribute(String).new(
       name: :eula,
       param: nil,
       value: value,
@@ -28,7 +28,7 @@ class InputTestForm
   end
 
   def admin(checked : Bool)
-    Avram::PermittedAttribute(Bool?).new(
+    Avram::PermittedAttribute(Bool).new(
       name: :admin,
       param: nil,
       value: checked,
@@ -37,7 +37,7 @@ class InputTestForm
   end
 
   def joined_at
-    Avram::PermittedAttribute(Time?).new(
+    Avram::PermittedAttribute(Time).new(
       name: :joined_at,
       param: nil,
       value: Time.utc(2016, 2, 15, 10, 20, 30),
@@ -46,7 +46,7 @@ class InputTestForm
   end
 
   def status(value : String)
-    Avram::PermittedAttribute(String?).new(
+    Avram::PermittedAttribute(String).new(
       name: :status,
       param: nil,
       value: value,

--- a/spec/lucky/select_helpers_spec.cr
+++ b/spec/lucky/select_helpers_spec.cr
@@ -1,5 +1,7 @@
 require "../spec_helper"
 
+include ContextHelper
+
 private class TestPage
   include Lucky::HTMLPage
 
@@ -29,7 +31,7 @@ end
 
 class SomeFormWithCompany
   def company_id
-    Avram::PermittedAttribute(Int32?).new(
+    Avram::PermittedAttribute(Int32).new(
       name: :company_id,
       param: "1",
       value: nil,
@@ -46,9 +48,9 @@ describe Lucky::SelectHelpers do
   end
 
   it "renders options" do
-    view.render_options(form.company_id, [{"Volvo", 2}, {"BMW", 3}])
+    view.render_options(form.company_id, [{"Volvo", 2}, {"BMW", 3}, {"None", nil}])
       .html.to_s.should eq <<-HTML
-      <option value="2">Volvo</option><option value="3">BMW</option>
+      <option value="2">Volvo</option><option value="3">BMW</option><option value="">None</option>
       HTML
   end
 

--- a/src/lucky/tags/input_helpers.cr
+++ b/src/lucky/tags/input_helpers.cr
@@ -73,11 +73,11 @@ module Lucky::InputHelpers
     generate_input(field, "checkbox", html_options)
   end
 
-  def checkbox(field : Avram::PermittedAttribute(Bool?), **html_options) : Nil
+  def checkbox(field : Avram::PermittedAttribute(Bool), **html_options) : Nil
     checkbox field, EMPTY_BOOLEAN_ATTRIBUTES, **html_options
   end
 
-  def checkbox(field : Avram::PermittedAttribute(Bool?), attrs : Array(Symbol), **html_options) : Nil
+  def checkbox(field : Avram::PermittedAttribute(Bool), attrs : Array(Symbol), **html_options) : Nil
     unchecked_value = "false"
     if field.value
       html_options = merge_options(html_options, {"checked" => "true"})
@@ -95,7 +95,7 @@ module Lucky::InputHelpers
   # radio(attribute, "checked_value")
   # # => <input type="radio" id="param_key_attribute_name_checked_value" name="param_key:attribute_name" value="checked_value" checked="true">
   # ```
-  def radio(field : Avram::PermittedAttribute(String?),
+  def radio(field : Avram::PermittedAttribute(String),
             checked_value : String,
             **html_options) : Nil
     radio field, checked_value, EMPTY_BOOLEAN_ATTRIBUTES, **html_options
@@ -107,7 +107,7 @@ module Lucky::InputHelpers
   # radio(attribute, "checked_value", attrs: [:required])
   # # => <input type="radio" id="param_key_attribute_name_checked_value" name="param_key:attribute_name" value="checked_value" checked="true" required />
   # ```
-  def radio(field : Avram::PermittedAttribute(String?),
+  def radio(field : Avram::PermittedAttribute(String),
             checked_value : String,
             attrs : Array(Symbol),
             **html_options) : Nil

--- a/src/lucky/tags/select_helpers.cr
+++ b/src/lucky/tags/select_helpers.cr
@@ -5,7 +5,7 @@ module Lucky::SelectHelpers
     end
   end
 
-  def options_for_select(field : Avram::PermittedAttribute(T), select_options : Array(Tuple(String, T)), **html_options) : Nil forall T
+  def options_for_select(field : Avram::PermittedAttribute(T), select_options : Array(Tuple(String, T?)), **html_options) : Nil forall T
     select_options.each do |option_name, option_value|
       attributes = {"value" => option_value.to_s}
 


### PR DESCRIPTION
## Purpose

Fixes #1404

## Description

Various places we were depending on the old way Avram worked where if the column was nilable, the attribute generated had a nilable generic `column name : String?` became `Avram::PermittedAttribute(String?)` but that is no longer the case. nilable and non-nilable columns both create a `Avram::PermittedAttribute(String)`

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
