### PR TITLE
Added more type options for status in the html_with_status macro

### DIFF
--- a/spec/lucky/action_rendering_spec.cr
+++ b/spec/lucky/action_rendering_spec.cr
@@ -19,9 +19,21 @@ class Rendering::Index < TestAction
   end
 end
 
-class Rendering::Show < TestAction
+class Rendering::Show::WithStatus < TestAction
   get "/rendering/:nothing" do
     html_with_status IndexPage, 419, title: "Closing Time", arg2: "You don't have to go home but you can't stay here"
+  end
+end
+
+class Rendering::Show::WithSymbolStatus < TestAction
+  get "/rendering1/:nothing" do
+    html_with_status IndexPage, :unauthorized, title: "Closing Time", arg2: "You don't have to go home but you can't stay here"
+  end
+end
+
+class Rendering::Show::WithEnumStatus < TestAction
+  get "/rendering2/:nothing" do
+    html_with_status IndexPage, HTTP::Status::UNPROCESSABLE_ENTITY, title: "Closing Time", arg2: "You don't have to go home but you can't stay here"
   end
 end
 
@@ -189,11 +201,17 @@ describe Lucky::Action do
     end
 
     it "renders with a different status code" do
-      response = Rendering::Show.new(build_context, params).call
+      response = Rendering::Show::WithStatus.new(build_context, params).call
 
       response.body.to_s.should contain "Closing Time"
       response.debug_message.to_s.should contain "Rendering::IndexPage"
       response.status.should eq 419
+
+      status = Rendering::Show::WithSymbolStatus.new(build_context, params).call.status
+      status.should eq 401
+
+      status = Rendering::Show::WithEnumStatus.new(build_context, params).call.status
+      status.should eq 422
     end
   end
 

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -86,7 +86,7 @@ module Lucky::Renderable
       html {{ page_class }}, _with_status_code: {{ status }}, {{ **assigns }}
     {% elsif status.is_a?(SymbolLiteral) %}
       html {{ page_class }}, _with_status_code: HTTP::Status::{{ status.upcase.id }}.value, {{ **assigns }}
-    {% elsif status.resolve.is_a?(NumberLiteral) %}
+    {% elsif status.is_a?(Path) && status.names.join("::").starts_with?("HTTP::Status::") %}
       html {{ page_class }}, _with_status_code: {{ status.resolve }}, {{ **assigns }}
     {% else %}
       {% raise <<-ERROR


### PR DESCRIPTION
The `html_with_status` macro now also accepts Symbols and `HTTP::Status` as the status argument.

## Purpose
Fixes #1558

## Description
I also added the option to use symbols, no worries they are typesafe, so you will get a compile time error in case of typos.
I think it reads better with a symbol, maybe i'm weird like that 🤷 

```crystal
html_with_status EditPage, :unprocessable_entity, operation: operation, post: post
```
## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
