### PR TITLE
Nightly Crystal and edge shard testing in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Lucky CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
     branches: "*"
 
@@ -11,18 +11,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        shard_file:
+          - shard.yml
         crystal_version:
           - 0.36.1
           - 1.0.0
         experimental:
           - false
+        include:
+          - shard_file: shard.edge.yml
+            crystal_version: 1.0.0
+            experimental: true
+          - shard_file: shard.yml
+            crystal_version: nightly
+            experimental: true
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     container: crystallang/crystal:${{ matrix.crystal_version }}-alpine
+    env:
+      SKIP_LUCKY_TASK_PRECOMPILATION: "1"
     steps:
       - uses: actions/checkout@v1
       - name: Install shards
-        run: shards install
+        run: SHARDS_OVERRIDE=${{ matrix.shard_file }} shards install
       - name: Format
         run: crystal tool format --check
       - name: Lint
@@ -31,22 +42,33 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        shard_file:
+          - shard.yml
         crystal_version:
           - 0.36.1
           - 1.0.0
         experimental:
           - false
+        include:
+          - shard_file: shard.edge.yml
+            crystal_version: 1.0.0
+            experimental: true
+          - shard_file: shard.yml
+            crystal_version: nightly
+            experimental: true
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
     container: crystallang/crystal:${{ matrix.crystal_version }}-alpine
+    env:
+      SKIP_LUCKY_TASK_PRECOMPILATION: "1"
     steps:
-    - uses: actions/checkout@v2
-    - name: Cache Crystal
-      uses: actions/cache@v1
-      with:
-        path: ~/.cache/crystal
-        key: ${{ runner.os }}-crystal
-    - name: Install shards
-      run: shards install
-    - name: Run tests
-      run: crystal spec
+      - uses: actions/checkout@v2
+      - name: Cache Crystal
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/crystal
+          key: ${{ runner.os }}-crystal
+      - name: Install shards
+        run: SHARDS_OVERRIDE=${{ matrix.shard_file }} shards install --ignore-crystal-version
+      - name: Run tests
+        run: crystal spec

--- a/shard.edge.yml
+++ b/shard.edge.yml
@@ -1,0 +1,39 @@
+dependencies:
+  lucky_task:
+    github: luckyframework/lucky_task
+    branch: master
+  habitat:
+    github: luckyframework/habitat
+    branch: master
+  wordsmith:
+    github: luckyframework/wordsmith
+    branch: master
+  avram:
+    github: luckyframework/avram
+    branch: master
+  lucky_router:
+    github: luckyframework/lucky_router
+    branch: master
+  shell-table:
+    github: luckyframework/shell-table.cr
+    branch: master
+  cry:
+    github: luckyframework/cry
+    branch: master
+  exception_page:
+    github: crystal-loot/exception_page
+    branch: master
+  dexter:
+    github: luckyframework/dexter
+    branch: master
+  pulsar:
+    github: luckyframework/pulsar
+    branch: master
+  teeplate:
+    github: luckyframework/teeplate
+    branch: master
+
+development_dependencies:
+  ameba:
+    github: crystal-ameba/ameba
+    branch: master

--- a/src/lucky/memoizable.cr
+++ b/src/lucky/memoizable.cr
@@ -22,7 +22,7 @@ module Lucky::Memoizable
   macro memoize(method_def)
     {% raise "You must define a return type for memoized methods" if method_def.return_type.is_a?(Nop) %}
     {%
-      raise "All arguments must have an explicit type for memoized methods" if method_def.args.any? &.is_a?(Nop) # ameba:disable Style/IsAFilter
+      raise "All arguments must have an explicit type for memoized methods" if method_def.args.any? &.is_a?(Nop)
     %}
 
     @__memoized_{{method_def.name}} : Tuple(


### PR DESCRIPTION
## Purpose
Test against the `master` branch of all dependencies, as well as the `nightly` Crystal version.

## Description
~~No idea if this is actually going to work like I think it will.~~

It worked!

This adds one additional matrix variable, `shard_file`, which is used to optionally install from alternate sources. The only one I've added to source control as a part of this PR is `shard.edge.yml`. The idea is that we should always keep every shard in that file on the latest version (`branch: master/main`).

I've added two additional `experimental`-flagged builds:

- Test the `shard.edge.yml` content with Crystal 1.0
- Test the `nightly` Crystal build against our standard `shard.yml` content

Because we leverage `continue-on-error` in our builds based on the `experimental` flag, it means that we could still push PRs through even if one of the above scenarios fails. That said, it's probably best to tackle these issues as they come up.

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
