### PR TITLE
Updating rendering the exception page to allow fully disabling cookie

### DIFF
--- a/src/lucky/error_action.cr
+++ b/src/lucky/error_action.cr
@@ -78,11 +78,10 @@ abstract class Lucky::ErrorAction
   end
 
   def render_exception_page(error : Exception, status : Int) : Lucky::Response
-    Lucky::TextResponse.new(
-      context: context,
-      status: status,
+    send_text_response(
+      body: Lucky::ExceptionPage.for_runtime_exception(context, error).to_s,
       content_type: "text/html",
-      body: Lucky::ExceptionPage.for_runtime_exception(context, error).to_s
+      status: status
     )
   end
 end


### PR DESCRIPTION
## Purpose
Fixes #1272

## Description
The final resolution to #1272 was to just add documentation to disable_cookies on the `Errors::Show` action. I have opened up https://github.com/luckyframework/website/issues/666 for this. The final bit was in development, your cookies would still be written on the Exception page because we weren't passing in the option ([see comment](https://github.com/luckyframework/lucky/issues/1272#issuecomment-774287670)). This refactor uses the built-in `send_text_response` which will handle disabling cookies already.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
