### PR TITLE
Generating an API action will always put the action in to the api nam…

### DIFF
--- a/spec/tasks/gen/action_spec.cr
+++ b/spec/tasks/gen/action_spec.cr
@@ -22,11 +22,11 @@ describe Gen::Action do
       valid_action_name = "Users::Index"
       io = generate valid_action_name, Gen::Action::Api
 
-      filename = "./src/actions/users/index.cr"
+      filename = "./src/actions/api/users/index.cr"
       should_have_generated "#{valid_action_name} < ApiAction", inside: filename
 
       io.to_s.should contain(valid_action_name)
-      io.to_s.should contain("/src/actions/users")
+      io.to_s.should contain("/src/actions/api/users")
     end
   end
 
@@ -47,11 +47,11 @@ describe Gen::Action do
       valid_nested_action_name = "Users::Announcements::Index"
       io = generate valid_nested_action_name, Gen::Action::Api
 
-      filename = "src/actions/users/announcements/index.cr"
+      filename = "src/actions/api/users/announcements/index.cr"
       should_have_generated "#{valid_nested_action_name} < ApiAction", inside: filename
 
       io.to_s.should contain(valid_nested_action_name)
-      io.to_s.should contain("/src/actions/users/announcements")
+      io.to_s.should contain("/src/actions/api/users/announcements")
     end
   end
 

--- a/tasks/gen/action/api.cr
+++ b/tasks/gen/action/api.cr
@@ -19,4 +19,13 @@ class Gen::Action::Api < LuckyTask::Task
   def call(io : IO = STDOUT)
     render_action_template(io, inherit_from: "ApiAction")
   end
+
+  private def action_name
+    name = ARGV.first
+    if name.downcase.starts_with?("api")
+      name
+    else
+      "Api::#{name}"
+    end
+  end
 end


### PR DESCRIPTION
## Purpose
Fixes #1502

## Description
When running the `lucky gen.action.api` task, this will now always generate the action in the Api namespace/directory. 

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
