### PR TITLE
Add new multi_select_input tag

### DIFF
--- a/spec/lucky/select_helpers_spec.cr
+++ b/spec/lucky/select_helpers_spec.cr
@@ -25,11 +25,6 @@ private class TestPage
     self
   end
 
-  def render_multi_select_options(field, options)
-    options_for_multi_select(field, options)
-    self
-  end
-
   def render_prompt(label)
     select_prompt(label)
     self
@@ -81,7 +76,7 @@ describe Lucky::SelectHelpers do
   end
 
   it "renders multi-select options" do
-    view.render_multi_select_options(form.tags, [{"One", "one"}, {"Two", "two"}, {"Three", "three"}])
+    view.render_options(form.tags, [{"One", "one"}, {"Two", "two"}, {"Three", "three"}])
       .html.to_s.should eq <<-HTML
       <option value="one" selected>One</option><option value="two" selected>Two</option><option value="three">Three</option>
       HTML

--- a/spec/lucky/select_helpers_spec.cr
+++ b/spec/lucky/select_helpers_spec.cr
@@ -14,8 +14,19 @@ private class TestPage
     self
   end
 
+  def render_multi_select(field)
+    multi_select_input field do
+    end
+    self
+  end
+
   def render_options(field, options)
     options_for_select(field, options)
+    self
+  end
+
+  def render_multi_select_options(field, options)
+    options_for_multi_select(field, options)
     self
   end
 
@@ -38,6 +49,15 @@ class SomeFormWithCompany
       param_key: "company"
     )
   end
+
+  def tags
+    Avram::PermittedAttribute(Array(String)).new(
+      name: :tags,
+      param: "",
+      value: ["one", "two"],
+      param_key: "company"
+    )
+  end
 end
 
 describe Lucky::SelectHelpers do
@@ -47,10 +67,23 @@ describe Lucky::SelectHelpers do
     HTML
   end
 
+  it "renders multi-select" do
+    view.render_multi_select(form.tags).html.to_s.should eq <<-HTML
+    <select name="company:tags[]" multiple></select>
+    HTML
+  end
+
   it "renders options" do
     view.render_options(form.company_id, [{"Volvo", 2}, {"BMW", 3}, {"None", nil}])
       .html.to_s.should eq <<-HTML
       <option value="2">Volvo</option><option value="3">BMW</option><option value="">None</option>
+      HTML
+  end
+
+  it "renders multi-select options" do
+    view.render_multi_select_options(form.tags, [{"One", "one"}, {"Two", "two"}, {"Three", "three"}])
+      .html.to_s.should eq <<-HTML
+      <option value="one" selected>One</option><option value="two" selected>Two</option><option value="three">Three</option>
       HTML
   end
 

--- a/src/lucky_avram/ext/lucky/select_helpers.cr
+++ b/src/lucky_avram/ext/lucky/select_helpers.cr
@@ -25,13 +25,14 @@ module Lucky::SelectHelpers
   def options_for_multi_select(field : Avram::PermittedAttribute(Array(T)), select_options : Array(Tuple(String, T)), **html_options) : Nil forall T
     select_options.each do |option_name, option_value|
       attributes = {"value" => option_value.to_s}
+      bool_attrs = [] of Symbol
 
       if value = field.value
         is_selected = value.includes?(option_value.to_s)
-        attributes["selected"] = "true" if is_selected
+        bool_attrs << :selected if is_selected
       end
 
-      option(option_name, merge_options(html_options, attributes))
+      option(option_name, attrs: bool_attrs, options: merge_options(html_options, attributes))
     end
   end
 

--- a/src/lucky_avram/ext/lucky/select_helpers.cr
+++ b/src/lucky_avram/ext/lucky/select_helpers.cr
@@ -5,8 +5,8 @@ module Lucky::SelectHelpers
     end
   end
 
-  def multi_select_input(field : Avram::PermittedAttribute, **html_options) : Nil
-    select_tag [:multiple], merge_options(html_options, {"name" => input_name(field, array: true)}) do
+  def multi_select_input(field : Avram::PermittedAttribute(Array), **html_options) : Nil
+    select_tag [:multiple], merge_options(html_options, {"name" => input_name(field)}) do
       yield
     end
   end
@@ -22,7 +22,7 @@ module Lucky::SelectHelpers
     end
   end
 
-  def options_for_multi_select(field : Avram::PermittedAttribute(Array(T)), select_options : Array(Tuple(String, T)), **html_options) : Nil forall T
+  def options_for_select(field : Avram::PermittedAttribute(Array(T)), select_options : Array(Tuple(String, T)), **html_options) : Nil forall T
     select_options.each do |option_name, option_value|
       attributes = {"value" => option_value.to_s}
       bool_attrs = [] of Symbol
@@ -42,11 +42,8 @@ module Lucky::SelectHelpers
     option(label, value: "")
   end
 
-  private def input_name(field, *, array : Bool = false)
-    String.build do |name|
-      name << "#{field.param_key}:#{field.name}"
-      name << "[]" if array
-    end
+  private def input_name(field)
+    "#{field.param_key}:#{field.name}"
   end
 
   private def input_name(field : Avram::PermittedAttribute(Array))

--- a/src/lucky_avram/ext/lucky/select_helpers.cr
+++ b/src/lucky_avram/ext/lucky/select_helpers.cr
@@ -5,6 +5,12 @@ module Lucky::SelectHelpers
     end
   end
 
+  def multi_select_input(field : Avram::PermittedAttribute, **html_options) : Nil
+    select_tag [:multiple], merge_options(html_options, {"name" => input_name(field, array: true)}) do
+      yield
+    end
+  end
+
   def options_for_select(field : Avram::PermittedAttribute(T), select_options : Array(Tuple(String, T?)), **html_options) : Nil forall T
     select_options.each do |option_name, option_value|
       attributes = {"value" => option_value.to_s}
@@ -16,13 +22,29 @@ module Lucky::SelectHelpers
     end
   end
 
+  def options_for_multi_select(field : Avram::PermittedAttribute(Array(T)), select_options : Array(Tuple(String, T)), **html_options) : Nil forall T
+    select_options.each do |option_name, option_value|
+      attributes = {"value" => option_value.to_s}
+
+      if value = field.value
+        is_selected = value.includes?(option_value.to_s)
+        attributes["selected"] = "true" if is_selected
+      end
+
+      option(option_name, merge_options(html_options, attributes))
+    end
+  end
+
   # Renders an <option> HTML tag with no value
   # The text is set to `label`.
   def select_prompt(label : String) : Nil
     option(label, value: "")
   end
 
-  private def input_name(field)
-    "#{field.param_key}:#{field.name}"
+  private def input_name(field, *, array : Bool = false)
+    String.build do |name|
+      name << "#{field.param_key}:#{field.name}"
+      name << "[]" if array
+    end
   end
 end


### PR DESCRIPTION
## Purpose
Fixes #777 

## Description
This adds a new select tag method `multi_select_input` which allows you to use Arrays and pass over multiple values with a select.

```crystal
# in your page
def render
  multi_select_input(operation.tags, class: "multi-select") do
    options_for_select(operation.tags, [{"Ruby", "ruby"}, {"Crystal", "crystal"}])
  end
end
```

## Notes

There is a caveat here in that Avram Operations do not support passing in Arrays from params just yet. If you were to use this as is right now, you'd have to update your actions a bit.

```crystal
post "/users" do
  SaveUser.create(params, tags: params.get_all("user:tags")) do |o, u|
      # ....
  end
end
```

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
