### PR TITLE
Remove old deprecations and compilation errors

### DIFF
--- a/src/charms/static_file_handler.cr
+++ b/src/charms/static_file_handler.cr
@@ -4,8 +4,4 @@ class Lucky::StaticFileHandler < HTTP::StaticFileHandler
   def call(context : HTTP::Server::Context)
     super(context)
   end
-
-  def self.configure(*args, **named_args, &block)
-    {% raise "All settings were removed from Lucky::StaticFileHandler. You can remove the Lucky::StaticFileHandler.configure block." %}
-  end
 end

--- a/src/lucky/action.cr
+++ b/src/lucky/action.cr
@@ -19,10 +19,4 @@ abstract class Lucky::Action
   include Lucky::Redirectable
   include Lucky::RedirectableTurbolinksSupport
   include Lucky::VerifyAcceptsFormat
-
-  # Must be defined here instead of in Renderable
-  # Otherwise it clashes with ErrorAction#render
-  private def render(page_class, **named_args)
-    {% raise "'render' in actions has been renamed to 'html'" %}
-  end
 end

--- a/src/lucky/cookies/cookie_jar.cr
+++ b/src/lucky/cookies/cookie_jar.cr
@@ -34,14 +34,6 @@ class Lucky::CookieJar
     set_cookies
   end
 
-  def destroy
-    {% raise "CookieJar#destroy has been renamed to CookieJar#clear to match Hash#clear" %}
-  end
-
-  def unset(*args)
-    {% raise "use CookieJar#delete instead of CookieJar#unset" %}
-  end
-
   # Delete all cookies.
   def clear : Nil
     clear { }

--- a/src/lucky/cookies/session.cr
+++ b/src/lucky/cookies/session.cr
@@ -18,18 +18,6 @@ class Lucky::Session
     end
   end
 
-  def destroy
-    {% raise "Session#destroy has been renamed to Session#clear to match Hash#clear" %}
-  end
-
-  def reset
-    {% raise "use Session#clear to reset the session" %}
-  end
-
-  def unset(*args)
-    {% raise "use Session#delete instead of Session#unset" %}
-  end
-
   def delete(key : Key) : String?
     store.delete key.to_s
   end

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -257,16 +257,6 @@ module Lucky::Renderable
     plain_text(body, status: status.value)
   end
 
-  # :nodoc:
-  private def text(*args, **named_args)
-    {% raise "'text' in actions has been renamed to 'plain_text'" %}
-  end
-
-  @[Deprecated("`render_text` deprecated. Use `plain_text` instead")]
-  private def render_text(*args, **named_args) : Lucky::TextResponse
-    plain_text(*args, **named_args)
-  end
-
   def head(status : Int32) : Lucky::TextResponse
     send_text_response(body: "", content_type: "", status: status)
   end

--- a/src/lucky/request_type_helpers.cr
+++ b/src/lucky/request_type_helpers.cr
@@ -97,9 +97,4 @@ module Lucky::RequestTypeHelpers
   def multipart? : Bool
     !!request.headers["Content-Type"]?.try(&.downcase.starts_with?("multipart/form-data"))
   end
-
-  # :nodoc:
-  def plain?
-    {% raise "This method has been renamed to 'plain_text?'" %}
-  end
 end


### PR DESCRIPTION
## Purpose

These are all old deprecations. Some places used a `Deprecated` annotation and others used a compilation error in the method. Either way, they have all been in more than one release.
