### PR TITLE
Fixes syntax error in generator template

### DIFF
--- a/tasks/gen/templates/resource/actions/{{folder_name}}/create.cr.ecr
+++ b/tasks/gen/templates/resource/actions/{{folder_name}}/create.cr.ecr
@@ -1,6 +1,6 @@
 class <%= pluralized_name %>::Create < BrowserAction
   <%= route("Create") %> do
-    Save<%= resource %>create(params) do |operation, <%= underscored_resource %>|
+    Save<%= resource %>.create(params) do |operation, <%= underscored_resource %>|
       if <%= underscored_resource %>
         flash.success = "The record has been saved"
         redirect Show.with(<%= underscored_resource %>.id)


### PR DESCRIPTION
## Purpose
Fixes https://github.com/luckyframework/lucky_cli/pull/641/checks?check_run_id=2833573262#step:9:271

## Description
When this was recently updated, there was a missing period. It was caught by LuckyCli

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [ ] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [ ] - Lucky builds on docker with `./script/setup`
* [ ] - All builds and specs pass on docker with `./script/test`
