### PR TITLE
Changing how inputs with Array attributes are generated.

### DIFF
--- a/spec/lucky_avram/input_helpers_spec.cr
+++ b/spec/lucky_avram/input_helpers_spec.cr
@@ -1,0 +1,31 @@
+require "../spec_helper"
+include ContextHelper
+
+private class TestPage
+  include Lucky::HTMLPage
+
+  def render
+  end
+end
+
+describe Lucky::InputHelpers do
+  it "generates the proper name for array attributes" do
+    view { |page|
+      page.text_input(array_attribute)
+      page.text_input(array_attribute)
+      page.text_input(array_attribute)
+    }.should contain <<-HTML
+    <input type="text" id="key_group_0" name="key:group[]" value="one"><input type="text" id="key_group_1" name="key:group[]" value="two"><input type="text" id="key_group_2" name="key:group[]" value="">
+    HTML
+  end
+end
+
+private def array_attribute
+  Avram::PermittedAttribute.new(name: :group, param: nil, value: ["one", "two"], param_key: "key")
+end
+
+private def view
+  TestPage.new(build_context).tap do |page|
+    yield page
+  end.view.to_s
+end

--- a/src/lucky_avram/ext/lucky/input_helpers.cr
+++ b/src/lucky_avram/ext/lucky/input_helpers.cr
@@ -208,16 +208,45 @@ module Lucky::InputHelpers
       "type"  => type,
       "id"    => input_id(field),
       "name"  => input_name(field),
-      "value" => field.param.to_s,
+      "value" => input_value(field),
     }.merge(input_overrides)
+    update_array_id_counter!(field)
     input attrs, merge_options(html_options, input_options)
+  end
+
+  private property array_id_counter : Hash(Symbol, Int32) do
+    Hash(Symbol, Int32).new { |h, k| h[k] = 0 }
+  end
+
+  private def update_array_id_counter!(field) : Nil
+    nil
+  end
+
+  private def update_array_id_counter!(field : Avram::PermittedAttribute(Array)) : Nil
+    array_id_counter[field.name] += 1
+  end
+
+  private def input_value(field) : String
+    field.param.to_s
+  end
+
+  private def input_value(field : Avram::PermittedAttribute(Array)) : String
+    field.value.try(&.[array_id_counter[field.name]]?).to_s
   end
 
   private def input_name(field)
     "#{field.param_key}:#{field.name}"
   end
 
+  private def input_name(field : Avram::PermittedAttribute(Array))
+    "#{field.param_key}:#{field.name}[]"
+  end
+
   private def input_id(field)
     "#{field.param_key}_#{field.name}"
+  end
+
+  private def input_id(field : Avram::PermittedAttribute(Array))
+    "#{field.param_key}_#{field.name}_#{array_id_counter[field.name]}"
   end
 end

--- a/src/lucky_avram/ext/lucky/select_helpers.cr
+++ b/src/lucky_avram/ext/lucky/select_helpers.cr
@@ -25,4 +25,8 @@ module Lucky::SelectHelpers
   private def input_name(field)
     "#{field.param_key}:#{field.name}"
   end
+
+  private def input_name(field : Avram::PermittedAttribute(Array))
+    "#{field.param_key}:#{field.name}[]"
+  end
 end


### PR DESCRIPTION
## Purpose
Related #1518 

## Description
We already treat the param names ending with `[]` as an array, but right now, there's no way to tell your input that it's an array without manually updating the name. This PR looks at the field, and if it's an Array type, we can append `[]` to the name. This required a few things to change since these would call [field.param](https://github.com/luckyframework/avram/blob/eb0d092828ad052ff6f3f2defa232198a91fc974/src/avram/attribute.cr#L26) which would just call `value.to_s` if it was nil. In the case of an array, this would make the value of the input `"[]"`.

Now we can keep track of how many times you call the attribute which allows us to set a different value for all of the array values you have.

```crystal
op.tags.each do |tag|
  span tag
  text_input(op.tags, value: tag)
end
span "Add new tag"
text_input(op.tags)
```

## Note

I've tagged this as "BREAKING CHANGE" because this will change how your forms will work when you have arrays. The other major deal is Avram still doesn't handle pulling in values from array params. 

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
