### PR TITLE
Extract Assignable code to single module and refactor

### DIFF
--- a/spec/lucky/assignable_spec.cr
+++ b/spec/lucky/assignable_spec.cr
@@ -81,6 +81,16 @@ class OverrideGetterPage
   end
 end
 
+class NonPageClass
+  include Lucky::Assignable
+
+  needs param : String
+end
+
+class InheritedNonPageClass < NonPageClass
+  needs other_param : String
+end
+
 describe "Assigns within multiple pages with the same name" do
   it "should only appear once in the initializer" do
     PageOne.new build_context, title: "foo", name: "Paul", second: "second"
@@ -91,5 +101,7 @@ describe "Assigns within multiple pages with the same name" do
     PageWithMetaclass.new(build_context, string_class: String)
       .perform_render.to_s.should contain("called from an auto-generated getter")
     OverrideGetterPage.new(build_context).perform_render.to_s.should eq("Joe")
+    NonPageClass.new(param: "foo").param.should eq("foo")
+    InheritedNonPageClass.new(param: "foo", other_param: "bar").other_param.should eq("bar")
   end
 end

--- a/src/lucky/assignable.cr
+++ b/src/lucky/assignable.cr
@@ -58,17 +58,19 @@ module Lucky::Assignable
   macro inherit_assigns
     macro included
       inherit_assigns
-
-      macro inherited
-        inherit_assigns
-      end
     end
-    ASSIGNS = [] of Nil
 
-    {% verbatim do %}
-      {% if @type.ancestors.first && @type.ancestors.first.has_constant? :ASSIGNS %}
-        {% for declaration in @type.ancestors.first.constant :ASSIGNS %}
-          {% ASSIGNS << declaration %}
+    macro inherited
+      inherit_assigns
+    end
+
+    {% if !@type.has_constant?(:ASSIGNS) %}
+      ASSIGNS = [] of Nil
+      {% verbatim do %}
+        {% if @type.ancestors.first %}
+          {% for declaration in @type.ancestors.first.constant(:ASSIGNS) %}
+            {% ASSIGNS << declaration %}
+          {% end %}
         {% end %}
       {% end %}
     {% end %}

--- a/src/lucky/assignable.cr
+++ b/src/lucky/assignable.cr
@@ -1,10 +1,4 @@
 module Lucky::Assignable
-  # :nodoc:
-  macro included
-    setup_initializer_hook
-    inherit_assigns
-  end
-
   # Declare what a class needs in order to be initialized.
   #
   # This will declare an instance variable and getter automatically. It will
@@ -112,4 +106,7 @@ module Lucky::Assignable
       end
     {% end %}
   end
+
+  setup_initializer_hook
+  inherit_assigns
 end

--- a/src/lucky/html_builder.cr
+++ b/src/lucky/html_builder.cr
@@ -21,51 +21,7 @@ module Lucky::HTMLBuilder
   include Lucky::RenderIfDefined
   include Lucky::TagDefaults
 
-  abstract def view
-
-  macro setup_initializer_hook
-    macro finished
-      generate_needy_initializer
-    end
-
-    macro included
-      setup_initializer_hook
-    end
-
-    macro inherited
-      setup_initializer_hook
-    end
-  end
-
-  macro included
-    setup_initializer_hook
-  end
-
-  macro generate_needy_initializer
-    {% if !@type.abstract? %}
-      {% sorted_assigns = ASSIGNS.sort_by { |dec|
-           has_explicit_value =
-             dec.type.is_a?(Metaclass) ||
-               dec.type.types.map(&.id).includes?(Nil.id) ||
-               dec.value ||
-               dec.value == nil ||
-               dec.value == false
-           has_explicit_value ? 1 : 0
-         } %}
-      def initialize(
-        {% for declaration in sorted_assigns %}
-          {% var = declaration.var %}
-          {% type = declaration.type %}
-          {% value = declaration.value %}
-          {% value = nil if type.stringify.ends_with?("Nil") && !value %}
-          {% has_default = value || value == false || value == nil %}
-          @{{ var.id }} : {{ type }}{% if has_default %} = {{ value }}{% end %},
-        {% end %}
-        **unused_exposures
-        )
-      end
-    {% end %}
-  end
+  abstract def view : IO
 
   def perform_render : IO
     render

--- a/src/lucky/html_page.cr
+++ b/src/lucky/html_page.cr
@@ -1,15 +1,14 @@
 require "./html_builder"
 
 module Lucky::HTMLPage
+  include Lucky::HTMLBuilder
+
   Habitat.create do
     setting render_component_comments : Bool = false
   end
 
-  macro included
-    include Lucky::HTMLBuilder
-    getter view = IO::Memory.new
-    needs context : HTTP::Server::Context
-  end
+  getter view : IO = IO::Memory.new
+  needs context : HTTP::Server::Context
 
   def to_s(io)
     io << view

--- a/src/lucky/tags/form_helpers.cr
+++ b/src/lucky/tags/form_helpers.cr
@@ -5,7 +5,7 @@ module Lucky::FormHelpers
 
   def form_for(route : Lucky::RouteHelper, **html_options) : Nil
     form build_form_options(route, html_options) do
-      csrf_hidden_input if settings.include_csrf_tag
+      csrf_hidden_input if Lucky::FormHelpers.settings.include_csrf_tag
       method_override_input(route)
       yield
     end


### PR DESCRIPTION
## Purpose

Related to https://github.com/luckyframework/lucky/pull/1480

Wanting to make sure I fully understood how our `needs` setup works, I cleaned up some of the macro code and made it completely detached from the html stuff so anyone can include the module in their code if they want to use `needs` in other areas.

## Description

- Moved everything related to `needs` and the generated initialize methods into the `Lucky::Assignable` module
- Remove old compilation error about needs ending with question marks (year old deprecation seemed reasonable to remove)
- changed getters to actually use the `getter/`getter?` macros
- Updated `macro included` to delegate to two sup methods to setup needs and initialize
- removed `SETTINGS` from `inherit_page_settings` (found no usage)
- `Lucky::HTMLPage` no longer includes `Lucky::HTMLBuilder` in a `macro included` since `Assignable` handles when it's run in a module (there was also a problem with the amount of times `Assignable` could be included that was fixed, it could only be included twice I think and then there would be a bug but I didn't actually verify)
- Removing the `macro included` from `HTMLPage` made the habitat stuff fail in `FormHelpers` which was fixed

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
