### PR TITLE
allows manifest file to be parameterized

### DIFF
--- a/src/lucky/asset_helpers.cr
+++ b/src/lucky/asset_helpers.cr
@@ -8,8 +8,8 @@ module Lucky::AssetHelpers
   ASSET_MANIFEST = {} of String => String
   CONFIG         = {has_loaded_manifest: false}
 
-  macro load_manifest
-    {{ run "../run_macros/generate_asset_helpers" }}
+  macro load_manifest(manifest_file = "")
+    {{ run "../run_macros/generate_asset_helpers", manifest_file }}
     {% CONFIG[:has_loaded_manifest] = true %}
   end
 

--- a/src/run_macros/generate_asset_helpers.cr
+++ b/src/run_macros/generate_asset_helpers.cr
@@ -2,15 +2,17 @@ require "json"
 require "colorize"
 
 private class AssetManifestBuilder
-  MANIFEST_PATH = File.expand_path("./public/mix-manifest.json")
-  MAX_RETRIES   =   20
-  RETRY_AFTER   = 0.25
+  MAX_RETRIES =   20
+  RETRY_AFTER = 0.25
 
   property retries
   @retries : Int32 = 0
+  @manifest_path : String = File.expand_path("./public/mix-manifest.json")
 
-  def self.build_with_retry
-    new.build_with_retry
+  def initialize
+  end
+
+  def initialize(@manifest_path)
   end
 
   def build_with_retry
@@ -32,7 +34,7 @@ private class AssetManifestBuilder
   end
 
   private def build
-    manifest_file = File.read(MANIFEST_PATH)
+    manifest_file = File.read(@manifest_path)
     manifest = JSON.parse(manifest_file)
 
     manifest.as_h.each do |key, value|
@@ -42,17 +44,25 @@ private class AssetManifestBuilder
   end
 
   private def manifest_exists?
-    File.exists?(MANIFEST_PATH)
+    File.exists?(@manifest_path)
   end
 
   private def raise_missing_manifest_error
-    puts "Manifest at #{AssetManifestBuilder::MANIFEST_PATH} does not exist".colorize(:red)
+    puts "Manifest at #{@manifest_path} does not exist".colorize(:red)
     puts "Make sure you have compiled your assets".colorize(:red)
   end
 end
 
 begin
-  AssetManifestBuilder.build_with_retry
+  manifest_path = ARGV[0]
+
+  builder = if manifest_path.blank?
+              AssetManifestBuilder.new
+            else
+              AssetManifestBuilder.new(manifest_path)
+            end
+
+  builder.build_with_retry
 rescue ex
   puts ex.message.colorize(:red)
   raise ex


### PR DESCRIPTION
## Purpose
fixes #1382 - manifest json file is hard coded to be laravel-mix specific.


## Description

This patch _allows_ src/app.cr in a generated application to be changed to this:

```diff
-# Load the asset manifest in public/mix-manifest.json
-Lucky::AssetHelpers.load_manifest
+Lucky::AssetHelpers.load_manifest "public/mix-manifest.json"
```

For folks using rollup, parcel, vite, or whatever hot javascript packaging engine suits them, this top level hook for replacing the manifest file is important.

Notably, this doesn't require the change to app.cr so this isn't a breaking change. It just provides an API where non existed before.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [ ] - Lucky builds on docker with `./script/setup`
* [ ] - All builds and specs pass on docker with `./script/test`
