### PR TITLE
Rename generated method from destroy to delete in resource task

### DIFF
--- a/spec/tasks/gen/resource_spec.cr
+++ b/spec/tasks/gen/resource_spec.cr
@@ -29,7 +29,7 @@ describe Gen::Resource::Browser do
           "./src/actions/users/show.cr": "html ShowPage, user: UserQuery.find(user_id)",
           "./src/actions/users/edit.cr": "user = UserQuery.find(user_id)",
           "./src/actions/users/update.cr": "user = UserQuery.find(user_id)",
-          "./src/actions/users/delete.cr": "DeleteUser.destroy(user)"
+          "./src/actions/users/delete.cr": "DeleteUser.delete(user)"
         should_create_files_with_contents io,
           "./src/pages/users/index_page.cr": "class Users::IndexPage < MainLayout",
           "./src/pages/users/show_page.cr": "class Users::ShowPage < MainLayout",

--- a/tasks/gen/templates/resource/actions/{{folder_name}}/delete.cr.ecr
+++ b/tasks/gen/templates/resource/actions/{{folder_name}}/delete.cr.ecr
@@ -1,7 +1,7 @@
 class <%= pluralized_name %>::Delete < BrowserAction
   <%= route("Delete") %> do
     <%= underscored_resource %>  = <%= query_class %>.find(<%= resource_id_method_name %>)
-    Delete<%= resource %>.destroy(<%= underscored_resource %>) do |_operation, _deleted|
+    Delete<%= resource %>.delete(<%= underscored_resource %>) do |_operation, _deleted|
       flash.success = "Deleted the <%= underscored_resource %>"
       redirect Index
     end 


### PR DESCRIPTION
## Purpose
Fixes #1546

## Description
We renamed the DeleteOperation method from `destroy` to `delete`. This PR updates the generated method

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
