### PR TITLE
Fix specs to cut dependency on avram integration

### DIFF
--- a/spec/lucky/errors_spec.cr
+++ b/spec/lucky/errors_spec.cr
@@ -2,28 +2,7 @@ require "../spec_helper"
 
 include ContextHelper
 
-private class User < Avram::Model
-  table do
-    column name : String
-  end
-end
-
 describe "Errors" do
-  describe Avram::InvalidOperationError do
-    it "is renderable and includes error details" do
-      operation = User::SaveOperation.new
-      operation.valid?.should be_false
-
-      error = Avram::InvalidOperationError.new(operation)
-
-      error.should be_a(Lucky::RenderableError)
-      error.invalid_attribute_name.should eq("name")
-      error.renderable_status.should eq(400)
-      error.renderable_message.should contain("Invalid params")
-      error.renderable_details.should eq("name is required")
-    end
-  end
-
   describe Lucky::InvalidParamError do
     it "is renderable" do
       error = Lucky::InvalidParamError.new(

--- a/spec/lucky/paginator/backend_helpers_spec.cr
+++ b/spec/lucky/paginator/backend_helpers_spec.cr
@@ -1,30 +1,10 @@
 require "../../spec_helper"
 
-class FakeUser < Avram::Model
-  table do
-  end
-
-  def self.database
-    UnusedDatabase
-  end
-
-  class BaseQuery
-    # Override so it doesn't hit the db and we get 2 pages of results
-    def select_count
-      50
-    end
-  end
-end
-
 class Paginatable
   include Lucky::Paginator::BackendHelpers
   include ContextHelper
 
   def initialize(@page : String? = nil)
-  end
-
-  def call
-    paginate(FakeUser::BaseQuery.new)
   end
 
   def call_array
@@ -62,26 +42,6 @@ class PaginatableWithOverriddenMethods < Paginatable
 end
 
 describe Lucky::Paginator::BackendHelpers do
-  it "uses default of page 1 and per_page of 25" do
-    pages, records = Paginatable.new.call
-
-    pages.page.should eq(1)
-    pages.per_page.should eq(25)
-    pages.total.should eq(2)
-    records.query.offset.should eq(0)
-    records.query.limit.should eq(25)
-  end
-
-  it "uses the 'page' param if given" do
-    pages, records = Paginatable.new(page: "2").call
-
-    pages.page.should eq(2)
-    pages.per_page.should eq(25)
-    pages.total.should eq(2)
-    records.query.offset.should eq(25)
-    records.query.limit.should eq(25)
-  end
-
   it "accept array with default" do
     pages, records = Paginatable.new.call_array
 
@@ -110,12 +70,11 @@ describe Lucky::Paginator::BackendHelpers do
   end
 
   it "allows overriding 'paginator_page' and 'paginator_per_page'" do
-    pages, records = PaginatableWithOverriddenMethods.new.call
+    pages, records = PaginatableWithOverriddenMethods.new.call_array
 
     pages.page.should eq(2)
     pages.per_page.should eq(10)
     pages.total.should eq(5)
-    records.query.offset.should eq(10)
-    records.query.limit.should eq(10)
+    records.size.should eq(10)
   end
 end

--- a/spec/lucky/paginator/backend_helpers_spec.cr
+++ b/spec/lucky/paginator/backend_helpers_spec.cr
@@ -1,4 +1,4 @@
-require "../spec_helper"
+require "../../spec_helper"
 
 class FakeUser < Avram::Model
   table do

--- a/spec/lucky/paginator/components_spec.cr
+++ b/spec/lucky/paginator/components_spec.cr
@@ -1,4 +1,4 @@
-require "../spec_helper"
+require "../../spec_helper"
 
 describe "Lucky::Paginator Components" do
   it "compiles and renders the components successfully" do

--- a/spec/lucky/paginator/paginator_spec.cr
+++ b/spec/lucky/paginator/paginator_spec.cr
@@ -1,4 +1,4 @@
-require "../spec_helper"
+require "../../spec_helper"
 
 private def build_pages(page = 1, per_page = 1, item_count = 1, full_path = "/items")
   Lucky::Paginator.new \

--- a/spec/lucky/tag_defaults_spec.cr
+++ b/spec/lucky/tag_defaults_spec.cr
@@ -4,53 +4,41 @@ private class TestTagDefaultsPage
   include Lucky::HTMLPage
 
   def render
-    tag_defaults field: name_field, class: "form-control" do |tag_builder|
-      tag_builder.text_input
+    tag_defaults do |tag_builder|
+      tag_builder.div "text content"
     end
 
-    tag_defaults field: name_field, class: "form-control" do |tag_builder|
-      tag_builder.text_input placeholder: "Name please"
-    end
-
-    tag_defaults field: name_field, placeholder: "default" do |tag_builder|
-      tag_builder.text_input placeholder: "replace default"
-    end
-
-    tag_defaults field: name_field, class: "default" do |tag_builder|
-      tag_builder.text_input append_class: "appended classes"
-    end
-
-    tag_defaults field: name_field, class: "default" do |tag_builder|
-      tag_builder.text_input replace_class: "replaced"
-    end
-
-    # No default 'class'
-    tag_defaults field: name_field do |tag_builder|
-      tag_builder.text_input append_class: "appended-without-default"
-    end
-
-    tag_defaults field: name_field do |tag_builder|
-      tag_builder.text_input replace_class: "replaced-without-default"
-    end
-
-    # tags that have content
     tag_defaults class: "default" do |tag_builder|
       tag_builder.div "text content"
     end
 
     tag_defaults class: "default" do |tag_builder|
+      tag_builder.div "text content", append_class: "appended classes"
+    end
+
+    tag_defaults class: "default" do |tag_builder|
+      tag_builder.div "text content", replace_class: "replaced"
+    end
+
+    tag_defaults id: "foo" do |tag_builder|
+      tag_builder.div "text content", append_class: "appended-without-default"
+    end
+
+    tag_defaults id: "foo" do |tag_builder|
+      tag_builder.div "text content", replace_class: "replaced-without-default"
+    end
+
+    tag_defaults do |tag_builder|
       tag_builder.div do
         text "block content"
       end
     end
 
-    {% if compare_versions(Crystal::VERSION, "0.36.1") > 0 %}
-      tag_defaults do |tag_builder|
-        tag_builder.div "@click": "onclick($event)" do
-          text "block content"
-        end
+    tag_defaults do |tag_builder|
+      tag_builder.div "@click": "onclick($event)" do
+        text "block content"
       end
-    {% end %}
+    end
 
     view
   end
@@ -62,36 +50,13 @@ describe "tag_defaults" do
   it "renders the component" do
     contents = TestTagDefaultsPage.new(build_context).render.to_s
 
-    contents
-      .should contain %(<input type="text" id="user_name" name="user:name" value="" class="form-control">)
-    contents
-      .should contain %(<input type="text" id="user_name" name="user:name" value="" class="form-control" placeholder="Name please">)
-    contents
-      .should contain %(<input type="text" id="user_name" name="user:name" value="" placeholder="replace default">)
-    contents
-      .should contain %(<input type="text" id="user_name" name="user:name" value="" class="default appended classes">)
-    contents
-      .should contain %(<input type="text" id="user_name" name="user:name" value="" class="replaced">)
-    contents
-      .should contain %(<input type="text" id="user_name" name="user:name" value="" class="appended-without-default">)
-    contents
-      .should contain %(<input type="text" id="user_name" name="user:name" value="" class="replaced-without-default">)
-    contents
-      .should contain %(<div class="default">text content</div>)
-    contents
-      .should contain %(<div class="default">block content</div>)
-    {% if compare_versions(Crystal::VERSION, "0.36.1") > 0 %}
-      contents
-        .should contain %(<div @click="onclick($event)">block content</div>)
-    {% end %}
+    contents.should contain %(<div>text content</div>)
+    contents.should contain %(<div class="default">text content</div>)
+    contents.should contain %(<div class="default appended classes">text content</div>)
+    contents.should contain %(<div class="replaced">text content</div>)
+    contents.should contain %(<div id="foo" class="appended-without-default">text content</div>)
+    contents.should contain %(<div id="foo" class="replaced-without-default">text content</div>)
+    contents.should contain %(<div>block content</div>)
+    contents.should contain %(<div @click="onclick($event)">block content</div>)
   end
-end
-
-private def name_field
-  Avram::PermittedAttribute(String).new(
-    name: :name,
-    param: "",
-    value: "",
-    param_key: "user"
-  )
 end

--- a/spec/lucky_avram/ext/avram/errors_spec.cr
+++ b/spec/lucky_avram/ext/avram/errors_spec.cr
@@ -1,0 +1,24 @@
+require "../../../spec_helper"
+
+private class User < Avram::Model
+  table do
+    column name : String
+  end
+end
+
+describe "Errors" do
+  describe Avram::InvalidOperationError do
+    it "is renderable and includes error details" do
+      operation = User::SaveOperation.new
+      operation.valid?.should be_false
+
+      error = Avram::InvalidOperationError.new(operation)
+
+      error.should be_a(Lucky::RenderableError)
+      error.invalid_attribute_name.should eq("name")
+      error.renderable_status.should eq(400)
+      error.renderable_message.should contain("Invalid params")
+      error.renderable_details.should eq("name is required")
+    end
+  end
+end

--- a/spec/lucky_avram/ext/lucky/input_helpers_spec.cr
+++ b/spec/lucky_avram/ext/lucky/input_helpers_spec.cr
@@ -1,4 +1,4 @@
-require "../spec_helper"
+require "../../../spec_helper"
 include ContextHelper
 
 class TestUser

--- a/spec/lucky_avram/ext/lucky/label_helpers_spec.cr
+++ b/spec/lucky_avram/ext/lucky/label_helpers_spec.cr
@@ -1,4 +1,4 @@
-require "../spec_helper"
+require "../../../spec_helper"
 
 include ContextHelper
 

--- a/spec/lucky_avram/ext/lucky/paginator/backend_helpers_spec.cr
+++ b/spec/lucky_avram/ext/lucky/paginator/backend_helpers_spec.cr
@@ -1,0 +1,70 @@
+require "../../../../spec_helper"
+
+class FakeUser < Avram::Model
+  table do
+  end
+
+  def self.database
+    UnusedDatabase
+  end
+
+  class BaseQuery
+    # Override so it doesn't hit the db and we get 2 pages of results
+    def select_count
+      50
+    end
+  end
+end
+
+class Paginatable
+  include Lucky::Paginator::BackendHelpers
+  include ContextHelper
+
+  def initialize(@page : String? = nil)
+  end
+
+  def call
+    paginate(FakeUser::BaseQuery.new)
+  end
+
+  def params
+    Params.new(@page)
+  end
+
+  def context
+    build_context
+  end
+
+  class Params
+    getter page
+
+    def initialize(@page : String?)
+    end
+
+    def get?(_value) : String?
+      @page
+    end
+  end
+end
+
+describe Lucky::Paginator::BackendHelpers do
+  it "uses default of page 1 and per_page of 25" do
+    pages, records = Paginatable.new.call
+
+    pages.page.should eq(1)
+    pages.per_page.should eq(25)
+    pages.total.should eq(2)
+    records.query.offset.should eq(0)
+    records.query.limit.should eq(25)
+  end
+
+  it "uses the 'page' param if given" do
+    pages, records = Paginatable.new(page: "2").call
+
+    pages.page.should eq(2)
+    pages.per_page.should eq(25)
+    pages.total.should eq(2)
+    records.query.offset.should eq(25)
+    records.query.limit.should eq(25)
+  end
+end

--- a/spec/lucky_avram/ext/lucky/select_helpers_spec.cr
+++ b/spec/lucky_avram/ext/lucky/select_helpers_spec.cr
@@ -1,4 +1,4 @@
-require "../spec_helper"
+require "../../../spec_helper"
 
 include ContextHelper
 

--- a/src/lucky/paginator/backend_helpers.cr
+++ b/src/lucky/paginator/backend_helpers.cr
@@ -1,45 +1,4 @@
 module Lucky::Paginator::BackendHelpers
-  # Call this in your actions to paginate an query.
-  #
-  # This method will return a `Lucky::Paginator` object and the requested page
-  # of records.
-  #
-  # ## Examples
-  #
-  # ```
-  # class Users::Index < BrowserAction
-  #   get "/users" do
-  #     # The 'UserQuery' will return just the records for the requested page
-  #     # because 'paginate' will add a 'limit' and 'offset' to the query.
-  #     pages, users = paginate(UserQuery.new)
-  #     render IndexPage, pages: pages, users: users
-  #   end
-  # end
-  #
-  # class Users::IndexPage < MainLayout
-  #   needs pages : Lucky::Paginator
-  #   needs users : UserQuery
-  #
-  #   def content
-  #     # Render 'users' like normal
-  #     mount Lucky::Paginator::SimpleNav, @pages
-  #   end
-  # end
-  # ```
-  def paginate(
-    query : Avram::Queryable(T),
-    per_page : Int32 = paginator_per_page
-  ) : Tuple(Paginator, Avram::Queryable(T)) forall T
-    pages = Paginator.new \
-      page: paginator_page,
-      per_page: per_page,
-      item_count: query.clone.reset_order.reset_limit.reset_offset.select_count,
-      full_path: context.request.resource
-
-    updated_query = query.limit(pages.per_page).offset(pages.offset)
-    {pages, updated_query}
-  end
-
   # Call this in your actions to paginate an array.
   #
   # This method will return a `Lucky::Paginator` object and the requested page

--- a/src/lucky_avram/ext/lucky/paginator/backend_helpers.cr
+++ b/src/lucky_avram/ext/lucky/paginator/backend_helpers.cr
@@ -1,0 +1,42 @@
+module Lucky::Paginator::BackendHelpers
+  # Call this in your actions to paginate an query.
+  #
+  # This method will return a `Lucky::Paginator` object and the requested page
+  # of records.
+  #
+  # ## Examples
+  #
+  # ```
+  # class Users::Index < BrowserAction
+  #   get "/users" do
+  #     # The 'UserQuery' will return just the records for the requested page
+  #     # because 'paginate' will add a 'limit' and 'offset' to the query.
+  #     pages, users = paginate(UserQuery.new)
+  #     render IndexPage, pages: pages, users: users
+  #   end
+  # end
+  #
+  # class Users::IndexPage < MainLayout
+  #   needs pages : Lucky::Paginator
+  #   needs users : UserQuery
+  #
+  #   def content
+  #     # Render 'users' like normal
+  #     mount Lucky::Paginator::SimpleNav, @pages
+  #   end
+  # end
+  # ```
+  def paginate(
+    query : Avram::Queryable(T),
+    per_page : Int32 = paginator_per_page
+  ) : Tuple(Paginator, Avram::Queryable(T)) forall T
+    pages = Paginator.new \
+      page: paginator_page,
+      per_page: per_page,
+      item_count: query.clone.reset_order.reset_limit.reset_offset.select_count,
+      full_path: context.request.resource
+
+    updated_query = query.limit(pages.per_page).offset(pages.offset)
+    {pages, updated_query}
+  end
+end


### PR DESCRIPTION
## Purpose

Fixes #1525 
Related to #1402 

## Description

With this PR, you can now comment out the [lucky_avram require in lucky.cr](https://github.com/luckyframework/lucky/blob/e13a8a6a7f1d31c47324943ec4fa14df834cd6e3/src/lucky.cr#L24) and run `crystal spec spec/lucky/` and everything passes.

In doing this, I found the paginator specs were in the wrong location and fixing that, also had to move a paginator method over.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
