### PR TITLE
Moving params in to HTTP::Server::Context 

### DIFF
--- a/spec/lucky/params_spec.cr
+++ b/spec/lucky/params_spec.cr
@@ -683,4 +683,17 @@ describe Lucky::Params do
       params.should eq({"filter" => {"name" => "euphonium"}, "page" => "1", "per" => "50"})
     end
   end
+
+  describe "Setting route_params later" do
+    it "returns the correct values for get?" do
+      request = build_request body: "", content_type: ""
+      route_params = {"id" => "from_route"}
+      params = Lucky::Params.new(request)
+
+      params.get?(:id).should eq nil
+
+      params.route_params = route_params
+      params.get?(:id).should eq "from_route"
+    end
+  end
 end

--- a/src/lucky/action.cr
+++ b/src/lucky/action.cr
@@ -4,6 +4,7 @@ abstract class Lucky::Action
   getter :context, :route_params
 
   def initialize(@context : HTTP::Server::Context, @route_params : Hash(String, String))
+    context.params.route_params = @route_params
   end
 
   abstract def call

--- a/src/lucky/context_extensions.cr
+++ b/src/lucky/context_extensions.cr
@@ -24,4 +24,10 @@ class HTTP::Server::Context
   def flash : Lucky::FlashStore
     @_flash ||= Lucky::FlashStore.from_session(session)
   end
+
+  @_params : Lucky::Params?
+
+  def params : Lucky::Params
+    @_params ||= Lucky::Params.new(request)
+  end
 end

--- a/src/lucky/http_method_override_handler.cr
+++ b/src/lucky/http_method_override_handler.cr
@@ -12,11 +12,11 @@ class Lucky::HttpMethodOverrideHandler
   end
 
   private def override_allowed?(context, http_method) : Bool
-    ["POST"].includes?(context.request.method) && ["PATCH", "PUT", "DELETE"].includes?(http_method)
+    (context.request.method == "POST") && ["PATCH", "PUT", "DELETE"].includes?(http_method)
   end
 
   private def overridden_http_method(context) : String?
-    Lucky::Params.new(context.request).get?(:_method).try(&.upcase)
+    context.params.get?(:_method).try(&.upcase)
   rescue Lucky::ParamParsingError
     nil
   end

--- a/src/lucky/param_helpers.cr
+++ b/src/lucky/param_helpers.cr
@@ -1,7 +1,5 @@
 module Lucky::ParamHelpers
-  @_params : Lucky::Params?
-
-  def params : Lucky::Params
-    @_params ||= Lucky::Params.new(context.request, @route_params)
+  memoize def params : Lucky::Params
+    context.params
   end
 end

--- a/src/lucky/params.cr
+++ b/src/lucky/params.cr
@@ -1,11 +1,9 @@
 class Lucky::Params
-  @request : HTTP::Request
-  @route_params : Hash(String, String) = {} of String => String
-
   # :nodoc:
-  private getter :request
+  private getter request : HTTP::Request
   # :nodoc:
-  private getter :route_params
+  private getter route_params : Hash(String, String)
+  setter :route_params
 
   # Create a new params object
   #
@@ -20,7 +18,7 @@ class Lucky::Params
   #
   # Lucky::Params.new(request, route_params)
   # ```
-  def initialize(@request, @route_params = {} of String => String)
+  def initialize(@request : HTTP::Request, @route_params : Hash(String, String) = empty_params)
   end
 
   # Parses the request body as `JSON::Any` or raises `Lucky::ParamParsingError` if JSON is invalid.


### PR DESCRIPTION
## Purpose
Fixes #1473

This is my stab at solving #1473 

## Description
The original issue was that we were instantiating the params object twice. This lets us do it just once by moving it in to context.

The only strange thing I'm not too sure on is the whole part of setting `route_params` later. I don't think it affects anything here, but I for sure want another set of eyes on this one.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
