### PR TITLE
Fix compile error

### DIFF
--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -311,7 +311,7 @@ module Lucky::Routable
 
     # optional path variables are nilable
     {% for param in optional_path_params %}
-      {{ param.gsub(/^\?:/, "").id }} : String? = nil,
+      {{ param.gsub(/^\?:/, "").id }} = nil,
     {% end %}
     anchor : String? = nil
       ) : Lucky::RouteHelper


### PR DESCRIPTION
Closes #1579.

Calls to `Lucky::Routable.route` failed to compile when passed optional path param values other than strings.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
