### PR TITLE
Implement `mount_with_defaults`

### DIFF
--- a/src/lucky/memoizable.cr
+++ b/src/lucky/memoizable.cr
@@ -22,7 +22,7 @@ module Lucky::Memoizable
   macro memoize(method_def)
     {% raise "You must define a return type for memoized methods" if method_def.return_type.is_a?(Nop) %}
     {%
-      raise "All arguments must have an explicit type for memoized methods" if method_def.args.any? &.is_a?(Nop) # ameba:disable Style/IsAFilter
+      raise "All arguments must have an explicit type for memoized methods" if method_def.args.any? &.is_a?(Nop)
     %}
 
     @__memoized_{{method_def.name}} : Tuple(

--- a/src/lucky/mount_component.cr
+++ b/src/lucky/mount_component.cr
@@ -82,7 +82,7 @@ module Lucky::MountComponent
 
            ▸ mount MyComponent
            ▸ mount_instance MyComponent.new
-           ▸ mount_with_defaults MyComponent.new
+           ▸ mount_with_defaults MyComponent
         ERROR
     %}
   end
@@ -96,7 +96,7 @@ module Lucky::MountComponent
 
            ▸ mount MyComponent
            ▸ mount_instance MyComponent.new
-           ▸ mount_with_defaults MyComponent.new
+           ▸ mount_with_defaults MyComponent
         ERROR
     %}
   end
@@ -110,7 +110,7 @@ module Lucky::MountComponent
 
            ▸ mount MyComponent
            ▸ mount_instance MyComponent.new
-           ▸ mount_with_defaults MyComponent.new
+           ▸ mount_with_defaults MyComponent
         ERROR
     %}
   end
@@ -124,7 +124,7 @@ module Lucky::MountComponent
 
            ▸ mount MyComponent
            ▸ mount_instance MyComponent.new
-           ▸ mount_with_defaults MyComponent.new
+           ▸ mount_with_defaults MyComponent
         ERROR
     %}
   end
@@ -177,7 +177,7 @@ module Lucky::MountComponent
 
            ▸ mount MyComponent
            ▸ mount_instance MyComponent.new
-           ▸ mount_with_defaults MyComponent.new
+           ▸ mount_with_defaults MyComponent
         ERROR
     %}
   end
@@ -191,7 +191,7 @@ module Lucky::MountComponent
 
            ▸ mount MyComponent
            ▸ mount_instance MyComponent.new
-           ▸ mount_with_defaults MyComponent.new
+           ▸ mount_with_defaults MyComponent
         ERROR
     %}
   end
@@ -200,7 +200,6 @@ module Lucky::MountComponent
   #
   # Includes the following common `needs` arguments:
   # * `context`
-  # * `current_user`
   #
   # When `Lucky::HTMLPage.settings.render_component_comments` is
   # set to `true`, it will render HTML comments showing where the component
@@ -212,7 +211,7 @@ module Lucky::MountComponent
   # ```
   def mount_with_defaults(component : Lucky::BaseComponent.class, *args, **named_args) : Nil
     print_component_comment(component) do
-      component.new(*args, **named_args).view(view).render
+      component.new(*args, **named_args, context: @context).view(view).render
     end
   end
 
@@ -221,7 +220,6 @@ module Lucky::MountComponent
   #
   # Includes the following common `needs` arguments:
   # * `context`
-  # * `current_user`
   #
   # When `Lucky::HTMLPage.settings.render_component_comments` is
   # set to `true`, it will render HTML comments showing where the component
@@ -234,7 +232,7 @@ module Lucky::MountComponent
   # ```
   def mount_with_defaults(component : Lucky::BaseComponent.class, *args, **named_args) : Nil
     print_component_comment(component) do
-      component.new(*args, **named_args).view(view).render do |*yield_args|
+      component.new(*args, **named_args, context: @context).view(view).render do |*yield_args|
         yield *yield_args
       end
     end

--- a/src/lucky/mount_component.cr
+++ b/src/lucky/mount_component.cr
@@ -200,6 +200,7 @@ module Lucky::MountComponent
   #
   # Includes the following common `needs` arguments:
   # * `context`
+  # * `current_user`
   #
   # When `Lucky::HTMLPage.settings.render_component_comments` is
   # set to `true`, it will render HTML comments showing where the component
@@ -211,7 +212,7 @@ module Lucky::MountComponent
   # ```
   def mount_with_defaults(component : Lucky::BaseComponent.class, *args, **named_args) : Nil
     print_component_comment(component) do
-      component.new(*args, **named_args, context: @context).view(view).render
+      component.new(*args, **named_args, context: @context, current_user: current_user).view(view).render
     end
   end
 
@@ -220,6 +221,7 @@ module Lucky::MountComponent
   #
   # Includes the following common `needs` arguments:
   # * `context`
+  # * `current_user`
   #
   # When `Lucky::HTMLPage.settings.render_component_comments` is
   # set to `true`, it will render HTML comments showing where the component
@@ -232,7 +234,7 @@ module Lucky::MountComponent
   # ```
   def mount_with_defaults(component : Lucky::BaseComponent.class, *args, **named_args) : Nil
     print_component_comment(component) do
-      component.new(*args, **named_args, context: @context).view(view).render do |*yield_args|
+      component.new(*args, **named_args, context: @context, current_user: current_user).view(view).render do |*yield_args|
         yield *yield_args
       end
     end

--- a/src/lucky/mount_component.cr
+++ b/src/lucky/mount_component.cr
@@ -82,6 +82,7 @@ module Lucky::MountComponent
 
            ▸ mount MyComponent
            ▸ mount_instance MyComponent.new
+           ▸ mount_with_defaults MyComponent.new
         ERROR
     %}
   end
@@ -95,6 +96,7 @@ module Lucky::MountComponent
 
            ▸ mount MyComponent
            ▸ mount_instance MyComponent.new
+           ▸ mount_with_defaults MyComponent.new
         ERROR
     %}
   end
@@ -108,6 +110,7 @@ module Lucky::MountComponent
 
            ▸ mount MyComponent
            ▸ mount_instance MyComponent.new
+           ▸ mount_with_defaults MyComponent.new
         ERROR
     %}
   end
@@ -121,6 +124,7 @@ module Lucky::MountComponent
 
            ▸ mount MyComponent
            ▸ mount_instance MyComponent.new
+           ▸ mount_with_defaults MyComponent.new
         ERROR
     %}
   end
@@ -159,6 +163,78 @@ module Lucky::MountComponent
   def mount_instance(component : Lucky::BaseComponent) : Nil
     print_component_comment(component.class) do
       component.view(view).render do |*yield_args|
+        yield *yield_args
+      end
+    end
+  end
+
+  # :nodoc:
+  def mount_with_defaults(_component : Lucky::BaseComponent.class) : Nil
+    {% raise <<-ERROR
+        'mount_with_defaults' requires an instance of a component, not component class.
+
+        Try this...
+
+           ▸ mount MyComponent
+           ▸ mount_instance MyComponent.new
+           ▸ mount_with_defaults MyComponent.new
+        ERROR
+    %}
+  end
+
+  # :nodoc:
+  def mount_with_defaults(_component : Lucky::BaseComponent.class, &) : Nil
+    {% raise <<-ERROR
+        'mount_with_defaults' requires an instance of a component, not component class.
+
+        Try this...
+
+           ▸ mount MyComponent
+           ▸ mount_instance MyComponent.new
+           ▸ mount_with_defaults MyComponent.new
+        ERROR
+    %}
+  end
+
+  # Appends the `component` to the view.
+  #
+  # Includes the following common `needs` arguments:
+  # * `context`
+  # * `current_user`
+  #
+  # When `Lucky::HTMLPage.settings.render_component_comments` is
+  # set to `true`, it will render HTML comments showing where the component
+  # starts and ends.
+  #
+  # ```
+  # mount_with_defaults(MyComponent)
+  # mount_with_defaults(MyComponent, with_args: 123)
+  # ```
+  def mount_with_defaults(component : Lucky::BaseComponent.class, *args, **named_args) : Nil
+    print_component_comment(component) do
+      component.new(*args, **named_args).view(view).render
+    end
+  end
+
+  # Appends the `component` to the view. Takes a block, and yields the
+  # args passed to the component.
+  #
+  # Includes the following common `needs` arguments:
+  # * `context`
+  # * `current_user`
+  #
+  # When `Lucky::HTMLPage.settings.render_component_comments` is
+  # set to `true`, it will render HTML comments showing where the component
+  # starts and ends.
+  #
+  # ```
+  # mount_with_defaults(MyComponent, name: "Jane") do |name|
+  #   text name.upcase
+  # end
+  # ```
+  def mount_with_defaults(component : Lucky::BaseComponent.class, *args, **named_args) : Nil
+    print_component_comment(component) do
+      component.new(*args, **named_args).view(view).render do |*yield_args|
         yield *yield_args
       end
     end


### PR DESCRIPTION
## Purpose
Fixes #1152 by adding a new `mount_with_defaults` method that can inject some helpful defaults into components.

## Description
I'd like to get some feedback from others before I go too far down any given path. That said, I've got the thing that was blocking me working. Say we have a component with a `form`, like this:

```crystal
class Filters::Form < BaseComponent
  needs context : HTTP::Server::Context
  needs current_user : User
  needs operation : SaveFilter
  needs route : Lucky::RouteHelper
  needs button_text : String

  def render
    form_for route, class: "divide-y divide-gray-200" do
      div class: "px-4 py-5 sm:p-6 space-y-4" do
        mount Filters::FormFields, operation
      end

      div class: "px-4 py-4 sm:px-6" do
        mount UI::Button, &.submit button_text
      end
    end
  end
end
```

This is a really nice abstraction, and greatly cleans up the duplication between `edit_page.cr` and`new_page.cr` for the `Filter` model, in this case.

**I'm not super thrilled about having to manually add `needs context` and `needs current_user` to the component, but also not sure if we can inject that after the component is initialized so that it's available but invisible.**

The use of this component looks something like this:

```crystal
class Filters::NewPage < MainLayout
  needs operation : SaveFilter
  quick_def page_title, "New Filter"

  def content
    div class: "bg-white overflow-hidden shadow rounded-lg divide-y divide-gray-200" do
      div class: "px-4 py-5 sm:px-6" do
        h3 class: "text-lg leading-6 font-medium text-gray-900" do
          text "New filter"
        end
      end

      mount_with_defaults Filters::Form, operation: operation, route: Filters::Create.route, button_text: "Create filter"
    end
  end
end
```

## To-do
* [ ] - Add specs for the new `mount_with_defaults`

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [ ] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [ ] - All builds and specs pass on docker with `./script/test`
