### PR TITLE
Working out Array param stuff

### DIFF
--- a/spec/lucky/action_spec.cr
+++ b/spec/lucky/action_spec.cr
@@ -129,6 +129,8 @@ class OptionalParams::Index < TestAction
   param bool_with_false_default : Bool? = false
   # This is to test that an explicit 'nil' can be assigned for nilable types
   param nilable_with_explicit_nil : Int32? = nil
+  param nilable_array_with_default : Array(String)? = [] of String
+  param with_array_default : Array(Int32) = [26, 37, 44]
 
   get "/optional_params" do
     plain_text "optional param: #{page} #{with_int_default} #{with_int_never_nil}"
@@ -276,7 +278,7 @@ describe Lucky::Action do
     end
 
     it "returns optional param declarations" do
-      OptionalParams::Index.query_param_declarations.size.should eq 6
+      OptionalParams::Index.query_param_declarations.size.should eq 8
       OptionalParams::Index.query_param_declarations.should contain "bool_with_false_default : Bool | ::Nil"
     end
   end
@@ -387,6 +389,21 @@ describe Lucky::Action do
       expect_raises Lucky::InvalidParamError, "Required param 'with_int_never_nil' with value 'no_int' couldn't be parsed to a 'Int32'" do
         OptionalParams::Index.new(build_context(path: "/?with_int_never_nil=no_int"), params()).call
       end
+    end
+
+    it "allows nilable arrays with defaults" do
+      action = OptionalParams::Index.new(build_context(path: "/?page=3"), params)
+      action.nilable_array_with_default.should eq([] of String)
+    end
+
+    it "sets a value to a nilable array" do
+      action = OptionalParams::Index.new(build_context(path: "/?nilable_array_with_default[]=1&nilable_array_with_default[]=2"), params)
+      action.nilable_array_with_default.should eq(["1", "2"])
+    end
+
+    it "allows required arrays with defaults" do
+      action = OptionalParams::Index.new(build_context(path: "/?with_array_default=2222222"), params)
+      action.with_array_default.should eq([26, 37, 44])
     end
   end
 end

--- a/spec/support/multipart_helper.cr
+++ b/spec/support/multipart_helper.cr
@@ -57,4 +57,10 @@ module MultipartHelper
       multipart_file_part(formdata, nested_name, nested_value)
     end
   end
+
+  private def multipart_file_part(formdata : HTTP::FormData::Builder, name : String, value : Array(String))
+    value.each do |val|
+      multipart_file_part(formdata, name + "[]", val)
+    end
+  end
 end

--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -410,7 +410,7 @@ module Lucky::Routable
     {% PARAM_DECLARATIONS << type_declaration %}
     @@query_param_declarations << "{{ type_declaration.var }} : {{ type_declaration.type }}"
 
-    def {{ type_declaration.var }} : {{ type_declaration.type }}
+    getter {{ type_declaration.var }} : {{ type_declaration.type }} do
       {% is_nilable_type = type_declaration.type.resolve.nilable? %}
       {% base_type = is_nilable_type ? type_declaration.type.types.first : type_declaration.type %}
       {% is_array = base_type.is_a?(Generic) %}

--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -401,7 +401,7 @@ module Lucky::Routable
   # ```
   #
   # When visiting this page, the path _must_ contain the token parameter:
-  # `/user_confirmations?token=abc123`
+  # `/user_confirmations/new?token=abc123`
   macro param(type_declaration)
     {% unless type_declaration.is_a?(TypeDeclaration) %}
       {% raise "'param' expects a type declaration like 'name : String', instead got: '#{type_declaration}'" %}


### PR DESCRIPTION
## Purpose
Alternative to #1519

## Description
Going the route of #1519 could still work; however, that route requires that params are defined in separate objects. In larger projects, that could end up being lots of duplication and such.

This first commit takes some of that code used in params, but with the idea that we leave the param parsing in Avram Operations. The plus side to this path is there's no breaking changes. We could support a few additional types with Arrays which would make forms slightly more robust. The downsides are that we leave the avram/lucky coupling, testing params in Avram become a little more difficult as we now have to add more methods to paramable, and this path still doesn't get us closer to supporting model associations (i.e. accepts_nested_attributes_for, etc...)

Maybe this is just a stepping stone of progress towards making some of those downsides doable?

This PR now makes this possible:

```crystal
class Searches::Index < BrowserAction
  param tags : Array(String)

  get "/searches" do
    results = SearchStuff.run!(tags: tags)

    html IndexPage, results: results
  end
end
```

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
