### PR TITLE
Support namespaces in model generator

### DIFF
--- a/tasks/gen/templates/model/models/{{underscored_namespace_path}}{{underscored_name}}.cr.ecr
+++ b/tasks/gen/templates/model/models/{{underscored_namespace_path}}{{underscored_name}}.cr.ecr
@@ -1,4 +1,4 @@
-class <%= @name %> < BaseModel
+class <%= @namespace %><%= @name %> < BaseModel
   table do
     <%- @columns.each do |column| -%>
     column <%= column.name %> : <%= column.type %>

--- a/tasks/gen/templates/model/operations/{{underscored_namespace_path}}save_{{underscored_name}}.cr.ecr
+++ b/tasks/gen/templates/model/operations/{{underscored_namespace_path}}save_{{underscored_name}}.cr.ecr
@@ -1,4 +1,4 @@
-class Save<%= @name %> < <%= @name %>::SaveOperation
+class <%= @namespace %>Save<%= @name %> < <%= @namespace %><%= @name %>::SaveOperation
   # To save user provided params to the database, you must permit them
   # https://luckyframework.org/guides/database/saving-records#perma-permitting-columns
   #

--- a/tasks/gen/templates/model/queries/{{underscored_namespace_path}}{{underscored_name}}_query.cr.ecr
+++ b/tasks/gen/templates/model/queries/{{underscored_namespace_path}}{{underscored_name}}_query.cr.ecr
@@ -1,0 +1,2 @@
+class <%= @namespace %><%= @name %>Query < <%= @namespace %><%= @name %>::BaseQuery
+end

--- a/tasks/gen/templates/model/queries/{{underscored_name}}_query.cr.ecr
+++ b/tasks/gen/templates/model/queries/{{underscored_name}}_query.cr.ecr
@@ -1,2 +1,0 @@
-class <%= @name %>Query < <%= @name %>::BaseQuery
-end

--- a/tasks/gen/templates/model_template.cr
+++ b/tasks/gen/templates/model_template.cr
@@ -1,16 +1,19 @@
 class Lucky::ModelTemplate < Teeplate::FileTree
   @name : String
+  @namespace : String
   @columns : Array(Lucky::GeneratedColumn)
-  @pluralized_name : String
   @underscored_name : String
+  @underscored_namespace_path : String
 
   getter underscored_name
+  getter underscored_namespace_path
 
   directory "#{__DIR__}/model/"
 
-  def initialize(@name : String, @columns : Array(Lucky::GeneratedColumn))
+  def initialize(full_name : String, @columns : Array(Lucky::GeneratedColumn))
+    @namespace, _, @name = full_name.partition(/\b(?=\w+$)/)
     @underscored_name = @name.underscore
-    @pluralized_name = Wordsmith::Inflector.pluralize(@underscored_name)
+    @underscored_namespace_path = @namespace.underscore.gsub("::", "/")
   end
 
   def columns_list


### PR DESCRIPTION
## Purpose
Fixes #1184
Adds support for generating namespaced models using the model generator.

## Description
Previously:

> $ lucky gen.model Blog::Post title:String
> Model name should only contain letters. Example: lucky gen.model BlogPost

But now it will create `src/models/blog/post.cr` with the class `Blog::Post`.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`

I've worked on this using the GitHub web IDE so I never compiled/ran the code, but I've tried real hard to make sure everything is in order (even read the source code of teeplate and some avram), so I'm pretty confident this works. If not I'll fix it.

btw I've never heard/used the Crystal language until now, and I hate it. But hopefully I helped. Although the macro feature is impressive.

## Note

There's a small edge case - all of `Foo::Bar::Baz`/`Foo::BarBaz`/`FooBar::Baz`/`FooBarBaz` use `create_foo_bar_baz` for the name of the migration Avram creates, so if you try to create this conflict then the generation will succeed but the migration generation will fail with `Migration name must be unique`.

I don't think this is fixable without changing Avram, since it expects a camel-cased name and converts it to underscored, so even if we wanted `Blog::Post` to turn into `create_blog__post` (double underscore to mark namespace) it isn't possible.
And I can't check for this conflict easily since I'd have to check all possibilities of adding double-colons between every word. Or I'd have to look in the migrations folder which is easier, but breaks the abstraction.