### PR TITLE
Bump exception_page shard to ~> 0.2.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -54,7 +54,7 @@ dependencies:
     version: ~> 0.4.3
   exception_page:
     github: crystal-loot/exception_page
-    version: ~> 0.1.5
+    version: ~> 0.2.0
   dexter:
     github: luckyframework/dexter
     version: ~> 0.3.3


### PR DESCRIPTION
## Purpose

Updates [exception_page](https://github.com/crystal-loot/exception_page) shard to ~> 0.2.0

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`