### PR TITLE
Fix empty response_id () when response_id is empty

### DIFF
--- a/spec/lucky/pretty_log_formatter_spec.cr
+++ b/spec/lucky/pretty_log_formatter_spec.cr
@@ -31,6 +31,15 @@ describe Lucky::PrettyLogFormatter do
 
       io.to_s.chomp.should start_with(" #{"▸".colorize.dim} Sent #{"200 OK".colorize.bold} (1.4ms) (#{"abc123".colorize.dim})")
     end
+
+    context "when request_id is empty" do
+      it "does not include empty () in the end of an HTTP request" do
+        io = IO::Memory.new
+        format(io, {status: 200, duration: "1.4ms", request_id: ""})
+
+        io.to_s.chomp.should eq(" #{"▸".colorize.dim} Sent #{"200 OK".colorize.bold} (1.4ms)")
+      end
+    end
   end
 
   context "when given data that is not the start/end of an HTTP request " do

--- a/src/lucky/pretty_log_formatter.cr
+++ b/src/lucky/pretty_log_formatter.cr
@@ -56,7 +56,7 @@ struct Lucky::PrettyLogFormatter < Dexter::BaseFormatter
     end
 
     private def add_request_id : Nil
-      if id = local_context["request_id"]
+      if id = local_context["request_id"].to_s.presence
         io << " (#{id.colorize.dim})"
       end
     end


### PR DESCRIPTION
Resolves #1626

## Purpose
Describe the feature or issue and link to the related issue.
If no issue has been opened about this, be sure to open an issue first to discuss the need for this PR.

## Description
Please include any relevant code samples or screen shots that may help to overview of this PR.
Link to specific lines of code, or examples if you need to.

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [ ] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [ ] - Lucky builds on docker with `./script/setup`
* [ ] - All builds and specs pass on docker with `./script/test`
