### PR TITLE
Remove custom error on default_format macro

### DIFF
--- a/src/lucky/request_type_helpers.cr
+++ b/src/lucky/request_type_helpers.cr
@@ -29,10 +29,6 @@ module Lucky::RequestTypeHelpers
   # default_format :html
   # ```
   macro default_format(format)
-    {% unless format.is_a?(SymbolLiteral) %}
-      {% raise "The default format in #{@type} must be a Symbol. Instead got #{format}" %}
-    {% end %}
-
     private def default_format : Symbol
       {{ format }}
     end


### PR DESCRIPTION
Standard error message is just as helpful, if not more so, than our custom one.

## Before

<img width="640" alt="Screen Shot 2022-01-03 at 10 31 56 PM" src="https://user-images.githubusercontent.com/17329408/148009805-b3ee2e6f-30a3-4e8f-a27b-c4dc4ffa5e17.png">

## After

<img width="693" alt="Screen Shot 2022-01-03 at 10 32 06 PM" src="https://user-images.githubusercontent.com/17329408/148009815-5ffe767a-6023-460d-bdb4-0cde49f2cf24.png">

