### PR TITLE
Refactor UploadedFile for small performance boost

### DIFF
--- a/spec/lucky/uploaded_file_spec.cr
+++ b/spec/lucky/uploaded_file_spec.cr
@@ -20,12 +20,6 @@ describe Lucky::UploadedFile do
     end
   end
 
-  describe "#metadata" do
-    it "returns the metadata object" do
-      uploaded_file.metadata.should be_a(HTTP::FormData::FileMetadata)
-    end
-  end
-
   describe "#path" do
     it "returns the file path" do
       uploaded_file.path.starts_with?(Dir.tempdir).should be_true
@@ -36,7 +30,6 @@ describe Lucky::UploadedFile do
   describe "#filename" do
     it "returns the original file from the metadata object" do
       uploaded_file.filename.should eq("welcome_file")
-      uploaded_file.filename.should eq(uploaded_file.metadata.filename)
     end
   end
 


### PR DESCRIPTION
## Purpose
Fixes #1302

## Description
This refactors UploadedFile to delegate all of the part methods to `@part`. We parsing the data and creating `metadata` to get the filename, but [Crystal does this already](https://github.com/crystal-lang/crystal/blob/a47491f8645d0cd52dfc83cf4d0c7ac64d1d4e20/src/http/formdata/part.cr#L17) which means we were parsing it twice. Now we just use what has already been given, and expose some additional methods.

Since `metadata` is required, we can re-build it from the [FileMetaData](https://github.com/crystal-lang/crystal/blob/a47491f8645d0cd52dfc83cf4d0c7ac64d1d4e20/src/http/formdata.cr#L223-L228). The thing that's left is is removing the [requirement in Avram](https://github.com/luckyframework/avram/blob/d19bb81a5fbea193b22375038e32feb7aee6e169/src/avram/uploadable.cr#L3)



## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
