### PR TITLE
Remove obsolete require

### DIFF
--- a/tasks.cr
+++ b/tasks.cr
@@ -1,6 +1,5 @@
 require "lucky_task"
 require "./src/lucky"
-require "./src/app/**"
 require "./tasks/**"
 
 LuckyTask::Runner.run


### PR DESCRIPTION
## Purpose
Fixes #1570

It removes the obsolete require statement

## Description
https://github.com/luckyframework/lucky/blob/5e283d24813e161d50d80a949cde9ba4c7ac90d2/tasks.cr#L3

```diff
-require "./src/app/**"
```
## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
