### PR TITLE
Improve error message creating route links

### DIFF
--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -336,23 +336,13 @@ module Lucky::Routable
       {% end %}
       anchor : String? = nil
         ) : Lucky::RouteHelper
+        \{% begin %}
         route(
-          {% for param in path_params %}
-            {% temp = param.gsub(/:/, "").id %}
-            {{ temp }}: {{ temp }},
-          {% end %}
-
-          {% for param in PARAM_DECLARATIONS %}
-            {{ param.var }}: {{ param.var }},
-          {% end %}
-
-          # optional path variables are nilable
-          {% for param in optional_path_params %}
-            {% temp = param.gsub(/^\?:/, "").id %}
-            {{ temp }}: {{ temp }},
-          {% end %}
-          anchor: anchor
+          \{% for arg in @def.args %}
+            \{{ arg.name }}: \{{ arg.internal_name }},
+          \{% end %}
         )
+        \{% end %}
       end
 
 

--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -319,17 +319,17 @@ module Lucky::Routable
       {% for param in path_params %}
         {{ param.gsub(/:/, "").id }},
       {% end %}
-  
+
       # required params
       {% for param in params_without_defaults %}
         {{ param }},
       {% end %}
-  
+
       # params with a default value set are always nilable
       {% for param in params_with_defaults %}
         {{ param.var }} = nil,
       {% end %}
-  
+
       # optional path variables are nilable
       {% for param in optional_path_params %}
         {{ param.gsub(/^\?:/, "").id }} = nil,

--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -336,14 +336,14 @@ module Lucky::Routable
       {% end %}
       anchor : String? = nil
         ) : Lucky::RouteHelper
-        \{% begin %}
-        route(
-          \{% for arg in @def.args %}
-            \{{ arg.name }}: \{{ arg.internal_name }},
-          \{% end %}
-        )
+      \{% begin %}
+      route(
+        \{% for arg in @def.args %}
+          \{{ arg.name }}: \{{ arg.internal_name }},
         \{% end %}
-      end
+      )
+      \{% end %}
+    end
 
 
     private def self.path_from_parts(

--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -314,33 +314,47 @@ module Lucky::Routable
       Lucky::RouteHelper.new {{ method }}, path
     end
 
-    def self.route(*_args, **_named_args) : Lucky::RouteHelper
-      {% requireds = path_params.map { |param| "#{param.gsub(/:/, "").id}" } %}
-      {% params_without_defaults.each { |param| requireds << "#{param.var}" } %}
-      {% optionals = optional_path_params.map { |param| "#{param.gsub(/^\?:/, "").id}" } %}
-      {% params_with_defaults.each { |param| optionals << "#{param.var}" } %}
-      \{% raise <<-ERROR
-        Invalid call to {{ @type }}.route
+    def self.with(
+      # required path variables
+      {% for param in path_params %}
+        {{ param.gsub(/:/, "").id }},
+      {% end %}
+  
+      # required params
+      {% for param in params_without_defaults %}
+        {{ param }},
+      {% end %}
+  
+      # params with a default value set are always nilable
+      {% for param in params_with_defaults %}
+        {{ param.var }} = nil,
+      {% end %}
+  
+      # optional path variables are nilable
+      {% for param in optional_path_params %}
+        {{ param.gsub(/^\?:/, "").id }} = nil,
+      {% end %}
+      anchor : String? = nil
+        ) : Lucky::RouteHelper
+        route(
+          {% for param in path_params %}
+            {% temp = param.gsub(/:/, "").id %}
+            {{ temp }}: {{ temp }},
+          {% end %}
 
-        {% if !requireds.empty? %}
-        Required arguments:
-        {% for req in requireds %}\n- {{ req.id }}{% end %}
-        {% end %}{% if !optionals.empty? %}
-        Optional arguments:
-        {% for opts in optionals %}\n- {{ opts.id }}{% end %}
-        {% end %}
-        For more information, refer to https://luckyframework.org/guides/http-and-routing/link-generation.
-        ERROR
-      %}
-    end
+          {% for param in PARAM_DECLARATIONS %}
+            {{ param.var }}: {{ param.var }},
+          {% end %}
 
-    def self.with(*args, **named_args) : Lucky::RouteHelper
-      route(*args, **named_args)
-    end
+          # optional path variables are nilable
+          {% for param in optional_path_params %}
+            {% temp = param.gsub(/^\?:/, "").id %}
+            {{ temp }}: {{ temp }},
+          {% end %}
+          anchor: anchor
+        )
+      end
 
-    def self.with
-      \{% raise "Use `route` instead of `with` if the route doesn't need params" %}
-    end
 
     private def self.path_from_parts(
         {% for param in path_params %}


### PR DESCRIPTION
Resolves #1637 

Check out the connected issue for screenshots. Instead of removing `Lucky::Action.with`, I set up the function to require the expected arguments the same way as `Lucky::Action.route` which then calls `route` with them. This means it is not a breaking change.

I did remove the compiler error if you call `Lucky::Action.with` with no arguments. You get an error that doesn't actually point you to where you called it.