### PR TITLE
Add additional JSON render overload for string bodies

### DIFF
--- a/spec/lucky/action_rendering_spec.cr
+++ b/spec/lucky/action_rendering_spec.cr
@@ -31,6 +31,12 @@ class Rendering::JSON::Index < TestAction
   end
 end
 
+class Rendering::JSON::WithStringBody < TestAction
+  get "/foo1" do
+    json("{\"name\":\"Paul\"}")
+  end
+end
+
 class Rendering::JSON::WithStatus < TestAction
   get "/foo" do
     json({name: "Paul"}, status: 201)
@@ -200,6 +206,10 @@ describe Lucky::Action do
 
   it "renders JSON" do
     response = Rendering::JSON::Index.new(build_context, params).call
+    response.body.to_s.should eq %({"name":"Paul"})
+    response.status.should eq 200
+
+    response = Rendering::JSON::WithStringBody.new(build_context, params).call
     response.body.to_s.should eq %({"name":"Paul"})
     response.status.should eq 200
 

--- a/spec/lucky/action_rendering_spec.cr
+++ b/spec/lucky/action_rendering_spec.cr
@@ -31,14 +31,20 @@ class Rendering::JSON::Index < TestAction
   end
 end
 
-class Rendering::JSON::WithStringBody < TestAction
-  get "/foo1" do
-    json("{\"name\":\"Paul\"}")
+class Rendering::JSON::WithRawStringBody < TestAction
+  get "/foo" do
+    raw_json("{\"name\":\"Paul\"}")
+  end
+end
+
+class Rendering::JSON::WithRawStringBodyWithStatus < TestAction
+  get "/bar" do
+    raw_json("{\"name\":\"Paul\"}", status: 201)
   end
 end
 
 class Rendering::JSON::WithStatus < TestAction
-  get "/foo" do
+  get "/foo1" do
     json({name: "Paul"}, status: 201)
   end
 end
@@ -209,9 +215,13 @@ describe Lucky::Action do
     response.body.to_s.should eq %({"name":"Paul"})
     response.status.should eq 200
 
-    response = Rendering::JSON::WithStringBody.new(build_context, params).call
+    response = Rendering::JSON::WithRawStringBody.new(build_context, params).call
     response.body.to_s.should eq %({"name":"Paul"})
     response.status.should eq 200
+
+    response = Rendering::JSON::WithRawStringBodyWithStatus.new(build_context, params).call
+    response.body.to_s.should eq %({"name":"Paul"})
+    response.status.should eq 201
 
     status = Rendering::JSON::WithStatus.new(build_context, params).call.status
     status.should eq 201

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -257,7 +257,7 @@ module Lucky::Renderable
   end
 
   # :nodoc:
-  def json(raw_string : String, status : Int32? = nil) : Lucky::TextResponse
+  def json(body : String, status : Int32? = nil) : Lucky::TextResponse
     {%
       raise <<-ERROR
 

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -248,8 +248,27 @@ module Lucky::Renderable
   end
 
   # allows json-compatible string to be returned directly
-  def json(body : String, status : Int32? = nil) : Lucky::TextResponse
+  def raw_json(body : String, status : Int32? = nil) : Lucky::TextResponse
     send_text_response(body, "application/json", status)
+  end
+
+  def raw_json(body : String, status : HTTP::Status) : Lucky::TextResponse
+    raw_json(body, status: status.value)
+  end
+
+  # :nodoc:
+  def json(raw_string : String, status : Int32? = nil) : Lucky::TextResponse
+    {%
+      raise <<-ERROR
+
+      Looks like your trying to pass a string to json response.
+
+      Use `raw_json(body, ...)` instead.
+
+      NOTE: `raw_json` doesn't validate JSON string validity/integrity, use at your own risk.
+
+      ERROR
+    %}
   end
 
   def json(body, status : Int32? = nil) : Lucky::TextResponse

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -247,6 +247,11 @@ module Lucky::Renderable
     head(status.value)
   end
 
+  # allows json-compatible string to be returned directly
+  def json(body : String, status : Int32? = nil) : Lucky::TextResponse
+    send_text_response(body, "application/json", status)
+  end
+
   def json(body, status : Int32? = nil) : Lucky::TextResponse
     send_text_response(body.to_json, "application/json", status)
   end


### PR DESCRIPTION
## Purpose
Some JSON serializer shards output raw JSON-compatible strings, which means we need to use `JSON.parse(*)` before passing the payload into the `json` render method.

This PR adds support for JSON strings being directly passed.

### Before

```crystal
get "/foo" do
  data = Serializer.new.serialize(scope)
  json(JSON.parse(data))
end
```

### After

```crystal
get "/foo" do
  data = Serializer.new.serialize(scope)
  json(data)
end
```

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
