### PR TITLE
Remove unused generate_getters macro from HtmlBuilder

### DIFF
--- a/src/lucky/html_builder.cr
+++ b/src/lucky/html_builder.cr
@@ -67,18 +67,6 @@ module Lucky::HTMLBuilder
     {% end %}
   end
 
-  macro generate_getters
-    {% if !@type.abstract? %}
-      {% for declaration in ASSIGNS %}
-        {% if declaration.type.stringify == "Bool" %}
-          getter? {{ declaration }}
-        {% else %}
-          getter {{ declaration }}
-        {% end %}
-      {% end %}
-    {% end %}
-  end
-
   def perform_render : IO
     render
     view


### PR DESCRIPTION
This macro is not called. Getters are generated from the `needs` macro [here](https://github.com/luckyframework/lucky/blob/5c963908990691d90b7beccb3a64baf2f1dbccbb/src/lucky/assignable.cr#L44-L52)

For more history:
- It was added here: https://github.com/luckyframework/lucky/commit/e2d1fa99c26348c5a8966ace4cf899e0cd4045ae
- It's usage was removed here: https://github.com/luckyframework/lucky/commit/87dbce512a9868d2e4d2259cda2f99c99e381a9e