### PR TITLE
Switch to oprypins github action for installing crystal

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,9 @@ jobs:
       - name: Cache shards
         uses: actions/cache@v2
         with:
-          path: lib
-          key: ${{ runner.os }}-shards-${{ hashFiles('**/shard.lock') }}
+          path: ~/.cache/shards
+          key: ${{ runner.os }}-shards-${{ hashFiles('shard.yml') }}
+          restore-keys: ${{ runner.os }}-shards-
       - name: Install shards
         run: SHARDS_OVERRIDE=${{ matrix.shard_file }} shards install --ignore-crystal-version
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,13 @@ jobs:
             experimental: true
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
-    container: crystallang/crystal:${{ matrix.crystal_version }}-alpine
     env:
       SKIP_LUCKY_TASK_PRECOMPILATION: "1"
     steps:
       - uses: actions/checkout@v1
+      - uses: crystal-lang/install-crystal@v1
+        with:
+          crystal: ${{matrix.crystal_version}}
       - name: Install shards
         run: SHARDS_OVERRIDE=${{ matrix.shard_file }} shards install
       - name: Format
@@ -56,16 +58,18 @@ jobs:
             experimental: true
     runs-on: ubuntu-latest
     continue-on-error: ${{ matrix.experimental }}
-    container: crystallang/crystal:${{ matrix.crystal_version }}-alpine
     env:
       SKIP_LUCKY_TASK_PRECOMPILATION: "1"
     steps:
       - uses: actions/checkout@v2
-      - name: Cache Crystal
-        uses: actions/cache@v1
+      - uses: crystal-lang/install-crystal@v1
         with:
-          path: ~/.cache/crystal
-          key: ${{ runner.os }}-crystal
+          crystal: ${{matrix.crystal_version}}
+      - name: Cache shards
+        uses: actions/cache@v2
+        with:
+          path: lib
+          key: ${{ runner.os }}-shards-${{ hashFiles('**/shard.lock') }}
       - name: Install shards
         run: SHARDS_OVERRIDE=${{ matrix.shard_file }} shards install --ignore-crystal-version
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,12 +65,6 @@ jobs:
       - uses: crystal-lang/install-crystal@v1
         with:
           crystal: ${{matrix.crystal_version}}
-      - name: Cache shards
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/shards
-          key: ${{ runner.os }}-shards-${{ hashFiles('shard.yml') }}
-          restore-keys: ${{ runner.os }}-shards-
       - name: Install shards
         run: SHARDS_OVERRIDE=${{ matrix.shard_file }} shards install --ignore-crystal-version
       - name: Run tests

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,12 +7,11 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    container:
-      image: crystallang/crystal
     steps:
       - uses: actions/checkout@v2
         with:
           persist-credentials: false
+      - uses: crystal-lang/install-crystal@v1
       - name: "Install shards"
         run: shards install
       - name: "Generate docs"


### PR DESCRIPTION
Looks like they haven't released Crystal 1.1.0 for the alpine docker images https://github.com/luckyframework/lucky/pull/1543

I think switching to https://github.com/crystal-lang/install-crystal will mean that we won't have to wait going forward.