### PR TITLE
Mount instance

### DIFF
--- a/src/lucky/mount_component.cr
+++ b/src/lucky/mount_component.cr
@@ -73,6 +73,45 @@ module Lucky::MountComponent
     end
   end
 
+  # Appends the `component` to the view.
+  # The `component` is a previously initialized instance of a component.
+  #
+  # When `Lucky::HTMLPage.settings.render_component_comments` is
+  # set to `true`, it will render HTML comments showing where the component
+  # starts and ends.
+  #
+  # ```
+  # component = MyComponent.new(name: "Jane")
+  # mount_instance(component)
+  # ```
+  def mount_instance(component : Lucky::BaseComponent) : Nil
+    print_component_comment(component.class) do
+      component.view(view).render
+    end
+  end
+
+  # Appends the `component` to the view. Takes a block, and yields the
+  # args passed to the component.
+  # The `component` is a previously initialized instance of a component.
+  #
+  # When `Lucky::HTMLPage.settings.render_component_comments` is
+  # set to `true`, it will render HTML comments showing where the component
+  # starts and ends.
+  #
+  # ```
+  # component = MyComponent.new(name: "Jane")
+  # mount_instance(component) do |name|
+  #   text name.upcase
+  # end
+  # ```
+  def mount_instance(component : Lucky::BaseComponent) : Nil
+    print_component_comment(component.class) do
+      component.view(view).render do |*yield_args|
+        yield *yield_args
+      end
+    end
+  end
+
   private def print_component_comment(component : Lucky::BaseComponent.class) : Nil
     if Lucky::HTMLPage.settings.render_component_comments
       raw "<!-- BEGIN: #{component.name} #{component.file_location} -->"

--- a/src/lucky/mount_component.cr
+++ b/src/lucky/mount_component.cr
@@ -73,6 +73,58 @@ module Lucky::MountComponent
     end
   end
 
+  # :nodoc:
+  def mount(_component : Lucky::BaseComponent, *args, **named_args) : Nil
+    {% raise <<-ERROR
+        'mount' requires a component class, not an instance of a component.
+
+        Try this...
+
+           ▸ mount MyComponent
+           ▸ mount_instance MyComponent.new
+        ERROR
+    %}
+  end
+
+  # :nodoc:
+  def mount(_component : Lucky::BaseComponent, *args, **named_args, &) : Nil
+    {% raise <<-ERROR
+        'mount' requires a component class, not an instance of a component.
+
+        Try this...
+
+           ▸ mount MyComponent
+           ▸ mount_instance MyComponent.new
+        ERROR
+    %}
+  end
+
+  # :nodoc:
+  def mount_instance(_component : Lucky::BaseComponent.class) : Nil
+    {% raise <<-ERROR
+        'mount_instance' requires an instance of a component, not component class.
+
+        Try this...
+
+           ▸ mount MyComponent
+           ▸ mount_instance MyComponent.new
+        ERROR
+    %}
+  end
+
+  # :nodoc:
+  def mount_instance(_component : Lucky::BaseComponent.class, &) : Nil
+    {% raise <<-ERROR
+        'mount_instance' requires an instance of a component, not component class.
+
+        Try this...
+
+           ▸ mount MyComponent
+           ▸ mount_instance MyComponent.new
+        ERROR
+    %}
+  end
+
   # Appends the `component` to the view.
   # The `component` is a previously initialized instance of a component.
   #


### PR DESCRIPTION
## Purpose
Addresses #1427 

Allows for dynamically creating components and mounting/rendering them. This is useful for lists of components and polymorphic components.

## Description
Adds `mount_instance` variants of the `mount` methods that take an instance of a component, rather than a class. Only one argument is accepted - the instance of a component. Also handles yielded arguments.

```crystal
component = MyComponent.new("some arg")
mount_instance(component)

component = MyOtherComponent.new("another arg")
mount_instance(component) do |name|
  text name.downcase
end
```

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
