### PR TITLE
fix watch recompile message logic

### DIFF
--- a/tasks/watch.cr
+++ b/tasks/watch.cr
@@ -153,7 +153,7 @@ module LuckySentry
     end
 
     def restart_app
-      build_in_progress = !@build_processes.empty?
+      build_in_progress = @build_processes.any?(&.exists?)
       stop_all_processes
       puts build_in_progress ? "Recompiling..." : "Compiling..."
       build_app_processes_and_start


### PR DESCRIPTION
show "Recompiling..." when current build is aborted
and "Compiling..." if previous build was completed

this PR fix bug in previous PR https://github.com/luckyframework/lucky/pull/1604