### PR TITLE
Remove deprecated m for mounting components

### DIFF
--- a/src/lucky/mount_component.cr
+++ b/src/lucky/mount_component.cr
@@ -6,44 +6,6 @@ module Lucky::MountComponent
   # starts and ends.
   #
   # ```
-  # m(MyComponent)
-  # m(MyComponent, with_args: 123)
-  # ```
-  @[Deprecated("Use `#mount` instead. Example: mount(MyComponent, arg1: 123)")]
-  def m(component : Lucky::BaseComponent.class, *args, **named_args) : Nil
-    print_component_comment(component) do
-      component.new(*args, **named_args).view(view).context(@context).render
-    end
-  end
-
-  # Appends the `component` to the view. Takes a block, and yields the
-  # args passed to the component.
-  #
-  # When `Lucky::HTMLPage.settings.render_component_comments` is
-  # set to `true`, it will render HTML comments showing where the component
-  # starts and ends.
-  #
-  # ```
-  # m(MyComponent, name: "Jane") do |name|
-  #   text name.upcase
-  # end
-  # ```
-  @[Deprecated("Use `#mount` instead. Example: mount(MyComponent, arg1: 123) do/end")]
-  def m(component : Lucky::BaseComponent.class, *args, **named_args) : Nil
-    print_component_comment(component) do
-      component.new(*args, **named_args).view(view).context(@context).render do |*yield_args|
-        yield *yield_args
-      end
-    end
-  end
-
-  # Appends the `component` to the view.
-  #
-  # When `Lucky::HTMLPage.settings.render_component_comments` is
-  # set to `true`, it will render HTML comments showing where the component
-  # starts and ends.
-  #
-  # ```
   # mount(MyComponent)
   # mount(MyComponent, with_args: 123)
   # ```


### PR DESCRIPTION
## Purpose

The deprecation notice was added way back in [0.24.0](https://github.com/luckyframework/lucky/blob/master/CHANGELOG.md#v0240-2020-09-05) so it seems like time to remove it.

