### PR TITLE
Pass context to components through mount

### DIFF
--- a/src/lucky/base_component.cr
+++ b/src/lucky/base_component.cr
@@ -21,6 +21,15 @@ abstract class Lucky::BaseComponent
     self
   end
 
+  private def context : HTTP::Server::Context
+    @context || raise "No context was set in #{self.class.name}. Use 'mount' or set it with 'context(@context)' before rendering."
+  end
+
+  def context(@context : HTTP::Server::Context?)
+    # This is used by Lucky::MountComponent to set the context.
+    self
+  end
+
   def render_to_string : String
     String.build do |io|
       view(io)

--- a/src/lucky/mount_component.cr
+++ b/src/lucky/mount_component.cr
@@ -12,7 +12,7 @@ module Lucky::MountComponent
   @[Deprecated("Use `#mount` instead. Example: mount(MyComponent, arg1: 123)")]
   def m(component : Lucky::BaseComponent.class, *args, **named_args) : Nil
     print_component_comment(component) do
-      component.new(*args, **named_args).view(view).render
+      component.new(*args, **named_args).view(view).context(@context).render
     end
   end
 
@@ -31,7 +31,7 @@ module Lucky::MountComponent
   @[Deprecated("Use `#mount` instead. Example: mount(MyComponent, arg1: 123) do/end")]
   def m(component : Lucky::BaseComponent.class, *args, **named_args) : Nil
     print_component_comment(component) do
-      component.new(*args, **named_args).view(view).render do |*yield_args|
+      component.new(*args, **named_args).view(view).context(@context).render do |*yield_args|
         yield *yield_args
       end
     end
@@ -49,7 +49,7 @@ module Lucky::MountComponent
   # ```
   def mount(component : Lucky::BaseComponent.class, *args, **named_args) : Nil
     print_component_comment(component) do
-      component.new(*args, **named_args).view(view).render
+      component.new(*args, **named_args).view(view).context(@context).render
     end
   end
 
@@ -67,7 +67,7 @@ module Lucky::MountComponent
   # ```
   def mount(component : Lucky::BaseComponent.class, *args, **named_args) : Nil
     print_component_comment(component) do
-      component.new(*args, **named_args).view(view).render do |*yield_args|
+      component.new(*args, **named_args).view(view).context(@context).render do |*yield_args|
         yield *yield_args
       end
     end
@@ -138,7 +138,7 @@ module Lucky::MountComponent
   # ```
   def mount_instance(component : Lucky::BaseComponent) : Nil
     print_component_comment(component.class) do
-      component.view(view).render
+      component.view(view).context(@context).render
     end
   end
 
@@ -158,7 +158,7 @@ module Lucky::MountComponent
   # ```
   def mount_instance(component : Lucky::BaseComponent) : Nil
     print_component_comment(component.class) do
-      component.view(view).render do |*yield_args|
+      component.view(view).context(@context).render do |*yield_args|
         yield *yield_args
       end
     end

--- a/src/lucky/page_helpers/url_helpers.cr
+++ b/src/lucky/page_helpers/url_helpers.cr
@@ -28,7 +28,7 @@ module Lucky::UrlHelpers
     value : String,
     check_query_params : Bool = false
   ) : Bool
-    request = @context.request
+    request = context.request
 
     return false unless {"GET", "HEAD"}.includes?(request.method)
 

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -272,7 +272,7 @@ module Lucky::Renderable
   # ```
   def component(comp : Lucky::BaseComponent.class, status : Int32? = nil, **named_args) : Lucky::TextResponse
     send_text_response(
-      comp.new(**named_args).render_to_string,
+      comp.new(**named_args).context(context).render_to_string,
       "text/html",
       status
     )

--- a/src/lucky/tags/forgery_protection_helpers.cr
+++ b/src/lucky/tags/forgery_protection_helpers.cr
@@ -8,7 +8,7 @@ module Lucky::ForgeryProtectionHelpers
   def csrf_hidden_input : Nil
     input type: "hidden",
       name: ProtectFromForgery::PARAM_KEY,
-      value: ProtectFromForgery.get_token(@context)
+      value: ProtectFromForgery.get_token(context)
   end
 
   # Meta tags used for submitting AJAX links and forms
@@ -20,6 +20,6 @@ module Lucky::ForgeryProtectionHelpers
     meta name: "csrf-param",
       content: ProtectFromForgery::PARAM_KEY
     meta name: "csrf-token",
-      content: ProtectFromForgery.get_token(@context)
+      content: ProtectFromForgery.get_token(context)
   end
 end


### PR DESCRIPTION
## Purpose

Related to https://github.com/luckyframework/lucky/issues/1152

## Description

Instead of implementing `mount_defaults` the main code that we want passed down into components without being asked for is the context. This adds it to be passed in just like view is.
