### PR TITLE
Make render abstract on Serializers

### DIFF
--- a/src/lucky/serializer.cr
+++ b/src/lucky/serializer.cr
@@ -1,6 +1,8 @@
 require "uuid/json"
 
 abstract class Lucky::Serializer
+  abstract def render
+
   def to_json(io)
     render.to_json(io)
   end


### PR DESCRIPTION
## Purpose
Fixes #1503

## Description
The `render` method is required when passed in to a `json()` call, so we should require that it's defined.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
