### PR TITLE
Add compile-time error when trying to expose predicate and bang methods.

### DIFF
--- a/src/lucky/exposable.cr
+++ b/src/lucky/exposable.cr
@@ -107,6 +107,19 @@ module Lucky::Exposable
   # end
   # ```
   macro expose(method_name)
+    {% if method_name.ends_with?('?') || method_name.ends_with?('!') %}
+      {% method_name.raise <<-ERROR
+
+      Methods ending in '?' or '!' cannot be exposed to pages.
+      #{@type.name} called `expose #{method_name.id}`
+
+      Try this...
+
+        ▸ Define your method without ? or ! then...
+        ▸ expose #{method_name.gsub(/[!?]$/, "").id}
+      ERROR
+      %}
+    {% end %}
     {% EXPOSURES << method_name.id %}
   end
 end


### PR DESCRIPTION
## Purpose
Fixes #1304

## Description
Because of how exposed methods are passed through the initializer of pages, it becomes very difficult to fix exposing predicate and bang methods. Instead, we will just raise a compile time error with an example of what to do instead.

Here's the error:

<img width="673" alt="Screen Shot 2021-05-29 at 1 16 32 PM" src="https://user-images.githubusercontent.com/2391/120083850-81be2080-c080-11eb-81a0-9f9877da0650.png">


## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
