### PR TITLE
Adds in boolean attributes to the form_for tag helper.

### DIFF
--- a/spec/lucky/form_helpers_spec.cr
+++ b/spec/lucky/form_helpers_spec.cr
@@ -55,6 +55,12 @@ private class TestPage
       text "foo"
     end
   end
+
+  def form_with_bool_attr
+    form_for FormHelpers::Create, attrs: [:novalidate], class: "even-cooler-form" do
+      text "foo"
+    end
+  end
 end
 
 describe Lucky::FormHelpers do
@@ -84,6 +90,10 @@ describe Lucky::FormHelpers do
       form = view(&.form_for(FormHelpers::Index, class: "form-block") { })
       form.should contain <<-HTML
       <form action="/form_helpers" method="get" class="form-block"></form>
+      HTML
+
+      view(&.form_with_bool_attr).should contain <<-HTML
+      <form action="/form_helpers" method="post" class="even-cooler-form" novalidate>foo</form>
       HTML
     end
   end

--- a/src/lucky/tags/form_helpers.cr
+++ b/src/lucky/tags/form_helpers.cr
@@ -3,16 +3,16 @@ module Lucky::FormHelpers
     setting include_csrf_tag : Bool = true
   end
 
-  def form_for(route : Lucky::RouteHelper, **html_options) : Nil
-    form build_form_options(route, html_options) do
+  def form_for(route : Lucky::RouteHelper, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
+    form attrs, build_form_options(route, html_options) do
       csrf_hidden_input if Lucky::FormHelpers.settings.include_csrf_tag
       method_override_input(route)
       yield
     end
   end
 
-  def form_for(route action : Lucky::Action.class, **html_options, &block) : Nil
-    form_for action.route, **html_options, &block
+  def form_for(route action : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options, &block) : Nil
+    form_for action.route, attrs, **html_options, &block
   end
 
   private def form_method(route) : String


### PR DESCRIPTION
## Purpose
Fixes #1490

## Description
All of the tags have an `attrs` option to add boolean attributes. This was missing from `form_for`.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
