### PR TITLE
Support VueJS style attributes on tag_defaults

### DIFF
--- a/spec/lucky/tag_defaults_spec.cr
+++ b/spec/lucky/tag_defaults_spec.cr
@@ -44,9 +44,19 @@ private class TestTagDefaultsPage
       end
     end
 
+    {% if compare_versions(Crystal::VERSION, "0.36.1") > 0 %}
+      tag_defaults do |tag_builder|
+        tag_builder.div "@click": "onclick($event)" do
+          text "block content"
+        end
+      end
+    {% end %}
+
     view
   end
 end
+
+include ContextHelper
 
 describe "tag_defaults" do
   it "renders the component" do
@@ -70,6 +80,10 @@ describe "tag_defaults" do
       .should contain %(<div class="default">text content</div>)
     contents
       .should contain %(<div class="default">block content</div>)
+    {% if compare_versions(Crystal::VERSION, "0.36.1") > 0 %}
+      contents
+        .should contain %(<div @click="onclick($event)">block content</div>)
+    {% end %}
   end
 end
 

--- a/src/lucky/tags/tag_defaults.cr
+++ b/src/lucky/tags/tag_defaults.cr
@@ -81,11 +81,7 @@ module Lucky::TagDefaults
         {% named_args = named_args.reject { |arg| arg.name == :replace_class } %}
       {% end %}
 
-      nargs = @named_args{% if named_args %}.merge(
-        {% for arg in named_args %}
-          {{ arg }}
-        {% end %}
-      )
+      nargs = @named_args{% if named_args %}.merge({{ named_args.splat }})
 
       # If there is no default class and we want to append/replace one, then
       # the compiler blows up because the @named_args type is a Union. Where

--- a/src/lucky/tags/tag_defaults.cr
+++ b/src/lucky/tags/tag_defaults.cr
@@ -83,7 +83,7 @@ module Lucky::TagDefaults
 
       nargs = @named_args{% if named_args %}.merge(
         {% for arg in named_args %}
-          {{ arg.name }}: {{ arg.value }},
+          {{ arg }}
         {% end %}
       )
 


### PR DESCRIPTION
## Purpose

Fixes #1409 

## Description

Allows using VueJS style attributes (like `@click`) when using `tag_defaults`. This only works on Crystal 1.0.0 because of https://github.com/crystal-lang/crystal/pull/10388

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
