### PR TITLE
Adding new Event to track when a request is complete

### DIFF
--- a/spec/lucky/log_handler_spec.cr
+++ b/spec/lucky/log_handler_spec.cr
@@ -42,6 +42,20 @@ describe Lucky::LogHandler do
     log_output = log_io.to_s
     log_output.should contain("an error")
   end
+
+  it "publishes the request_complete_event" do
+    Lucky::Events::RequestCompleteEvent.subscribe do |event|
+      event.duration.should_not be_nil
+    end
+
+    called = false
+    log_io = IO::Memory.new
+    context = build_context_with_io(log_io)
+
+    call_log_handler_with(log_io, context) { called = true }
+
+    called.should be_true
+  end
 end
 
 private def call_log_handler_with(io : IO, context : HTTP::Server::Context, &block)

--- a/src/lucky/events/request_complete_event.cr
+++ b/src/lucky/events/request_complete_event.cr
@@ -1,0 +1,6 @@
+class Lucky::Events::RequestCompleteEvent < Pulsar::Event
+  getter :duration
+
+  def initialize(@duration : Time::Span)
+  end
+end


### PR DESCRIPTION
## Purpose
Ref: https://github.com/luckyframework/breeze/issues/33

## Description
This PR adds in a new Pulsar event that will allow Breeze to subscribe and get the request duration. I've also refactored the LogHandler a little to clean up some of the logic with skipping logging.

With that, the time that was logged before included the time it took to print to the logs that a request was starting. That time is irrelevant though. By moving that up, we can just use `Time.measure` which will measure how long it takes to run the rest of the middleware stack. In a future PR, I'll be adding in a unique request ID that will be tracked in here so we can join the before/after logging 

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
