### PR TITLE
Allow creating custom tag with name and hash only

### DIFF
--- a/spec/lucky/custom_tags_spec.cr
+++ b/spec/lucky/custom_tags_spec.cr
@@ -25,6 +25,8 @@ describe Lucky::CustomTags do
       .to_s.should contain "<foo-tag></foo-tag>"
     view(&.tag("foo-tag", class: "my-class"))
       .to_s.should contain %(<foo-tag class="my-class"></foo-tag>)
+    view(&.tag("foo-tag", {"class" => "my-class"}))
+      .to_s.should contain %(<foo-tag class="my-class"></foo-tag>)
     view(&.tag("foo-tag", attrs: [:ng_strict_di], ng_app: "ngAppStrictDemo", name: "JSApp"))
       .to_s.should contain %(<foo-tag ng-app="ngAppStrictDemo" name="JSApp" ng-strict-di></foo-tag>)
 

--- a/src/lucky/tags/custom_tags.cr
+++ b/src/lucky/tags/custom_tags.cr
@@ -16,6 +16,14 @@ module Lucky::CustomTags
     end
   end
 
+  def tag(
+    tag_name : String,
+    options = EMPTY_HTML_ATTRS,
+    **other_options
+  ) : Nil
+    tag(tag_name, "", options, **other_options)
+  end
+
   def tag(tag_name : String, attrs : Array(Symbol) = [] of Symbol, options = EMPTY_HTML_ATTRS, **other_options, &block) : Nil
     merged_options = merge_options(other_options, options)
     tag_attrs = build_tag_attrs(merged_options)


### PR DESCRIPTION
## Purpose

Fixes #1418 

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
