### PR TITLE
fix: Better wording after generating a new resource

### DIFF
--- a/tasks/gen/resource/browser.cr
+++ b/tasks/gen/resource/browser.cr
@@ -34,7 +34,7 @@ class Gen::Resource::Browser < LuckyCli::Task
   def call(@io : IO = STDOUT)
     validate!
     generate_resource
-    io.puts "\nRun generated migrations with #{"lucky db.migrate".colorize.green}"
+    io.puts "\nYou will need to run the #{"lucky db.migrate".colorize.green} task next"
     display_path_to_resource
   rescue e : InvalidOption
     io.puts e.message.colorize.red


### PR DESCRIPTION
## Purpose
Fix #1416  

## Description
Adjusted the phrase as suggested by @jwoertink. 

## Checklist
* [X] - An issue already exists detailing the issue/or feature request that this PR fixes
* [X] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [X] - Lucky builds on docker with `./script/setup`
* [X] - All builds and specs pass on docker with `./script/test`
