### PR TITLE
Add subdomain support

### DIFF
--- a/spec/lucky/subdomain_spec.cr
+++ b/spec/lucky/subdomain_spec.cr
@@ -1,0 +1,129 @@
+require "../spec_helper"
+
+include ContextHelper
+
+abstract class BaseAction < Lucky::Action
+  include Lucky::Subdomain
+  accepted_formats [:html], default: :html
+end
+
+class Simple::Index < BaseAction
+  register_subdomain
+
+  get "/simple" do
+    plain_text subdomain
+  end
+end
+
+class Specific::Index < BaseAction
+  register_subdomain "foo"
+
+  get "/specific" do
+    plain_text subdomain
+  end
+end
+
+class Regex::Index < BaseAction
+  register_subdomain /www\d/
+
+  get "/regex" do
+    plain_text subdomain
+  end
+end
+
+class Multiple::Index < BaseAction
+  register_subdomain ["test", "staging", /(prod|production)/]
+
+  get "/multiple" do
+    plain_text subdomain
+  end
+end
+
+describe Lucky::Subdomain do
+  it "handles general subdomain expectation" do
+    request = build_request(host: "foo.example.com")
+    response = Simple::Index.new(build_context(request), params).call
+    response.body.should eq "foo"
+  end
+
+  it "raises error if subdomain missing" do
+    request = build_request(host: "example.com")
+    expect_raises(Lucky::InvalidSubdomainError) do
+      Simple::Index.new(build_context(request), params).call
+    end
+  end
+
+  it "handles specific subdomain expectation" do
+    request = build_request(host: "foo.example.com")
+    response = Specific::Index.new(build_context(request), params).call
+    response.body.should eq "foo"
+  end
+
+  it "raises error if subdomain does not match specific" do
+    request = build_request(host: "admin.example.com")
+    expect_raises(Lucky::InvalidSubdomainError) do
+      Specific::Index.new(build_context(request), params).call
+    end
+  end
+
+  it "handles regex subdomain expectation" do
+    request = build_request(host: "www4.example.com")
+    response = Regex::Index.new(build_context(request), params).call
+    response.body.should eq "www4"
+  end
+
+  it "raises error if subdomain does not match regex" do
+    request = build_request(host: "4www.example.com")
+    expect_raises(Lucky::InvalidSubdomainError) do
+      Regex::Index.new(build_context(request), params).call
+    end
+  end
+
+  it "handles multiple options for expectation" do
+    request = build_request(host: "test.example.com")
+    response = Multiple::Index.new(build_context(request), params).call
+    response.body.should eq "test"
+
+    request = build_request(host: "staging.example.com")
+    response = Multiple::Index.new(build_context(request), params).call
+    response.body.should eq "staging"
+
+    request = build_request(host: "prod.example.com")
+    response = Multiple::Index.new(build_context(request), params).call
+    response.body.should eq "prod"
+
+    request = build_request(host: "production.example.com")
+    response = Multiple::Index.new(build_context(request), params).call
+    response.body.should eq "production"
+  end
+
+  it "raises error if subdomain does not match any expectations" do
+    request = build_request(host: "development.example.com")
+    expect_raises(Lucky::InvalidSubdomainError) do
+      Multiple::Index.new(build_context(request), params).call
+    end
+  end
+
+  it "has configuration for urls with larger tld length" do
+    Lucky::Subdomain.temp_config(tld_length: 2) do
+      request = build_request(host: "foo.example.co.uk")
+      response = Simple::Index.new(build_context(request), params).call
+      response.body.should eq "foo"
+    end
+  end
+
+  it "will fail if using ip address" do
+    request = build_request(host: "development.127.0.0.1:3000")
+    expect_raises(Lucky::InvalidSubdomainError) do
+      Simple::Index.new(build_context(request), params).call
+    end
+  end
+
+  it "will not fail if using localhost and port with tld length set to 0" do
+    Lucky::Subdomain.temp_config(tld_length: 0) do
+      request = build_request(host: "foo.locahost:3000")
+      response = Simple::Index.new(build_context(request), params).call
+      response.body.should eq "foo"
+    end
+  end
+end

--- a/spec/support/context_helper.cr
+++ b/spec/support/context_helper.cr
@@ -5,11 +5,12 @@ module ContextHelper
     method = "GET",
     body = "",
     content_type = "",
-    fixed_length : Bool = false
+    fixed_length : Bool = false,
+    host = "example.com"
   ) : HTTP::Request
     headers = HTTP::Headers.new
     headers.add("Content-Type", content_type)
-    headers.add("Host", "example.com")
+    headers.add("Host", host)
     if fixed_length
       body = HTTP::FixedLengthContent.new(IO::Memory.new(body), body.size)
     end

--- a/src/lucky/errors.cr
+++ b/src/lucky/errors.cr
@@ -239,5 +239,20 @@ module Lucky
   end
 
   class InvalidSubdomainError < Error
+    def initialize(@host : String?, @expected : Lucky::Subdomain::Matcher)
+    end
+
+    def message : String
+      if @host.nil?
+        "Expected to find a subdomain but did not find a hostname on the request."
+      elsif @expected == true
+        "Expected request to have a subdomain but did not find one."
+      else
+        <<-MESSAGE
+          Expected subdomain matcher(s): #{@expected.pretty_inspect}
+          Did not match host: #{@host}
+        MESSAGE
+      end
+    end
   end
 end

--- a/src/lucky/errors.cr
+++ b/src/lucky/errors.cr
@@ -237,4 +237,7 @@ module Lucky
       MESSAGE
     end
   end
+
+  class InvalidSubdomainError < Error
+  end
 end

--- a/src/lucky/subdomain.cr
+++ b/src/lucky/subdomain.cr
@@ -71,7 +71,7 @@ module Lucky::Subdomain
     if result
       continue
     else
-      raise InvalidSubdomainError.new
+      raise InvalidSubdomainError.new(host: request.hostname, expected: matcher)
     end
   end
 end

--- a/src/lucky/subdomain.cr
+++ b/src/lucky/subdomain.cr
@@ -1,0 +1,71 @@
+module Lucky::Subdomain
+  # Taken from https://github.com/rails/rails/blob/afc6abb674b51717dac39ea4d9e2252d7e40d060/actionpack/lib/action_dispatch/http/url.rb#L8
+  IP_HOST_REGEXP = /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$/
+
+  Habitat.create do
+    # tld_length is the number of Top Level Domain segments separated by periods
+    # the default is 1 because most domains end in ".com" or ".org"
+    # The tld_length should be changed to 2 when you have a ".co.uk" domain for example
+    # It can also be changed to 0 for local development so that you can use `tenant.localhost:3000`
+    setting tld_length : Int32 = 1
+  end
+
+  alias Matcher = String | Regex | Bool | Array(String | Regex) | Array(String) | Array(Regex)
+
+  # Sets up a subdomain requirement for an action
+  #
+  # ```
+  # register_subdomain                                    # subdomain required but can be anything
+  # register_subdomain "admin"                            # subdomain required and must equal "admin"
+  # register_subdomain /(dev|qa|prod)/                    # subdomain required and must match regex
+  # register_subdomain ["tenant1", "tenant2", /tenant\d/] # subdomain required and must match one of the items in the array
+  # ```
+  macro register_subdomain(matcher = true)
+    before _match_subdomain
+
+    private def subdomain : String
+      _fetch_subdomain.not_nil!
+    end
+
+    private def _match_subdomain
+      _match_subdomain({{ matcher }})
+    end
+  end
+
+  def subdomain : String
+    {% raise "No subdomain available without calling `register_subdomain` first." %}
+  end
+
+  private def _fetch_subdomain : String?
+    host = request.hostname
+    return if host.nil? || IP_HOST_REGEXP.matches?(host)
+
+    parts = host.split('.')
+    parts.pop(settings.tld_length + 1)
+
+    parts.empty? ? nil : parts.join(".")
+  end
+
+  private def _match_subdomain(matcher : Matcher)
+    expected = [matcher].flatten.compact
+    return continue if expected.empty?
+
+    actual = _fetch_subdomain
+    result = expected.any? do |expected_subdomain|
+      case expected_subdomain
+      when true
+        actual.present?
+      when Symbol
+        actual.to_s == expected_subdomain.to_s
+      else
+        expected_subdomain === actual
+      end
+    end
+
+    if result
+      continue
+    else
+      raise InvalidSubdomainError.new
+    end
+  end
+end


### PR DESCRIPTION
## Purpose

Resolves #1166 

## Description

Adds subdomain support to Lucky.

## Usage

### For request requirement

```crystal
abstract class AdminAction < Lucky::Action
  include Lucky::Subdomain

  register_subdomain "admin" # requires all requests to be made through admin.example.com
end
```

### For subdomain access

```crystal
class Payments::Create < BrowserAction
  include Lucky::Subdomain
  register_subdomain ["tenant1", "tenant2", ...]

  post "/payments" do
    tenant = TenantQuery.new.name(subdomain).first
    ...
  end
end
```

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
