### PR TITLE
Combine server bind_tcp and listen

### DIFF
--- a/src/lucky/base_app_server.cr
+++ b/src/lucky/base_app_server.cr
@@ -20,8 +20,7 @@ abstract class Lucky::BaseAppServer
 
   # :nodoc:
   def listen : Nil
-    server.bind_tcp host, port
-    server.listen
+    server.listen(host, port)
   end
 
   # :nodoc:

--- a/src/lucky/base_app_server.cr
+++ b/src/lucky/base_app_server.cr
@@ -3,6 +3,7 @@ abstract class Lucky::BaseAppServer
   private getter server
 
   abstract def middleware : Array(HTTP::Handler)
+  abstract def listen
 
   def initialize
     @server = HTTP::Server.new(middleware)
@@ -16,11 +17,6 @@ abstract class Lucky::BaseAppServer
   # :nodoc:
   def port : Int32
     Lucky::Server.settings.port
-  end
-
-  # :nodoc:
-  def listen : Nil
-    server.listen(host, port)
   end
 
   # :nodoc:


### PR DESCRIPTION
`HTTP::Server#listen` provides an overload that does exactly what we are doing on two lines.

https://crystal-lang.org/api/1.0.0/HTTP/Server.html#listen(host:String,port:Int32,reuse_port:Bool=false)-instance-method