### PR TITLE
Add ability to check that all routes maintain similar style (with escape hatches)

### DIFF
--- a/spec/lucky/action_pipes_spec.cr
+++ b/spec/lucky/action_pipes_spec.cr
@@ -33,7 +33,7 @@ end
 class Pipes::Skipped < InheritablePipes
   skip set_before_cookie, overwrite_after_cookie
 
-  get "/skipped-pipes" do
+  get "/skipped_pipes" do
     plain_text "Body"
   end
 end

--- a/spec/lucky/action_route_params_spec.cr
+++ b/spec/lucky/action_route_params_spec.cr
@@ -9,19 +9,19 @@ private class TestParamAction < TestAction
 end
 
 private class TestOptionalParamAction < TestAction
-  get "/test-complex_posts/:required/?:optional_1/?:optional_2" do
+  get "/test_complex_posts/:required/?:optional_1/?:optional_2" do
     plain_text "test"
   end
 end
 
 private class TestGlobAction < TestAction
-  get "/test-complex_posts_glob/*" do
+  get "/test_complex_posts_glob/*" do
     plain_text "test"
   end
 end
 
 private class TestNamedGlobAction < TestAction
-  get "/test-complex_posts_named_glob/*:leftover" do
+  get "/test_complex_posts_named_glob/*:leftover" do
     plain_text "test"
   end
 end

--- a/spec/lucky/action_spec.cr
+++ b/spec/lucky/action_spec.cr
@@ -3,7 +3,8 @@ require "../spec_helper"
 include ContextHelper
 
 class CustomRoutes::Index < TestAction
-  get "/so_custom" do
+  include Lucky::EnforceUnderscoredRoute
+  get "/so_custom-foo" do
     plain_text "test"
   end
 end

--- a/spec/lucky/action_spec.cr
+++ b/spec/lucky/action_spec.cr
@@ -3,8 +3,7 @@ require "../spec_helper"
 include ContextHelper
 
 class CustomRoutes::Index < TestAction
-  include Lucky::EnforceUnderscoredRoute
-  get "/so_custom-foo" do
+  get "/so_custom" do
     plain_text "test"
   end
 end
@@ -143,7 +142,7 @@ class ParamsWithDefaultParamsLast < TestAction
   param has_nil_default : String?
   param no_default : String
 
-  get "/args-with-defaults" do
+  get "/args_with_defaults" do
     plain_text "doesn't matter"
   end
 end

--- a/spec/lucky/component_spec.cr
+++ b/spec/lucky/component_spec.cr
@@ -44,7 +44,7 @@ private class ComponentWithBlockAndNoBlockArgs < Lucky::BaseComponent
 end
 
 private class NoAction < TestAction
-  get "/nothing-to-do" do
+  get "/nothing_to_do" do
     plain_text "blip"
   end
 end

--- a/spec/lucky/expose_spec.cr
+++ b/spec/lucky/expose_spec.cr
@@ -42,7 +42,7 @@ end
 class MultipleExposeAndAssigns < InheritedExposureAction
   expose :expose_three
 
-  get "/mutli-expose" do
+  get "/multi_expose" do
     html arg1: "arg1", arg2: "arg2"
     html MultipleExposeAndAssignsPage, arg1: "arg1", arg2: "arg2"
   end

--- a/spec/lucky/infer_page_spec.cr
+++ b/spec/lucky/infer_page_spec.cr
@@ -12,13 +12,13 @@ class Rendering::CustomPage
 end
 
 class Rendering::Foo < TestAction
-  get "/rendering-foo" do
+  get "/rendering_foo" do
     html Rendering::CustomPage, title: "EditPage", arg2: "testing_multiple_args"
   end
 end
 
 class Rendering::WithinSameNameSpace < TestAction
-  get "/in-namespace" do
+  get "/in_namespace" do
     html CustomPage, title: "WithinSameNameSpace", arg2: "testing_multiple_args"
   end
 end

--- a/spec/lucky/route_prefix_spec.cr
+++ b/spec/lucky/route_prefix_spec.cr
@@ -33,39 +33,39 @@ class PrefixedActions < TestAction
 end
 
 abstract class TestApiPrefixAction < TestAction
-  route_prefix "/parent-api"
+  route_prefix "/parent_api"
 end
 
 class ChildApiWithParentPrefix < TestApiPrefixAction
-  get "/has-parent-prefix" do
+  get "/has_parent_prefix" do
     plain_text "child route prefixed"
   end
 end
 
 class ChildApiWithOwnPrefix < TestApiPrefixAction
-  route_prefix "/child-api"
+  route_prefix "/child_api"
 
-  get "/has-own-prefix" do
+  get "/has_own_prefix" do
     plain_text "child route prefixed"
   end
 end
 
 module ApiPrefixModule
   macro included
-    route_prefix "/module-prefix"
+    route_prefix "/module_prefix"
   end
 end
 
 class ActionIncludingModulePrefix < TestAction
   include ApiPrefixModule
 
-  get "/has-module-prefix" do
+  get "/has_module_prefix" do
     plain_text "child route prefixed"
   end
 end
 
 class ActionNotIncludingModulePrefix < TestAction
-  get "/no-prefix" do
+  get "/no_prefix" do
     plain_text "no prefix"
   end
 end
@@ -82,13 +82,13 @@ describe "prefixing routes" do
   end
 
   it "correctly prefixes through inheritance" do
-    assert_route_added? Lucky::Route.new :get, "/parent-api/has-parent-prefix", ChildApiWithParentPrefix
-    assert_route_added? Lucky::Route.new :get, "/child-api/has-own-prefix", ChildApiWithOwnPrefix
+    assert_route_added? Lucky::Route.new :get, "/parent_api/has_parent_prefix", ChildApiWithParentPrefix
+    assert_route_added? Lucky::Route.new :get, "/child_api/has_own_prefix", ChildApiWithOwnPrefix
   end
 
   it "correctly prefixes action through included modules" do
-    assert_route_added? Lucky::Route.new :get, "/module-prefix/has-module-prefix", ActionIncludingModulePrefix
-    assert_route_added? Lucky::Route.new :get, "/no-prefix", ActionNotIncludingModulePrefix
+    assert_route_added? Lucky::Route.new :get, "/module_prefix/has_module_prefix", ActionIncludingModulePrefix
+    assert_route_added? Lucky::Route.new :get, "/no_prefix", ActionNotIncludingModulePrefix
   end
 end
 

--- a/spec/support/test_action.cr
+++ b/spec/support/test_action.cr
@@ -1,3 +1,4 @@
 abstract class TestAction < Lucky::Action
+  include Lucky::EnforceUnderscoredRoute
   accepted_formats [:html], default: :html
 end

--- a/src/lucky/enforce_underscored_route.cr
+++ b/src/lucky/enforce_underscored_route.cr
@@ -1,0 +1,27 @@
+# Include this in your actions to enforce underscores are used in your paths
+#
+# This is purely to help maintain consistency in your app and can be removed if
+# desired.
+module Lucky::EnforceUnderscoredRoute
+  macro enforce_route_style(path, action)
+    {% if path.includes?("-") %}
+      {% raise <<-ERROR
+      #{path} defined in #{action} includes a dash, but should use an underscore.
+
+      Try this...
+
+        ▸ Change #{path} to #{path.gsub(/-/, "_")}
+
+      Or, skip checking this action...
+
+          class #{action}
+            include Lucky::SkipPathStyleCheck
+          end
+
+      Or, skip checking all actions by removing `Lucky::EnforceUnderscoredRoute` from `BrowserAction` and `ApiAction`
+
+      ERROR
+      %}
+    {% end %}
+  end
+end

--- a/src/lucky/enforce_underscored_route.cr
+++ b/src/lucky/enforce_underscored_route.cr
@@ -6,19 +6,26 @@ module Lucky::EnforceUnderscoredRoute
   macro enforce_route_style(path, action)
     {% if path.includes?("-") %}
       {% raise <<-ERROR
-      #{path} defined in #{action} includes a dash, but should use an underscore.
+      #{path} defined in '#{action}' should use an underscore.
 
-      Try this...
+      In '#{action}'
 
-        ▸ Change #{path} to #{path.gsub(/-/, "_")}
+        ▸ Change #{path}
+        ▸ To #{path.gsub(/-/, "_")}
 
-      Or, skip checking this action...
+      Or, skip the style check for this action
 
           class #{action}
-            include Lucky::SkipPathStyleCheck
+        +  include Lucky::SkipRouteStyleCheck
           end
 
-      Or, skip checking all actions by removing `Lucky::EnforceUnderscoredRoute` from `BrowserAction` and `ApiAction`
+      Or, skip checking all actions by removing 'Lucky::EnforceUnderscoredRoute'
+
+          # Remove from both BrowserAction and ApiAction
+          class BrowserAction/ApiAction
+        -  include Lucky::EnforceUnderscoredRoute
+          end
+
 
       ERROR
       %}

--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -135,11 +135,19 @@ module Lucky::Routable
     {{ run "../run_macros/infer_route", @type.name, has_parent }}
   end
 
+  # Implement this macro in your action to check the path for a particular style.
+  macro check_path_style(path)
+    # no-op by default
+  end
+
   # :nodoc:
   macro add_route(method, path, action)
-    Lucky::Router.add({{ method }}, {{ ROUTE_SETTINGS[:prefix] + path }}, {{ @type.name.id }})
-
     {% path = ROUTE_SETTINGS[:prefix] + path %}
+
+    check_path_style({{ path }})
+
+    Lucky::Router.add({{ method }}, {{ path }}, {{ @type.name.id }})
+
     {% path_parts = path.split('/').reject(&.empty?) %}
     {% path_params = path_parts.select(&.starts_with?(':')) %}
     {% optional_path_params = path_parts.select(&.starts_with?("?:")) %}

--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -136,7 +136,12 @@ module Lucky::Routable
   end
 
   # Implement this macro in your action to check the path for a particular style.
-  macro check_path_style(path)
+  #
+  # By default Lucky ships with a `Lucky::EnforceUnderscoredRoute` that is included
+  # in your `BrowserAction` and `ApiAction` (as of Lucky 0.28)
+  #
+  # See the docs for `Lucky::EnforceUnderscoredRoute` to learn how to use it or disable it.
+  macro enforce_route_style(path, action)
     # no-op by default
   end
 
@@ -144,7 +149,7 @@ module Lucky::Routable
   macro add_route(method, path, action)
     {% path = ROUTE_SETTINGS[:prefix] + path %}
 
-    check_path_style({{ path }})
+    enforce_route_style({{ path }}, {{ @type.name.id }})
 
     Lucky::Router.add({{ method }}, {{ path }}, {{ @type.name.id }})
 

--- a/src/lucky/skip_route_style_check.cr
+++ b/src/lucky/skip_route_style_check.cr
@@ -1,0 +1,6 @@
+# Include this in an action to skip any style checks on routes
+module Lucky::SkipRouteStyleCheck
+  macro enforce_route_style(path, action)
+    # no-op
+  end
+end


### PR DESCRIPTION
Closes #1100 

This caught a bunch of routes in our test suite that used dashes 🤪 So it works!

Need to add this to the default Lucky CLI template in a follow-up PR

<img width="784" alt="Screen Shot 2021-07-04 at 11 56 37 AM" src="https://user-images.githubusercontent.com/22394/124391934-0542e100-dcc1-11eb-9d21-f71407294345.png">
