### PR TITLE
Adding new path_without_query_params method

### DIFF
--- a/spec/lucky/action_spec.cr
+++ b/spec/lucky/action_spec.cr
@@ -191,6 +191,28 @@ describe Lucky::Action do
     end
   end
 
+  describe ".path_without_query_params" do
+    it "returns path without declared non-nil query params" do
+      Lucky::RouteHelper.temp_config(base_uri: "example.com") do
+        RequiredParams::Index.path_without_query_params.should eq "/required_params"
+      end
+    end
+
+    it "returns path with (required) path params" do
+      Lucky::RouteHelper.temp_config(base_uri: "example.com") do
+        Tests::Edit.path_without_query_params(1).should eq "/tests/1/edit"
+      end
+    end
+
+    it "returns path with optional path params" do
+      Lucky::RouteHelper.temp_config(base_uri: "example.com") do
+        OptionalRouteParams::Index.path_without_query_params(1).should eq "/complex_posts/1"
+        OptionalRouteParams::Index.path_without_query_params(1, 2).should eq "/complex_posts/1/2"
+        OptionalRouteParams::Index.path_without_query_params(1, 2, 3).should eq "/complex_posts/1/2/3"
+      end
+    end
+  end
+
   describe "routing" do
     it "creates URL helpers for the resourceful actions" do
       Tests::Index.path.should eq "/tests"

--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -267,6 +267,25 @@ module Lucky::Routable
       Lucky::RouteHelper.new({{ method }}, path).url
     end
 
+    def self.path_without_query_params(
+    {% for param in path_params %}
+      {{ param.gsub(/:/, "").id }},
+    {% end %}
+    {% for param in optional_path_params %}
+      {{ param.gsub(/^\?:/, "").id }} = nil,
+    {% end %}
+    )
+      path = path_from_parts(
+        {% for param in path_params %}
+          {{ param.gsub(/:/, "").id }},
+        {% end %}
+        {% for param in optional_path_params %}
+          {{ param.gsub(/^\?:/, "").id }},
+        {% end %}
+      )
+      Lucky::RouteHelper.new({{ method }}, path).path
+    end
+
     {% params_with_defaults = PARAM_DECLARATIONS.select do |decl|
          !decl.value.is_a?(Nop) || decl.type.is_a?(Union) && decl.type.types.last.id == Nil.id
        end %}


### PR DESCRIPTION
## Purpose
Fixes #1571

## Description
We already have a `url_without_query_params` method. This adds in the `path` version to be complimentary.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
