### PR TITLE
register ajax just as a plain mime type.

### DIFF
--- a/spec/lucky/request_type_helper_spec.cr
+++ b/spec/lucky/request_type_helper_spec.cr
@@ -61,6 +61,7 @@ describe Lucky::RequestTypeHelpers do
 
   it "checks if request send via AJAX" do
     action = FakeAction.new
+    action.context._clients_desired_format = :ajax
     action.ajax?.should(be_false)
 
     action.context.request.headers["X-Requested-With"] = "XMLHttpRequest"

--- a/src/lucky/mime_type.cr
+++ b/src/lucky/mime_type.cr
@@ -9,6 +9,8 @@ class Lucky::MimeType
   register "text/json", :json
   register "application/jsonrequest", :json
   register "text/javascript", :js
+  # It's a JS request, but not JSON, or XML
+  register "text/plain", :ajax
   register "application/xml", :xml
   register "application/rss+xml", :rss
   register "application/atom+xml", :atom


### PR DESCRIPTION
## Purpose
Fixes #1320

## Description
If you wanted to set your desired format to be `ajax`, but you're not sending JSON or XML, then we just set it to plain and return the raw text.


## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
