### PR TITLE
Only split the signed message in to 2 parts with the message verifier

### DIFF
--- a/spec/lucky/support/message_verifier_spec.cr
+++ b/spec/lucky/support/message_verifier_spec.cr
@@ -1,0 +1,9 @@
+require "../../spec_helper"
+
+describe Lucky::MessageVerifier do
+  it "is valid" do
+    verifier = Lucky::MessageVerifier.new("supersecretsquirrel", :sha256)
+    signed_message = verifier.generate("abc123")
+    verifier.verified(signed_message).should eq("abc123")
+  end
+end

--- a/src/lucky/support/message_verifier.cr
+++ b/src/lucky/support/message_verifier.cr
@@ -11,7 +11,7 @@ module Lucky
     end
 
     def verified(signed_message : String) : String?
-      data, digest = signed_message.split("--")
+      data, digest = signed_message.split("--", 2)
       if valid_message?(data, digest)
         String.new(decode(data))
       end
@@ -25,7 +25,7 @@ module Lucky
     end
 
     def verify_raw(signed_message : String) : Bytes
-      data, digest = signed_message.split("--")
+      data, digest = signed_message.split("--", 2)
       if valid_message?(data, digest)
         decode(data)
       else


### PR DESCRIPTION
## Purpose
Fixes #1595

## Description
In rare cases, the generated data can contain the `--` sequence in it. If it does, this PR ensures that the string will only ever be split in to 2 parts. The first part is the data, and the second part is the digest.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
