### PR TITLE
Replace Void returns type with Nil.

### DIFF
--- a/src/lucky/base_log_formatter.cr
+++ b/src/lucky/base_log_formatter.cr
@@ -5,5 +5,5 @@ abstract class Lucky::BaseLogFormatter
     progname : String,
     data : NamedTuple,
     io : IO
-  ) : Void
+  ) : Nil
 end

--- a/src/lucky/cookies/cookie_jar.cr
+++ b/src/lucky/cookies/cookie_jar.cr
@@ -43,7 +43,7 @@ class Lucky::CookieJar
   end
 
   # Delete all cookies.
-  def clear : Void
+  def clear : Nil
     clear { }
   end
 
@@ -54,7 +54,7 @@ class Lucky::CookieJar
   #         .http_only(true)
   #         .secure(true)
   # end
-  def clear(&block : HTTP::Cookie ->) : Void
+  def clear(&block : HTTP::Cookie ->) : Nil
     cookies.each do |cookie|
       yield cookie
       delete cookie.name

--- a/src/lucky/pretty_log_formatter.cr
+++ b/src/lucky/pretty_log_formatter.cr
@@ -38,7 +38,7 @@ struct Lucky::PrettyLogFormatter < Dexter::BaseFormatter
       res
     end
 
-    private def add_arrow : Void
+    private def add_arrow : Nil
       io << " #{arrow} "
     end
 

--- a/src/lucky/text_response.cr
+++ b/src/lucky/text_response.cr
@@ -49,21 +49,21 @@ class Lucky::TextResponse < Lucky::Response
     {% end %}
   end
 
-  private def write_flash : Void
+  private def write_flash : Nil
     context.session.set(
       Lucky::FlashStore::SESSION_KEY,
       context.flash.to_json
     )
   end
 
-  private def write_session : Void
+  private def write_session : Nil
     context.cookies.set(
       Lucky::Session.settings.key,
       context.session.to_json
     )
   end
 
-  private def write_cookies : Void
+  private def write_cookies : Nil
     response = context.response
 
     context.cookies.updated.each do |cookie|

--- a/tasks/gen/resource/browser.cr
+++ b/tasks/gen/resource/browser.cr
@@ -54,7 +54,7 @@ class Gen::Resource::Browser < LuckyTask::Task
     "/" + pluralized_name.underscore
   end
 
-  private def validate! : Void
+  private def validate! : Nil
     validate_name_is_present!
     validate_not_namespaced!
     validate_name_is_singular!
@@ -132,7 +132,7 @@ class Gen::Resource::Browser < LuckyTask::Task
     Wordsmith::Inflector.pluralize resource_name
   end
 
-  private def success_message(class_name : String, filename : String) : Void
+  private def success_message(class_name : String, filename : String) : Nil
     io.puts "Generated #{class_name.colorize.bold} in #{filename.colorize.bold}"
   end
 


### PR DESCRIPTION
## Purpose
Fixes #1504

## Description
Specifying `Void` as a return type does the same thing as using `Nil`, but as convention, `Void` should only be used within C libs. There's talk about Crystal raising errors in the future if you use `Void` outside of a C lib, so this just gets the convention started.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
