### PR TITLE
Update links for discord and code of conduct

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,5 +7,5 @@ contact_links:
     url: https://github.com/luckyframework/lucky/discussions
     about: Ask questions and discuss with other community members
   - name: Chat
-    url: https://discord.com/invite/HeqJUcb
+    url: https://luckyframework.org/chat
     about: Chat with the community

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 # Contributing to Lucky
 
 We love pull requests from everyone. By participating in this project, you
-agree to abide by the thoughtbot [code of conduct].
+agree to abide by the project [code of conduct].
 
-[code of conduct]: https://thoughtbot.com/open-source-code-of-conduct
+[code of conduct]: https://github.com/luckyframework/lucky/blob/master/CODE_OF_CONDUCT.md
 
 Here are some ways *you* can contribute:
 
@@ -41,7 +41,7 @@ already been submitted.
 
 ## Setting Up Local Environment
 
-1. Fork it ( https://github.com/luckyframework/web/fork )
+1. Fork it ( https://github.com/luckyframework/lucky/fork )
 1. Create your feature branch (git checkout -b my-new-feature)
 1. Install docker and docker-compose: https://docs.docker.com/compose/install/
 1. Run `script/setup` to build the Docker containers with everything you need.
@@ -67,7 +67,7 @@ already been submitted.
   asking for help. We love helping!
 * Please don't update the Gem version.
 
-[repo]: https://github.com/luckyframework/web/tree/master
+[repo]: https://github.com/luckyframework/lucky/tree/master
 [fork]: https://help.github.com/articles/fork-a-repo/
 [branch]: https://help.github.com/articles/creating-and-deleting-branches-within-your-repository/
 [pr]: https://help.github.com/articles/using-pull-requests/

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Lucky has a [fresh new set of guides](https://luckyframework.org/guides/) that
 make it easy to get started.
 
 Feel free to say hi or ask questions on our
-[chat room](https://discord.gg/HeqJUcb).
+[chat room](https://luckyframework.org/chat).
 
 Or you can copy a real working app with [Lucky JumpStart](https://github.com/stephendolan/lucky_jumpstart/).
 

--- a/src/lucky/welcome_page.cr
+++ b/src/lucky/welcome_page.cr
@@ -69,15 +69,15 @@ class Lucky::WelcomePage
         tr do
           td "Ask for ideas in our chatroom", class: "left-column"
           td class: "right-column" do
-            a discord_url, href: discord_url, target: "_blank"
+            a chat_url, href: chat_url, target: "_blank"
           end
         end
       end
     end
   end
 
-  private def discord_url
-    "https://discord.gg/HeqJUcb"
+  private def chat_url
+    "https://luckyframework.org/chat"
   end
 
   private def welcome_page_styles

--- a/tasks/watch.cr
+++ b/tasks/watch.cr
@@ -192,7 +192,7 @@ module LuckySentry
 
           ▸  Run setup: #{"script/setup".colorize.bold}
           ▸  Reinstall shards: #{"rm -rf lib bin && shards install".colorize.bold}
-          ▸  Ask for help: #{"https://discord.gg/HeqJUcb".colorize.bold}
+          ▸  Ask for help: #{"https://luckyframework.org/chat".colorize.bold}
         ERROR
       end
     end


### PR DESCRIPTION
## Purpose
Updates documentation to close #1631 and #1632

## Description
For #1631, searched through the codebase to update almost all references from the discord to the luckyframework.com/chat link. The only unchanged reference is the badge in the README. 

For #1632, updated the contributing guidelines to remove the reference to the thoughtbot code of conduct as well as making a few updates to urls that while still worked, pointed to an outdated repo name. 

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [ ] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [ ] - Lucky builds on docker with `./script/setup`
* [ ] - All builds and specs pass on docker with `./script/test`
