### PR TITLE
Prevent ameba from being installed during postinstall

### DIFF
--- a/script/precompile_tasks
+++ b/script/precompile_tasks
@@ -3,7 +3,15 @@
 # Precompile tasks if not in production and not in CI
 # Also allow skipping precompilation with an ENV var
 if [ "$LUCKY_ENV" != "production" ] && [ -z "$CI" ] && [ -z "$SKIP_LUCKY_TASK_PRECOMPILATION" ]; then
-    shards build
+    # This is to prevent Lucky's development dependencies being installed
+    # from an external source like running `shards install` from a Lucky app.
+    # Install shards and build shard targets.
+    if [ -z "$BUILD_WITHOUT_DEVELOPMENT" ]; then
+        shards build
+    else
+        shards build --without-development
+    fi
+
     mkdir -p ../../bin
     cp -r "$PWD/bin" "$PWD/../.."
 fi

--- a/shard.yml
+++ b/shard.yml
@@ -71,6 +71,6 @@ development_dependencies:
     version: ~> 0.14.2
 
 scripts:
-  postinstall: script/precompile_tasks
+  postinstall: BUILD_WITHOUT_DEVELOPMENT=true script/precompile_tasks
 
 license: MIT


### PR DESCRIPTION
## Purpose
Fixes https://github.com/luckyframework/lucky/issues/1524

## Description
When Lucky is included as a dependency of an app, and you run `shards install`, it will call Lucky's `postinstall` script. That will then run `shards build` from within the lucky directory causing it to install all shards including development dependencies.

This PR tells it to only build the targets, but don't build development dependencies.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
