### PR TITLE
Updates to TextReponse#print

### DIFF
--- a/spec/lucky/text_response_spec.cr
+++ b/spec/lucky/text_response_spec.cr
@@ -2,6 +2,17 @@ require "../spec_helper"
 
 include ContextHelper
 
+# Monkey patch HTTP::Server::Response to allow accessing the response body directly.
+class HTTP::Server::Response
+  getter body_io : IO = IO::Memory.new
+
+  def write(slice : Bytes) : Nil
+    @body_io.write slice
+
+    previous_def
+  end
+end
+
 describe Lucky::TextResponse do
   describe "#print" do
     context "flash" do
@@ -169,7 +180,7 @@ describe Lucky::TextResponse do
         context = build_context("HEAD")
         print_response_with_body(context, "Body", status: nil)
         context.request.method.should eq "HEAD"
-        context.request.body.to_s.should eq ""
+        context.response.body_io.to_s.should eq("")
         context.response.status_code.should eq 200
       end
     end


### PR DESCRIPTION
## Purpose
Fixes #1608

## Description
When you make a `HEAD` call to a `GET` route, no body is to be returned. We have been writing the body. There was a spec to test that, but it was incorrectly checking the `request.body` and not the `response.body`.

I've also added a catch for when we do write to the response, but the response has already been closed. This may be an issue related to Crystal directly https://github.com/crystal-lang/crystal/issues/9065 but for now, we can just rescue that exception, and log out an error. Chances are, the client left before we were able to respond, so the exception does us no good anyway.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
