### PR TITLE
[WIP] Birth of the new ParamSerializable objects.

### DIFF
--- a/shard.override.yml
+++ b/shard.override.yml
@@ -1,0 +1,4 @@
+dependencies:
+  avram:
+    github: luckyframework/avram
+    branch: master

--- a/spec/lucky/param_serializable_spec.cr
+++ b/spec/lucky/param_serializable_spec.cr
@@ -34,6 +34,8 @@ class ComplexParams
   property default : Bool = true
   @[Lucky::ParamField(param_key: :override)]
   property version : Float64
+  @[Lucky::ParamField(ignore: true)]
+  property internal : Int32 = 4
 end
 
 class CrashingParams
@@ -111,7 +113,7 @@ describe Lucky::ParamSerializable do
 
     it "parses more complex param types" do
       request = build_request
-      request.query = "complex_params:tags[]=one&complex_params:tags[]=two&complex_params:numbers[]=1&complex_params:numbers[]=2&override:version=0.1"
+      request.query = "complex_params:tags[]=one&complex_params:tags[]=two&complex_params:numbers[]=1&complex_params:numbers[]=2&override:version=0.1&complex_params:internal=2"
 
       run_complext_assertions(request)
     end
@@ -193,4 +195,5 @@ private def run_complext_assertions(req : HTTP::Request)
   complex_params.numbers.should eq([1, 2])
   complex_params.default.should eq(true)
   complex_params.version.should eq(0.1)
+  complex_params.internal.should eq(4)
 end

--- a/spec/lucky/param_serializable_spec.cr
+++ b/spec/lucky/param_serializable_spec.cr
@@ -47,6 +47,13 @@ class CrashingParams
   property wrong : Bool
 end
 
+class ParamsWithFile
+  include Lucky::ParamSerializable
+  param_key :data
+
+  property avatar : Lucky::UploadedFile
+end
+
 # {
 #   "query":{
 #     "bool":{
@@ -167,6 +174,20 @@ describe Lucky::ParamSerializable do
       }
 
       run_complex_assertions(request)
+    end
+
+    describe "with files" do
+      it "parses with an UploadedFile" do
+        request = build_multipart_request file_parts: {
+          "data:avatar" => "file_contents",
+        }
+
+        params = Lucky::Params.new(request)
+        file_params = ParamsWithFile.from_params(params)
+
+        file_params.avatar.should be_a(Lucky::UploadedFile)
+        File.read(file_params.avatar.path).should eq "file_contents"
+      end
     end
   end
 end

--- a/spec/lucky/param_serializable_spec.cr
+++ b/spec/lucky/param_serializable_spec.cr
@@ -84,7 +84,6 @@ describe Lucky::ParamSerializable do
       params = Lucky::Params.new(request)
       user_params = UserWithKeyParams.from_params(params)
 
-      user_params.param_key.should eq "user"
       user_params.name.should eq("Gandalf")
       user_params.age.should eq(11000)
       user_params.fellowship.should be_nil
@@ -131,7 +130,7 @@ describe Lucky::ParamSerializable do
       request = build_request body: "complex_params:tags[]=one&complex_params:tags[]=two&complex_params:numbers[]=1&complex_params:numbers[]=2&override:version=0.1",
         content_type: "application/x-www-form-urlencoded"
 
-      run_complext_assertions(request)
+      run_complex_assertions(request)
     end
   end
 
@@ -147,7 +146,7 @@ describe Lucky::ParamSerializable do
       json = {complex_params: {tags: ["one", "two"], numbers: [1, 2]}, override: {version: 0.1}}
       request = build_request body: json.to_json, content_type: "application/json"
 
-      run_complext_assertions(request)
+      run_complex_assertions(request)
     end
   end
 
@@ -167,7 +166,7 @@ describe Lucky::ParamSerializable do
         "override:version" => "0.1",
       }
 
-      run_complext_assertions(request)
+      run_complex_assertions(request)
     end
   end
 end
@@ -187,7 +186,7 @@ private def run_basic_assertions(req : HTTP::Request)
   user_params.responds_to?(:fellowship).should be_false
 end
 
-private def run_complext_assertions(req : HTTP::Request)
+private def run_complex_assertions(req : HTTP::Request)
   params = Lucky::Params.new(req)
   complex_params = ComplexParams.from_params(params)
 

--- a/spec/lucky/param_serializable_spec.cr
+++ b/spec/lucky/param_serializable_spec.cr
@@ -63,19 +63,20 @@ class LocationParams
   property lng : Float64
 end
 
-class HomeOwnerParams
-  include Lucky::ParamSerializable
-  param_key :owner
-
-  property name : String
-end
-
 class AddressParams
   include Lucky::ParamSerializable
   param_key :address
 
   property street : String
   property location : LocationParams
+end
+
+class ActorParams
+  include Lucky::ParamSerializable
+  param_key :actor
+
+  property name : String = "George"
+  property age : Int32?
 end
 
 describe Lucky::ParamSerializable do
@@ -90,6 +91,31 @@ describe Lucky::ParamSerializable do
       user_params.name.should eq("Gandalf")
       user_params.age.should eq(11000)
       user_params.fellowship.should be_nil
+    end
+  end
+
+  describe "original_source" do
+    it "returns the original params used to create the object" do
+      request = build_request
+      params = Lucky::Params.new(request)
+      actor_params = ActorParams.from_params(params)
+
+      actor_params.original_source.should eq(params)
+    end
+  end
+
+  describe "has_source?" do
+    it "returns true when the original_source received the key" do
+      request = build_request
+      request.query = "actor:name=Jim"
+
+      params = Lucky::Params.new(request)
+      actor_params = ActorParams.from_params(params)
+
+      actor_params.name.should eq("Jim")
+      actor_params.age.should eq(nil)
+      actor_params.has_source?("name").should be_true
+      actor_params.has_source?("age").should be_false
     end
   end
 

--- a/spec/lucky/param_serializable_spec.cr
+++ b/spec/lucky/param_serializable_spec.cr
@@ -52,6 +52,7 @@ class ParamsWithFile
   param_key :data
 
   property avatar : Lucky::UploadedFile
+  property docs : Array(Lucky::UploadedFile)
 end
 
 # {
@@ -180,13 +181,16 @@ describe Lucky::ParamSerializable do
       it "parses with an UploadedFile" do
         request = build_multipart_request file_parts: {
           "data:avatar" => "file_contents",
+          "data:docs"   => ["file1", "file2"],
         }
 
         params = Lucky::Params.new(request)
         file_params = ParamsWithFile.from_params(params)
 
         file_params.avatar.should be_a(Lucky::UploadedFile)
+        file_params.docs.size.should eq(2)
         File.read(file_params.avatar.path).should eq "file_contents"
+        File.read(file_params.docs.last.path).should eq "file2"
       end
     end
   end

--- a/spec/lucky/param_serializable_spec.cr
+++ b/spec/lucky/param_serializable_spec.cr
@@ -115,7 +115,7 @@ describe Lucky::ParamSerializable do
       request = build_request
       request.query = "complex_params:tags[]=one&complex_params:tags[]=two&complex_params:numbers[]=1&complex_params:numbers[]=2&override:version=0.1&complex_params:internal=2"
 
-      run_complext_assertions(request)
+      run_complex_assertions(request)
     end
   end
 

--- a/spec/lucky/param_serializable_spec.cr
+++ b/spec/lucky/param_serializable_spec.cr
@@ -1,0 +1,196 @@
+require "../spec_helper"
+
+include ContextHelper
+include MultipartHelper
+
+class BasicParams
+  include Lucky::ParamSerializable
+  skip_param_key
+
+  property string : String
+  property int16 : Int16
+  property int32 : Int32
+  property int64 : Int64
+  property bool : Bool
+  property float64 : Float64
+  property uuid : UUID
+  property blank : String?
+end
+
+class UserWithKeyParams
+  include Lucky::ParamSerializable
+  param_key :user
+
+  property name : String
+  property age : Int32
+  property fellowship : String?
+end
+
+class ComplexParams
+  include Lucky::ParamSerializable
+
+  property tags : Array(String)
+  property numbers : Array(Int32)
+  property default : Bool = true
+  @[Lucky::ParamField(param_key: :override)]
+  property version : Float64
+end
+
+class CrashingParams
+  include Lucky::ParamSerializable
+  skip_param_key
+
+  property required_but_missing : String
+  @[Lucky::ParamField(param_key: :key)]
+  property wrong : Bool
+end
+
+# {
+#   "query":{
+#     "bool":{
+#       "must":[
+#          {"terms":{"brand":["micromax","samsung"]}}
+#       ] ,
+#       "should":[
+#          { "range": { "price": { "gte": 6000, "lte": 10000 } } },
+#          { "range": { "price": { "gte": 16000, "lte": 30000 } } }
+#       ]
+#     }
+#   }
+# }
+
+# class SearchParams
+#   include Lucky::ParamSerializable
+
+#   property q : String
+#   property page : Int32
+#   property per : Int32 = 50
+#   property sort : Array(String)
+#   @[Lucky::ParamField(param_key: :filter)]
+#   property active : Bool = false
+#   @[Lucky::ParamField(param_key: :filter)]
+#   property city : String
+
+# end
+
+describe Lucky::ParamSerializable do
+  describe "param_key" do
+    it "checks the key on all params" do
+      request = build_request
+      request.query = "user:name=Gandalf&user:age=11000&fellowship=bracelet"
+
+      params = Lucky::Params.new(request)
+      user_params = UserWithKeyParams.from_params(params)
+
+      user_params.param_key.should eq "user"
+      user_params.name.should eq("Gandalf")
+      user_params.age.should eq(11000)
+      user_params.fellowship.should be_nil
+    end
+  end
+
+  describe "handling errors" do
+    it "raises an exception when the required value is missing" do
+      request = build_request
+      request.query = "wrong=true"
+      params = Lucky::Params.new(request)
+
+      expect_raises(Lucky::MissingParamError) do
+        CrashingParams.from_params(params)
+      end
+    end
+  end
+
+  describe "query params" do
+    it "parses the basic param types" do
+      request = build_request
+      request.query = "string=Test&int16=1&int32=123&int64=12341234&bool=true&float64=3.14&uuid=d65869ee-f08f-47ff-b15d-568dc23c2eb7&fellowship=bracelet"
+
+      run_basic_assertions(request)
+    end
+
+    it "parses more complex param types" do
+      request = build_request
+      request.query = "complex_params:tags[]=one&complex_params:tags[]=two&complex_params:numbers[]=1&complex_params:numbers[]=2&override:version=0.1"
+
+      run_complext_assertions(request)
+    end
+  end
+
+  describe "form params" do
+    it "parses the basic param types" do
+      request = build_request body: "string=Test&int16=1&int32=123&int64=12341234&bool=true&float64=3.14&uuid=d65869ee-f08f-47ff-b15d-568dc23c2eb7&fellowship=bracelet",
+        content_type: "application/x-www-form-urlencoded"
+
+      run_basic_assertions(request)
+    end
+
+    it "parses more complex param types" do
+      request = build_request body: "complex_params:tags[]=one&complex_params:tags[]=two&complex_params:numbers[]=1&complex_params:numbers[]=2&override:version=0.1",
+        content_type: "application/x-www-form-urlencoded"
+
+      run_complext_assertions(request)
+    end
+  end
+
+  describe "json params" do
+    it "parses the basic param types" do
+      json = {string: "Test", int16: 1, int32: 123, int64: 12341234, bool: true, float64: 3.14, uuid: "d65869ee-f08f-47ff-b15d-568dc23c2eb7", fellowship: "bracelet"}
+      request = build_request body: json.to_json, content_type: "application/json"
+
+      run_basic_assertions(request)
+    end
+
+    it "parses more complex param types" do
+      json = {complex_params: {tags: ["one", "two"], numbers: [1, 2]}, override: {version: 0.1}}
+      request = build_request body: json.to_json, content_type: "application/json"
+
+      run_complext_assertions(request)
+    end
+  end
+
+  describe "multipart params" do
+    it "parses the basic param types" do
+      request = build_multipart_request form_parts: {
+        "string" => "Test", "int16" => "1", "int32" => "123", "int64" => "12341234", "bool" => "true", "float64" => "3.14",
+        "uuid" => "d65869ee-f08f-47ff-b15d-568dc23c2eb7", "fellowship" => "bracelet",
+      }
+
+      run_basic_assertions(request)
+    end
+
+    it "parses more complex param types" do
+      request = build_multipart_request form_parts: {
+        "complex_params:tags" => ["one", "two"], "complex_params:numbers" => ["1", "2"],
+        "override:version" => "0.1",
+      }
+
+      run_complext_assertions(request)
+    end
+  end
+end
+
+private def run_basic_assertions(req : HTTP::Request)
+  params = Lucky::Params.new(req)
+  user_params = BasicParams.from_params(params)
+
+  user_params.string.should eq("Test")
+  user_params.int16.should eq(1_i16)
+  user_params.int32.should eq(123_i32)
+  user_params.int64.should eq(12341234_i64)
+  user_params.bool.should eq(true)
+  user_params.float64.should eq(3.14)
+  user_params.uuid.should eq(UUID.new("d65869ee-f08f-47ff-b15d-568dc23c2eb7"))
+  user_params.blank.should be_nil
+  user_params.responds_to?(:fellowship).should be_false
+end
+
+private def run_complext_assertions(req : HTTP::Request)
+  params = Lucky::Params.new(req)
+  complex_params = ComplexParams.from_params(params)
+
+  complex_params.tags.should eq(["one", "two"])
+  complex_params.numbers.should eq([1, 2])
+  complex_params.default.should eq(true)
+  complex_params.version.should eq(0.1)
+end

--- a/spec/lucky/permitted_param_spec.cr
+++ b/spec/lucky/permitted_param_spec.cr
@@ -1,0 +1,25 @@
+require "../spec_helper"
+
+describe Lucky::PermittedParam do
+  it "sets the proper name and value" do
+    param = Lucky::PermittedParam(String).new(name: "name", value: "Gamora")
+    param.name.should eq("name")
+    param.value.should eq("Gamora")
+
+    param = Lucky::PermittedParam(Array(Int32)).new(name: "deposits", value: [1, 5, 3, 99])
+    param.name.should eq("deposits")
+    param.value.should eq([1, 5, 3, 99])
+  end
+
+  it "sets the param_name with the name and param_key" do
+    param = Lucky::PermittedParam(Bool).new(name: "unlocked", value: true, param_key: "code")
+    param.param_key.should eq("code")
+    param.name.should eq("unlocked")
+    param.param_name.should eq("code:unlocked")
+
+    param = Lucky::PermittedParam(Array(Float64)).new(name: "points", value: [0.1, 0.4, 1.2], param_key: "code")
+    param.param_key.should eq("code")
+    param.name.should eq("points")
+    param.param_name.should eq("code:points[]")
+  end
+end

--- a/spec/support/multipart_helper.cr
+++ b/spec/support/multipart_helper.cr
@@ -57,4 +57,10 @@ module MultipartHelper
       multipart_file_part(formdata, nested_name, nested_value)
     end
   end
+
+  private def multipart_file_part(formdata : HTTP::FormData::Builder, name : String, value : Array(String))
+    value.each do |val|
+      multipart_file_part(formdata, name + "[]", val)
+    end
+  end
 end

--- a/src/lucky/param_serializable.cr
+++ b/src/lucky/param_serializable.cr
@@ -4,16 +4,9 @@ module Lucky
 
   module ParamSerializable
     macro included
-      @[Lucky::ParamField(ignore: true)]
-      @_original_source : Lucky::Params?
+      PARAM_DECLARATIONS = [] of Nil
 
-      @[Lucky::ParamField(ignore: true)]
       @_param_key : String?
-
-      @[Lucky::ParamField(ignore: true)]
-      getter metadata : Hash(String, Hash(String, String?)) do
-        {} of String => Hash(String, String?)
-      end
 
       def self.from_params(param_data : Lucky::Params)
         new_from_params(param_data)
@@ -25,6 +18,34 @@ module Lucky
         GC.add_finalizer(instance) if instance.responds_to?(:finalize)
         instance
       end
+
+      macro finished
+        generate_needy_initializer
+      end
+    end
+
+    macro generate_needy_initializer
+      {% initializer_args = "" %}
+      {% for metadata in @type.constant(:PARAM_DECLARATIONS) %}
+        {% initializer_args = initializer_args + "#{metadata[:type_declaration]}" %}
+        {% if metadata[:nilable] && !metadata[:type_declaration].value %}
+        {% initializer_args = initializer_args + " = nil" %}
+        {% end %}
+        {% initializer_args = initializer_args + "," %}
+      {% end %}
+
+      {% if @type.constant(:PARAM_DECLARATIONS).size > 0 %}
+      def initialize(*, {{ initializer_args.id }})
+        {% for metadata in @type.constant(:PARAM_DECLARATIONS) %}
+          param_key_value = {{ metadata[:param_key] ? metadata[:param_key].id.stringify : nil }} || param_key
+          @{{ metadata[:type_declaration].var.id }} = Lucky::PermittedParam({{ metadata[:type_declaration].type }}).new(
+            name: {{ metadata[:type_declaration].var.stringify }},
+            value: {{ metadata[:type_declaration].var.id }},
+            param_key: param_key_value
+          )
+        {% end %}
+      end
+      {% end %}
     end
 
     private def param_key
@@ -43,97 +64,114 @@ module Lucky
       end
     end
 
-    def has_source?(key : String) : Bool
-      metadata[key]["received_data"]? == "true"
-    end
-
-    def original_source : Lucky::Params
-      @_original_source.not_nil!
-    end
-
     def initialize(*, __param_data params : Lucky::Params)
-      @_original_source = params
-      {% begin %}
-        {% for ivar in @type.instance_vars %}
-          {% ann = ivar.annotation(::Lucky::ParamField) %}
-          {% ignore_var = ann && ann[:ignore] %}
-          {% unless ignore_var %}
-            {% is_nilable_type = ivar.type.nilable? %}
-            {% base_type = is_nilable_type ? ivar.type.union_types.reject(&.==(Nil)).first : ivar.type %}
-            {% is_array = base_type.name.starts_with?("Array") %}
-            {% type = is_array ? base_type.type_vars.first : base_type %}
-            {% is_file = type.name.starts_with?("Lucky::UploadedFile") %}
-            {% is_param_serializable = type.resolve < Lucky::ParamSerializable %}
-
-            param_key_value = {{ ann && ann[:param_key] ? ann[:param_key].id.stringify : nil }} || param_key
-
-            metadata[{{ ivar.id.stringify }}] = {} of String => String?
-            metadata[{{ ivar.id.stringify }}]["param_key"] = param_key_value
-
-            {% if is_array %}
-            val = if param_key_value
-              {% if is_file %}
-              data = params.nested_array_files?(param_key_value)
+      {% for metadata in @type.constant(:PARAM_DECLARATIONS) %}
+        {% begin %}
+          %param_key_value = {{ metadata[:param_key] ? metadata[:param_key].id.stringify : nil }} || param_key
+          {% if metadata[:is_array] %}
+            %val = if %param_key_value
+              {% if metadata[:is_file] %}
+              %data = params.nested_array_files?(%param_key_value)
               {% else %}
-              data = params.nested_arrays?(param_key_value)
+              %data = params.nested_arrays?(%param_key_value)
               {% end %}
-              metadata[{{ ivar.id.stringify }}]["received_data"] = data.has_key?({{ ivar.id.stringify }}).to_s
-              data.get(:{{ ivar.id }})
+              %data.get(:{{ metadata[:type_declaration].var.id }})
             else
-              metadata[{{ ivar.id.stringify }}]["received_data"] = params.has_key?("{{ ivar.id }}[]").to_s
-              params.get_all{% if is_file %}_files{% end %}?(:{{ ivar.id }})
+              params.get_all{% if metadata[:is_file] %}_files{% end %}?(:{{ metadata[:type_declaration].var.id }})
             end
-            {% else %}
-            val = if param_key_value
-              data = params.nested{% if is_file %}_file{% end %}?(param_key_value.not_nil!)
+          {% else %}
+            %val = if %param_key_value
+              %data = params.nested{% if metadata[:is_file] %}_file{% end %}?(%param_key_value.not_nil!)
 
-              {% if is_param_serializable %}
-              metadata[{{ ivar.id.stringify }}]["received_data"] = data.keys.any?(&.starts_with?({{ ivar.id.stringify }})).to_s
-              Lucky::Params.from_hash(data)
+              {% if metadata[:is_serializable] %}
+              Lucky::Params.from_hash(%data)
               {% else %}
-              metadata[{{ ivar.id.stringify }}]["received_data"] = data.has_key?({{ ivar.id.stringify }}).to_s
-              data.get(:{{ ivar.id }})
+              %data.get(:{{ metadata[:type_declaration].var.id }})
               {% end %}
             else
-              metadata[{{ ivar.id.stringify }}]["received_data"] = params.has_key?("{{ ivar.id }}").to_s
-              params.get{% if is_file %}_file{% end %}?(:{{ ivar.id }})
-            end
-            {% end %}
-
-            if val.nil?
-              default_or_nil = {{ ivar.has_default_value? ? ivar.default_value : nil }}
-              {% if is_nilable_type %}
-              @{{ ivar.id }} = default_or_nil
-              {% else %}
-              if default_or_nil.nil?
-                raise Lucky::MissingParamError.new <<-ERROR
-                {{ @type }} is missing value for required param "{{ ivar.id }} : {{ ivar.type }}"
-                ERROR
-              else
-                @{{ ivar.id }} = default_or_nil
-              end
-              {% end %}
-            else
-              {% if is_param_serializable %}
-              @{{ ivar.id }} = {{ type }}.from_params(val.as(Lucky::Params))
-              {% else %}
-              # NOTE: these come from Avram directly
-              result = {{ type }}::Lucky.parse(val)
-
-              if result.is_a? Avram::Type::SuccessfulCast
-                @{{ ivar.id }} = result.value.as({{ base_type }})
-              else
-                raise Lucky::InvalidParamError.new(
-                  param_name: "{{ ivar.id }}",
-                  param_value: val.to_s,
-                  param_type: "{{ type }}"
-                )
-              end
-              {% end %}
+              params.get{% if metadata[:is_file] %}_file{% end %}?(:{{ metadata[:type_declaration].var.id }})
             end
           {% end %}
+
+          if %val.nil?{% if metadata[:nilable] %} || %val == ""{% end %}
+            default_or_nil = {{ metadata[:type_declaration].value ? metadata[:type_declaration].value : nil }}
+            {% if metadata[:nilable] %}
+              if %val.nil? && default_or_nil.nil?
+                @{{ metadata[:type_declaration].var.id }} = nil
+              else
+                @{{ metadata[:type_declaration].var.id }} = Lucky::PermittedParam({{ metadata[:type_declaration].type }}).new(name: {{ metadata[:type_declaration].var.stringify }}, value: default_or_nil, param_key: %param_key_value)
+              end
+            {% else %}
+              if default_or_nil.nil?
+                raise Lucky::MissingParamError.new <<-ERROR
+                {{ @type }} is missing value for required param "{{ metadata[:type_declaration] }}"
+                ERROR
+              else
+                @{{ metadata[:type_declaration].var.id }} = Lucky::PermittedParam({{ metadata[:type_declaration].type }}).new(name: {{ metadata[:type_declaration].var.stringify }}, value: default_or_nil, param_key: %param_key_value)
+              end
+            {% end %}
+          else
+            {% if metadata[:is_serializable] %}
+            @{{ metadata[:type_declaration].var.id }} = Lucky::PermittedParam({{ metadata[:type_declaration].type }}).new(name: {{ metadata[:type_declaration].var.stringify }}, value: {{ metadata[:core_type] }}.from_params(%val.as(Lucky::Params)), param_key: %param_key_value)
+            {% else %}
+              # NOTE: these come from Avram directly
+              %result = {{ metadata[:core_type] }}::Lucky.parse(%val)
+
+              if %result.is_a? Avram::Type::SuccessfulCast
+                @{{ metadata[:type_declaration].var.id }} = Lucky::PermittedParam({{ metadata[:type_declaration].type }}).new(name: {{ metadata[:type_declaration].var.stringify }}, value: %result.value.as({{ metadata[:type] }}), param_key: %param_key_value)
+              else
+                raise Lucky::InvalidParamError.new(
+                  param_name: "{{ metadata[:type_declaration].var.id }}",
+                  param_value: %val.to_s,
+                  param_type: "{{ metadata[:type] }}"
+                )
+              end
+            {% end %}
+          end
         {% end %}
       {% end %}
+    end
+
+    macro param(type_declaration, param_key = nil)
+      {% unless type_declaration.is_a?(TypeDeclaration) %}
+        {% raise "'param' expects a type declaration like 'name : String', instead got: '#{type_declaration}'" %}
+      {% end %}
+
+      {% is_nilable_type = type_declaration.type.resolve.nilable? %}
+      {% type = is_nilable_type ? type_declaration.type.types.reject(&.==(Nil)).first.resolve : type_declaration.type.resolve %}
+      {% is_array = type.name.starts_with?("Array") %}
+      # TODO: This probably breaks if the type is Array(String?)
+      {% core_type = is_array ? type.type_vars.first : type %}
+      {% is_file = core_type.name.starts_with?("Lucky::UploadedFile") %}
+      {% is_param_serializable = core_type.resolve < Lucky::ParamSerializable %}
+
+      {%
+        PARAM_DECLARATIONS << {
+          type_declaration: type_declaration,
+          param_key:        param_key,
+          nilable:          is_nilable_type,
+          type:             type,
+          core_type:        core_type,
+          is_array:         is_array,
+          is_file:          is_file,
+          is_serializable:  is_param_serializable,
+        }
+      %}
+
+      getter {{ type_declaration.var }} : Lucky::PermittedParam({{ type_declaration.type }}){% if is_nilable_type %}?{% end %}
+
+      # TODO: This seems to always raise, even though I'm never calling it
+      # def {{ type_declaration.var }}=(val : {{ type_declaration.type }})
+      #   % raise <<-ERROR
+      #   #{@type} values can only be assigned from Lucky::Params, or by initialization.
+
+      #   Try this...
+
+      #     ▸ #{@type}.from_params(params)
+      #     ▸ #{@type}.new(#{type_declaration.var}: "my value")
+      #   ERROR
+      #   %
+      # end
     end
   end
 end

--- a/src/lucky/param_serializable.cr
+++ b/src/lucky/param_serializable.cr
@@ -18,18 +18,18 @@ module Lucky
       end
     end
 
-    def param_key
+    private def param_key
       @_param_key ||= Wordsmith::Inflector.underscore({{ @type.name.stringify }})
     end
 
     macro param_key(key)
-      def param_key
+      private def param_key
         {{ key.id.stringify }}
       end
     end
 
     macro skip_param_key
-      def param_key
+      private def param_key
         nil
       end
     end

--- a/src/lucky/param_serializable.cr
+++ b/src/lucky/param_serializable.cr
@@ -50,10 +50,10 @@ module Lucky
 
             {% if is_array %}
             val = if param_key_value
-              data = params.nested_array?(param_key_value)
+              data = params.nested_array{% if is_file %}_files{% end %}?(param_key_value)
               data.get(:{{ ivar.id }})
             else
-              params.get_all?(:{{ ivar.id }})
+              params.get_all{% if is_file %}_files{% end %}?(:{{ ivar.id }})
             end
             {% else %}
             val = if param_key_value

--- a/src/lucky/param_serializable.cr
+++ b/src/lucky/param_serializable.cr
@@ -1,0 +1,95 @@
+module Lucky
+  annotation ParamField
+  end
+
+  module ParamSerializable
+    macro included
+      @_param_key : String?
+      def self.from_params(param_data : Lucky::Params)
+        new_from_params(param_data)
+      end
+
+      private def self.new_from_params(param_data : Lucky::Params)
+        instance = allocate
+        instance.initialize(__param_data: param_data)
+        GC.add_finalizer(instance) if instance.responds_to?(:finalize)
+        instance
+      end
+    end
+
+    def param_key
+      @_param_key ||= Wordsmith::Inflector.underscore({{ @type.name.stringify }})
+    end
+
+    macro param_key(key)
+      def param_key
+        {{ key.id.stringify }}
+      end
+    end
+
+    macro skip_param_key
+      def param_key
+        nil
+      end
+    end
+
+    def initialize(*, __param_data params : Lucky::Params)
+      {% begin %}
+        {% for ivar in @type.instance_vars.reject(&.id.stringify.starts_with?("_")) %}
+          {% is_nilable_type = ivar.type.nilable? %}
+          {% type = is_nilable_type ? ivar.type.union_types.reject(&.==(Nil)).first : ivar.type %}
+          {% is_array = type.name.starts_with?("Array") %}
+          {% type = is_array ? type.type_vars.first : type %}
+          {% ann = ivar.annotation(::Lucky::ParamField) %}
+
+          param_key_value = {{ ann && ann[:param_key] ? ann[:param_key].id.stringify : nil }} || param_key
+
+          {% if is_array %}
+          val = if param_key_value
+            data = params.nested_array?(param_key_value)
+            data.get(:{{ ivar.id }})
+          else
+            params.get_all?(:{{ ivar.id }})
+          end
+          {% else %}
+          val = if param_key_value
+            data = params.nested?(param_key_value.not_nil!)
+            data.get(:{{ ivar.id }})
+          else
+            params.get?(:{{ ivar.id }})
+          end
+          {% end %}
+
+          if val.nil?
+            default_or_nil = {{ ivar.has_default_value? ? ivar.default_value : nil }}
+            {% if is_nilable_type %}
+            @{{ ivar.id }} = default_or_nil
+            {% else %}
+            if default_or_nil.nil?
+              raise Lucky::MissingParamError.new <<-ERROR
+              {{ @type }} is missing value for required param "{{ ivar.id }} : {{ ivar.type }}"
+              ERROR
+            else
+              @{{ ivar.id }} = default_or_nil
+            end
+            {% end %}
+          else
+            # NOTE: these come from Avram directly
+            result = {{ type }}.adapter.parse(val)
+
+            if result.is_a? Avram::Type::SuccessfulCast
+              @{{ ivar.id }} = result.value
+            else
+              raise Lucky::InvalidParamError.new(
+                param_name: "{{ ivar.id }}",
+                param_value: val.to_s,
+                param_type: "{{ type }}"
+              )
+            end
+          end
+
+        {% end %}
+      {% end %}
+    end
+  end
+end

--- a/src/lucky/param_serializable.cr
+++ b/src/lucky/param_serializable.cr
@@ -5,7 +5,14 @@ module Lucky
   module ParamSerializable
     macro included
       @[Lucky::ParamField(ignore: true)]
+      property original_source : Lucky::Params
+
+      @[Lucky::ParamField(ignore: true)]
       @_param_key : String?
+
+      @[Lucky::ParamField(ignore: true)]
+      @metadata : Hash(String, Hash(String, String?))
+
       def self.from_params(param_data : Lucky::Params)
         new_from_params(param_data)
       end
@@ -34,7 +41,13 @@ module Lucky
       end
     end
 
+    def has_source?(key : String) : Bool
+      @metadata[key]["received_data"]? == "true"
+    end
+
     def initialize(*, __param_data params : Lucky::Params)
+      @original_source = params
+      @metadata = {} of String => Hash(String, String?)
       {% begin %}
         {% for ivar in @type.instance_vars %}
           {% ann = ivar.annotation(::Lucky::ParamField) %}
@@ -49,11 +62,16 @@ module Lucky
 
             param_key_value = {{ ann && ann[:param_key] ? ann[:param_key].id.stringify : nil }} || param_key
 
+            @metadata[{{ ivar.id.stringify }}] = {} of String => String?
+            @metadata[{{ ivar.id.stringify }}]["param_key"] = param_key_value
+
             {% if is_array %}
             val = if param_key_value
               data = params.nested_array{% if is_file %}_files{% end %}?(param_key_value)
+              @metadata[{{ ivar.id.stringify }}]["received_data"] = data.has_key?({{ ivar.id.stringify }}).to_s
               data.get(:{{ ivar.id }})
             else
+              @metadata[{{ ivar.id.stringify }}]["received_data"] = params.has_key?("{{ ivar.id }}[]").to_s
               params.get_all{% if is_file %}_files{% end %}?(:{{ ivar.id }})
             end
             {% else %}
@@ -61,11 +79,14 @@ module Lucky
               data = params.nested{% if is_file %}_file{% end %}?(param_key_value.not_nil!)
 
               {% if is_param_serializable %}
+              @metadata[{{ ivar.id.stringify }}]["received_data"] = data.keys.any?(&.starts_with?({{ ivar.id.stringify }})).to_s
               Lucky::Params.from_hash(data)
               {% else %}
+              @metadata[{{ ivar.id.stringify }}]["received_data"] = data.has_key?({{ ivar.id.stringify }}).to_s
               data.get(:{{ ivar.id }})
               {% end %}
             else
+              @metadata[{{ ivar.id.stringify }}]["received_data"] = params.has_key?("{{ ivar.id }}").to_s
               params.get{% if is_file %}_file{% end %}?(:{{ ivar.id }})
             end
             {% end %}

--- a/src/lucky/params.cr
+++ b/src/lucky/params.cr
@@ -409,6 +409,10 @@ class Lucky::Params
     end
   end
 
+  def has_key?(key : String)
+    route_params.has_key?(key) || query_params.has_key?(key) || !!body_param(key)
+  end
+
   private def nested_json_params(nested_key : String) : Hash(String, String)
     nested_params = {} of String => String
     nested_key_json = parsed_json[nested_key]? || JSON.parse("{}")

--- a/src/lucky/params.cr
+++ b/src/lucky/params.cr
@@ -21,6 +21,13 @@ class Lucky::Params
   def initialize(@request : HTTP::Request, @route_params : Hash(String, String) = empty_params)
   end
 
+  def self.from_hash(data : Hash(String, String | Array(String))) : self
+    request = HTTP::Request.new("GET", "/", body: "", headers: HTTP::Headers.new)
+    request.query = URI::Params.encode(data)
+
+    self.new(request)
+  end
+
   # Parses the request body as `JSON::Any` or raises `Lucky::ParamParsingError` if JSON is invalid.
   #
   # ```

--- a/src/lucky/permitted_param.cr
+++ b/src/lucky/permitted_param.cr
@@ -1,0 +1,18 @@
+module Lucky
+  class PermittedParam(T)
+    getter name : String
+    getter value : T
+    getter param_key : String?
+
+    def initialize(*, @name : String, @value : T, @param_key : String? = nil)
+    end
+
+    def param_name : String
+      String.build do |str|
+        str << "#{param_key}:" if param_key
+        str << name
+        str << "[]" if T.is_a?(Array.class)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Purpose
New `Lucky::ParamSerializable` module which takes param data incoming from a user, and serializes it in to usable objects. The values in this object become "permitted" params based on how the data was passed in.

## Description
This is the start to moving param permissions from Avram up to Lucky. This also starts to open up the possibility as to what we can pass through params.

### Issues

Here's a basic example of how things work right now:

```crystal
post "/users" do
  # This requires the SaveOperation to understand how to parse params, and what data to permit
  #  and by which keys, etc...
  SaveUser.create(params) do |op, user|
    #...
  end
end
```

Because of this, Avram needs to have a Param type object. If we need ` Lucky::Params` to implement something, we have to also tell `Avram::Params` to update it as well.

On top of that, Operations in Avram also aren't able to take in arrays from params.

```crystal
# user:name=Toejam&user:friends[]=Earl&user:friends[]=Funkster
post "/users" do
  # name can be saved, but friends[] can't
  SaveUser.create(params) do |o, u|

  end
end
```

### Solution

These new "Param" objects can tell you which data it needs, and it knows how to take params from JSON, query string, multipart request, or just a form body, and then convert that data in to an object.

Now imagine we have something that looks like this:

```crystal
post "/users" do
  user_params = UserParams.from_params(params)
  SaveUser.create(user_params) do |o, u|
    #...
  end
end
```

In this case, `user_params` would be an instance that has methods like `name` that returns a String, and `friends` that returns Array(String). The `SaveUser` object now just decides which of those values it needs, and worries about the validation of the data, and storing in the database. 

So what does this `UserParams` look like?

```crystal
class UserParams
  include Lucky::ParamSerializable
  param_key :user

  param name : String
  param friends : Array(String)
end
```

What else do we get from this? We can now create params that look like this:

```
q=tacos&page=2&sort[]=name&sort[]=asc&filter:city=Las+Vegas
```

```crystal
class SearchParams
  include Lucky::ParamSerializable
  skip_param_key

  param q : String
  param page : Int32
  param per : Int32 = 50
  param sort : Array(String)
  param active : Bool = false, param_key: :filter
  param city : String, param_key: :filter
end
```

Notice how the `q`, `page`, and `sort` aren't nested keys, but `city` is. Also notice how we don't have to send some values as they have defaults.

```crystal
get "/search" do
  search_params = SearchParams.from_params(params)
  AppSearch.run(search_params) do |op, results|
   #....
  end
end
```

## Current Issues

* HTML Form elements should now take a `Lucky::PermittedParam`. Maybe we can support both Avram::Attribute, and this so it's not a breaking change?

* Associated objects do work, but they are a bit of a hack. They won't support nested multipart or json params.

* This works great when you're dealing with small forms, but large forms could get really tedious. I'm not sure how we could proxy a model data over, but maybe we have a `UserParams.from_model(user)`? This could be an extension that exists in `lucky_avram`.

* The specs pass locally for me, but seem to fail in the CI. There's a bit of weirdness that surrounds the files due to trying to typecast Avram::Uploadable and Lucky::UploadedFile... 

* We still need to discuss how this will be integrated in to Avram itself. How does the `SaveOperation` know to get the value from this param object? Where does that method live? If it's in Avram, then Avram will have to include Lucky as a dependency. If Avram implements some contract, then Lucky will need to know about that, and what does that look like?

* Including this module in to your models won't work, but with this path, the idea is that you wouldn't want to do that anyway. I still need to write out a clear and concise description of where this thing fits in the stack so a newcomer can understand the thought process behind why we chose this route.


## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
