### PR TITLE
Added new module to disable FLoC

### DIFF
--- a/spec/lucky/secure_headers_spec.cr
+++ b/spec/lucky/secure_headers_spec.cr
@@ -66,6 +66,14 @@ class SniffGuardRoutes::Index < TestAction
   end
 end
 
+class FLoCGGuardRoutes::Index < TestAction
+  include Lucky::SecureHeaders::DisableFLoC
+
+  get "/secure_path7" do
+    plain_text "test"
+  end
+end
+
 describe Lucky::SecureHeaders do
   describe "SetFrameGuard" do
     it "sets the X-Frame-Options header with sameorigin" do
@@ -108,6 +116,13 @@ describe Lucky::SecureHeaders do
     it "sets the X-Content-Type-Options to nosniff" do
       route = SniffGuardRoutes::Index.new(build_context, params).call
       route.context.response.headers["X-Content-Type-Options"].should eq "nosniff"
+    end
+  end
+
+  describe "DisableFLoC" do
+    it "sets the Permissions-Policy to interest-cohort=()" do
+      route = FLoCGGuardRoutes::Index.new(build_context, params).call
+      route.context.response.headers["Permissions-Policy"].should eq "interest-cohort=()"
     end
   end
 end

--- a/src/lucky/secure_headers/disable_floc.cr
+++ b/src/lucky/secure_headers/disable_floc.cr
@@ -1,0 +1,33 @@
+module Lucky
+  module SecureHeaders
+    # This module disables Google FLoC by setting the
+    # [Permissions-Policy](https://github.com/WICG/floc) HTTP header to `interest-cohort=()`.
+    #
+    # This header is a part of Google's Federated Learning of Cohorts (FLoC) which is used
+    # to track browsing history instead of using 3rd-party cookies.
+    #
+    # Include this module in the actions you want to disable this feature.
+
+    # ```
+    # class BrowserAction < Lucky::Action
+    #   include Lucky::SecureHeaders::DisableFLoC
+    # end
+    # ```
+    module DisableFLoC
+      macro included
+        before set_floc_guard_header
+      end
+
+      private def set_floc_guard_header
+        unless context.response.headers["Permissions-Policy"]?
+          context.response.headers["Permissions-Policy"] = floc_guard_value
+        end
+        continue
+      end
+
+      private def floc_guard_value
+        "interest-cohort=()"
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Purpose
Fixes #1486

## Description
This adds a new module to optionally disable FLoC. Just include it in your app, and it will set the appropriate header.

```crystal
class BrowserAction < Lucky::Action
  include Lucky::SecureHeaders::DisableFLoC
end
```

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
