### PR TITLE
Add previous_page and next_page methods to paginator

### DIFF
--- a/spec/paginator/paginator_spec.cr
+++ b/spec/paginator/paginator_spec.cr
@@ -92,6 +92,24 @@ describe Lucky::Paginator do
     end
   end
 
+  describe "#previous_page" do
+    it "returns the next page" do
+      build_pages(page: 0, per_page: 3, item_count: 10).previous_page.should be_nil
+      build_pages(page: 1, per_page: 3, item_count: 10).previous_page.should be_nil
+      build_pages(page: 3, per_page: 3, item_count: 10).previous_page.should eq(2)
+      build_pages(page: 4, per_page: 3, item_count: 10).previous_page.should eq(3)
+    end
+  end
+
+  describe "#next_page" do
+    it "returns the next page" do
+      build_pages(page: 1, per_page: 3, item_count: 10).next_page.should eq(2)
+      build_pages(page: 3, per_page: 3, item_count: 10).next_page.should eq(4)
+      build_pages(page: 4, per_page: 3, item_count: 10).next_page.should be_nil
+      build_pages(page: 9, per_page: 3, item_count: 10).next_page.should be_nil
+    end
+  end
+
   describe "#path_to_page" do
     it "adds a query param to the path" do
       path = build_pages(full_path: "/comments").path_to_page(1)

--- a/src/lucky/paginator/paginator.cr
+++ b/src/lucky/paginator/paginator.cr
@@ -61,12 +61,22 @@ class Lucky::Paginator
     Range.new(starting_item_number, ending_item_number)
   end
 
+  # Returns the previous page number or nil if the current page is the first one.
+  def previous_page : Int32?
+    page - 1 unless first_page?
+  end
+
+  # Returns the next page number or nil if the current page is the last one.
+  def next_page : Int32?
+    page + 1 unless last_page? || overflowed?
+  end
+
   # Returns the path with a 'page' query param for the previous page.
   #
   # Return nil if there is no previous page
   def path_to_previous : String?
-    unless first_page?
-      path_to_page(page - 1)
+    if page_number = previous_page
+      path_to_page(page_number)
     end
   end
 
@@ -74,8 +84,8 @@ class Lucky::Paginator
   #
   # Return nil if there is no previous page
   def path_to_next : String?
-    unless last_page?
-      path_to_page(page + 1)
+    if page_number = next_page
+      path_to_page(page_number)
     end
   end
 


### PR DESCRIPTION
## Purpose
Adds `previous_page` and `next_page` methods to `Lucky::Paginator`.

(Sorry for not opening an issue first, but this seems like such an obvious addition).

## Description
Currently, there are only the `path_to_next` and `path_to_previous` methods, returning a path including all query params. There's no way to get the next/previous page _number_ other than calculating it based on the values returned by the `paginator.page` and `paginator.total` methods.

I'm working on an API and I need pagination with the full url and without any additional query parameters that may be present. To build the url, I need the previous and next page numbers rather than the paths.

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
