### PR TITLE
Removing compile-time catches for html_with_status

### DIFF
--- a/spec/lucky/action_rendering_spec.cr
+++ b/spec/lucky/action_rendering_spec.cr
@@ -21,7 +21,8 @@ end
 
 class Rendering::Show::WithStatus < TestAction
   get "/rendering/:nothing" do
-    html_with_status IndexPage, 419, title: "Closing Time", arg2: "You don't have to go home but you can't stay here"
+    gather_status = 419
+    html_with_status IndexPage, gather_status, title: "Closing Time", arg2: "You don't have to go home but you can't stay here"
   end
 end
 

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -82,29 +82,12 @@ module Lucky::Renderable
   # [HTTP::Status](https://crystal-lang.org/api/latest/HTTP/Status.html)
   # enum for more available http status codes.
   macro html_with_status(page_class, status, **assigns)
-    {% if status.is_a?(NumberLiteral) %}
-      html {{ page_class }}, _with_status_code: {{ status }}, {{ **assigns }}
-    {% elsif status.is_a?(SymbolLiteral) %}
+    {% if status.is_a?(SymbolLiteral) %}
       html {{ page_class }}, _with_status_code: HTTP::Status::{{ status.upcase.id }}.value, {{ **assigns }}
     {% elsif status.is_a?(Path) && status.names.join("::").starts_with?("HTTP::Status::") %}
       html {{ page_class }}, _with_status_code: {{ status.resolve }}, {{ **assigns }}
     {% else %}
-      {% raise <<-ERROR
-
-      #{@type.name} called `html_with_status #{page_class}` with status '#{status}'.
-      The `status` value should either be a Number, a HTTP::Status or a Symbol that corresponds to the HTTP::Status.
-      If you want to render a page with status code 200 you can also use `html`
-
-
-      Try this...
-
-        ▸ html_with_status #{page_class}, 419, arg1: "...", arg2: "..."
-        ▸ html_with_status #{page_class}, HTTP::Status::FORBIDDEN, arg1: "...", arg2: "..."
-        ▸ html_with_status #{page_class}, :unprocessable_entity, arg1: "...", arg2: "..."
-        ▸ html #{page_class}, arg1: "...", arg2: "..."
-
-      ERROR
-      %}
+      html {{ page_class }}, _with_status_code: {{ status }}, {{ **assigns }}
     {% end %}
   end
 


### PR DESCRIPTION
## Purpose
Fixes #1575 

## Description
If your status code comes from a variable, this was failing because it was looking for literal objects only. This was originally to ensure you were passing in something proper since the macro arguments don't catch type-safety.

Removing those compile-time catches allows us to just fallback to a "whatever you passed in". If it's a Number, then it will pass that over. If it's a variable that returns a Number, then it will be fine. Anything else, and you'll end up getting a "No overload matches" error from `TextResponse`.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
