### PR TITLE
Cleaning up Lucky::Params

### DIFF
--- a/src/lucky/params.cr
+++ b/src/lucky/params.cr
@@ -41,9 +41,9 @@ class Lucky::Params
     parsed_json
   end
 
-  # Returns just the query params as `HTTP::Params`
+  # Returns just the query params as `URI::Params`
   #
-  # Returns an `HTTP::Params` object for only the query params. This method is rarely
+  # Returns a `URI::Params` object for only the query params. This method is rarely
   # helpful since you can get query params with `get`, but if you do need raw
   # access to the query params this is the way to get them.
   #
@@ -52,13 +52,13 @@ class Lucky::Params
   # ```
   #
   # See the docs on [`HTTP::Params`](https://crystal-lang.org/api/HTTP/Params.html) for more information.
-  def from_query : HTTP::Params
+  def from_query : URI::Params
     request.query_params
   end
 
-  # Returns x-www-form-urlencoded body params as `HTTP::Params`
+  # Returns x-www-form-urlencoded body params as `URI::Params`
   #
-  # Returns an `HTTP::Params` object for the request body. This method is rarely
+  # Returns a `URI::Params` object for the request body. This method is rarely
   # helpful since you can get query params with `get`, but if you do need raw
   # access to the body params this is the way to get them.
   #
@@ -66,8 +66,8 @@ class Lucky::Params
   # params.from_form_data["name"]
   # ```
   #
-  # See the docs on [`HTTP::Params`](https://crystal-lang.org/api/HTTP/Params.html) for more information.
-  def from_form_data : HTTP::Params
+  # See the docs on [`URI::Params`](https://crystal-lang.org/api/URI/Params.html) for more information.
+  def from_form_data : URI::Params
     form_params
   end
 
@@ -482,23 +482,23 @@ class Lucky::Params
     end
   end
 
-  private memoize def form_params : HTTP::Params
-    HTTP::Params.parse(body)
+  private memoize def form_params : URI::Params
+    URI::Params.parse(body)
   end
 
-  private def multipart_params
+  private def multipart_params : Lucky::FormData::MultiValueStorage(String)
     parse_form_data.params
   end
 
-  private def multipart_files
+  private def multipart_files : Lucky::FormData::MultiValueStorage(Lucky::UploadedFile)
     parse_form_data.files
   end
 
-  private def json?
+  private def json? : Bool
     !!(/^application\/json/ =~ content_type)
   end
 
-  private def multipart?
+  private def multipart? : Bool
     !!(/^multipart\/form-data/ =~ content_type)
   end
 
@@ -526,7 +526,7 @@ class Lucky::Params
     {} of String => Lucky::UploadedFile
   end
 
-  private def query_params
+  private def query_params : URI::Params
     request.query_params
   end
 


### PR DESCRIPTION
## Purpose
Will help to make less changes in #1519 

## Description
The Crystal `HTTP::Params` is just an alias to `URI::Params` https://crystal-lang.org/api/1.0.0/HTTP/Params.html. Also added a few return extra types to make looking up documentation from method signatures a little easier. 


## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
