### PR TITLE
Ability to render HTML pages with a non-200 status code

### DIFF
--- a/spec/lucky/action_rendering_spec.cr
+++ b/spec/lucky/action_rendering_spec.cr
@@ -19,6 +19,12 @@ class Rendering::Index < TestAction
   end
 end
 
+class Rendering::Show < TestAction
+  get "/rendering/:nothing" do
+    html_with_status IndexPage, 419, title: "Closing Time", arg2: "You don't have to go home but you can't stay here"
+  end
+end
+
 class Namespaced::Rendering::Index < TestAction
   route do
     html ::Rendering::IndexPage, title: "Anything", arg2: "testing multiple args"
@@ -179,6 +185,15 @@ describe Lucky::Action do
 
       response.body.to_s.should contain "Anything"
       response.debug_message.to_s.should contain "Rendering::IndexPage"
+      response.status.should eq 200
+    end
+
+    it "renders with a different status code" do
+      response = Rendering::Show.new(build_context, params).call
+
+      response.body.to_s.should contain "Closing Time"
+      response.debug_message.to_s.should contain "Rendering::IndexPage"
+      response.status.should eq 419
     end
   end
 


### PR DESCRIPTION
## Purpose
Fixes #1312

## Description
This PR adds a new `html_with_status` macro that will let you render an HTML page with a status that's not 200.

```crystal
class SomeAction::Index < BrowserAction

  get "/page" do
    html_with_status IndexPage, 244, some_arg: "hi"
  end
end
```

If you don't pass a number, you'll get an error message that looks like this:

<img width="1036" alt="Screen Shot 2021-05-28 at 11 15 23 AM" src="https://user-images.githubusercontent.com/2391/120026431-ec9b2900-bfa6-11eb-9a3a-dd276bed128b.png">


/cc. @robacarp 

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
