### PR TITLE
adding a better help message to lucky exec

### DIFF
--- a/tasks/exec.cr
+++ b/tasks/exec.cr
@@ -17,6 +17,21 @@ class Lucky::Exec < LuckyTask::Task
     setting template_path : String = "#{__DIR__}/exec_template.cr.template"
   end
 
+  def help_message
+    <<-TEXT
+    #{summary}
+
+    Options:
+      --editor=EDITOR, -e EDITOR    Use the EDITOR for editing code
+      --back=NUMBER, -b NUMBER      Load code NUMBER sessions back
+      --once, -o                    Only run this code once then exit
+
+    example: lucky exec -e emacs -b 3 -o
+
+    Run this task with 'lucky #{name} [OPTIONS]'
+    TEXT
+  end
+
   def call
     editor_to_use = editor || settings.editor
     repeat = !once?


### PR DESCRIPTION
## Purpose
Fixes #1559

## Description
This help message didn't tell you about possible options before.

<img width="777" alt="Screen Shot 2021-11-01 at 3 24 52 PM" src="https://user-images.githubusercontent.com/2391/139750177-cac544bf-9b3b-4208-837c-89079894657a.png">


## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
