### PR TITLE
Catch and error when href passed to link

### DIFF
--- a/src/lucky/tags/link_helpers.cr
+++ b/src/lucky/tags/link_helpers.cr
@@ -1,12 +1,12 @@
 module Lucky::LinkHelpers
   def link(text, to : Lucky::RouteHelper, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
-    link(to, attrs, **html_options) do
+    link(**html_options, to: to, attrs: attrs) do
       text text
     end
   end
 
   def link(to : Lucky::RouteHelper, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
-    link(to, attrs, **html_options) {}
+    link(**html_options, to: to, attrs: attrs) {}
   end
 
   def link(to : Lucky::RouteHelper, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
@@ -16,17 +16,17 @@ module Lucky::LinkHelpers
   end
 
   def link(text, to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
-    link(to, attrs, **html_options) do
+    link(**html_options, to: to, attrs: attrs) do
       text text
     end
   end
 
   def link(to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
-    link(to, attrs, **html_options) {}
+    link(**html_options, to: to, attrs: attrs) {}
   end
 
   def link(to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
-    link(to.route, attrs, **html_options) do
+    link(**html_options, to: to.route, attrs: attrs) do
       yield
     end
   end

--- a/src/lucky/tags/link_helpers.cr
+++ b/src/lucky/tags/link_helpers.cr
@@ -9,6 +9,25 @@ module Lucky::LinkHelpers
     link(**html_options, to: to, attrs: attrs) {}
   end
 
+  def link(to : Lucky::RouteHelper, href : String, **html_options, &block) : Nil
+    {%
+     raise <<-ERROR
+     'link' cannot be called with an href.
+
+     Use 'a()' or remove the href argument.
+
+     Example:
+
+       a href: "/" do
+       end
+
+       link to: Home::Index do
+       end
+
+     ERROR
+    %}
+  end
+
   def link(to : Lucky::RouteHelper, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
     a attrs, merge_options(html_options, link_to_href(to)) do
       yield

--- a/src/lucky/tags/link_helpers.cr
+++ b/src/lucky/tags/link_helpers.cr
@@ -6,25 +6,25 @@ module Lucky::LinkHelpers
   end
 
   def link(to : Lucky::RouteHelper, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
-    link(**html_options, to: to, attrs: attrs) {}
+    link(**html_options, to: to, attrs: attrs) { }
   end
 
   def link(to : Lucky::RouteHelper, href : String, **html_options, &block) : Nil
     {%
-     raise <<-ERROR
-     'link' cannot be called with an href.
+      raise <<-ERROR
+      'link' cannot be called with an href.
 
-     Use 'a()' or remove the href argument.
+      Use 'a()' or remove the href argument.
 
-     Example:
+      Example:
 
-       a href: "/" do
-       end
+        a href: "/" do
+        end
 
-       link to: Home::Index do
-       end
+        link to: Home::Index do
+        end
 
-     ERROR
+      ERROR
     %}
   end
 
@@ -41,7 +41,7 @@ module Lucky::LinkHelpers
   end
 
   def link(to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
-    link(**html_options, to: to, attrs: attrs) {}
+    link(**html_options, to: to, attrs: attrs) { }
   end
 
   def link(to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil

--- a/src/lucky/tags/link_helpers.cr
+++ b/src/lucky/tags/link_helpers.cr
@@ -1,10 +1,12 @@
 module Lucky::LinkHelpers
   def link(text, to : Lucky::RouteHelper, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
-    a text, merge_options(html_options, link_to_href(to)), attrs
+    link(to, attrs, **html_options) do
+      text text
+    end
   end
 
-  def link(text, to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
-    a text, merge_options(html_options, link_to_href(to.route)), attrs
+  def link(to : Lucky::RouteHelper, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
+    link(to, attrs, **html_options) {}
   end
 
   def link(to : Lucky::RouteHelper, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
@@ -13,18 +15,20 @@ module Lucky::LinkHelpers
     end
   end
 
-  def link(to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
-    a attrs, merge_options(html_options, link_to_href(to.route)) do
-      yield
+  def link(text, to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
+    link(to, attrs, **html_options) do
+      text text
     end
   end
 
-  def link(to : Lucky::RouteHelper, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
-    a(attrs, merge_options(html_options, link_to_href(to))) { }
+  def link(to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
+    link(to, attrs, **html_options) {}
   end
 
   def link(to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
-    a(attrs, merge_options(html_options, link_to_href(to.route))) { }
+    link(to.route, attrs, **html_options) do
+      yield
+    end
   end
 
   private def link_to_href(route)


### PR DESCRIPTION
## Purpose

Fixes #1415 

## Description

Link is a helper method that allows you to pass lucky routes instead of specifying the `href` string specifically. This adds a method overload to catch when `href` is accidentally passed.

Before I was able to add the overload, I had to refactor all the methods to have them funnel into one method so that an overload wouldn't have to be added for every different way you can call `link`

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
