### PR TITLE
Adds previous_url method to url_helpers

### DIFF
--- a/spec/lucky/url_helpers_spec.cr
+++ b/spec/lucky/url_helpers_spec.cr
@@ -146,15 +146,39 @@ describe Lucky::UrlHelpers do
       end
     end
   end
+
+  describe "#previous_url" do
+    it "returns the previous url from referer header when present" do
+      view_for("/pages/456", headers: { "Referer" => "http://luckyframework.org/pages/123" } )
+        .previous_url(Pages::Index)
+        .should eq "http://luckyframework.org/pages/123"
+    end
+
+    it "falls back to passed Lucky::Action when referer header is not present" do
+      view_for("/pages/123")
+        .previous_url(Pages::Index)
+        .should eq "/pages"
+    end
+
+    it "falls back to passed Lucky::RouteHelper when referer header is not present" do
+      view_for("/pages/123")
+        .previous_url(Pages::Show.with(456))
+        .should eq "/pages/456"
+    end
+  end
 end
 
 private def view_for(
   path : String,
   method : String = "GET",
-  host_with_port : String = "example.com"
+  host_with_port : String = "example.com",
+  headers : Hash(String, String) = {} of String => String
 )
   request = HTTP::Request.new(method, path)
   request.headers["Host"] = host_with_port
+  headers.each do |header, value|
+    request.headers[header] = value
+  end
   TestPage.new(build_context(path: path, request: request))
 end
 

--- a/spec/lucky/url_helpers_spec.cr
+++ b/spec/lucky/url_helpers_spec.cr
@@ -149,7 +149,7 @@ describe Lucky::UrlHelpers do
 
   describe "#previous_url" do
     it "returns the previous url from referer header when present" do
-      view_for("/pages/456", headers: { "Referer" => "http://luckyframework.org/pages/123" } )
+      view_for("/pages/456", headers: {"Referer" => "http://luckyframework.org/pages/123"})
         .previous_url(Pages::Index)
         .should eq "http://luckyframework.org/pages/123"
     end

--- a/src/lucky/page_helpers/url_helpers.cr
+++ b/src/lucky/page_helpers/url_helpers.cr
@@ -85,7 +85,26 @@ module Lucky::UrlHelpers
     current_page?(action.path, check_query_params)
   end
 
+  # Returns the url of the page that issued the request (the referrer)
+  # if possible, otherwise redirects to the provided default fallback
+  # location.
+  #
+  # The referrer information is pulled from the 'Referer' header on
+  # the request. This is an optional header, and if the request
+  # is missing this header the *fallback* will be used.
+  def previous_url(fallback : Lucky::Action.class | Lucky::RouteHelper)
+    referrer_header || fallback.path
+  end
+
   private def comparable_query_params(query_params : HTTP::Params) : String
     URI.decode(query_params.map(&.join).sort!.join)
+  end
+
+  private def referrer_header
+    request = context.request
+    return unless request.headers.has_key?("Referer")
+
+    referrer = request.headers["Referer"]
+    referrer if referrer.is_a?(String)
   end
 end

--- a/src/lucky/page_helpers/url_helpers.cr
+++ b/src/lucky/page_helpers/url_helpers.cr
@@ -92,6 +92,12 @@ module Lucky::UrlHelpers
   # The referrer information is pulled from the 'Referer' header on
   # the request. This is an optional header, and if the request
   # is missing this header the *fallback* will be used.
+  #
+  # Ex. within a Lucky Page, previous_url can be used to provide an href
+  # to an anchor element that would allow the user to go back.
+  # ```
+  # a "Back", href: previous_url(fallback: Users::Index)
+  # ```
   def previous_url(fallback : Lucky::Action.class | Lucky::RouteHelper)
     referrer_header || fallback.path
   end


### PR DESCRIPTION
## Purpose
Adds the `previous_url` helper as described in #1025 

## Description
If the `Referer` header is set, this method should return the url from the header. A user should pass a Lucky::Action or Lucky::RouteHelper as a fallback in instances where the Referer header is not set. 

Functionally, it works very similar to the `redirect_back` method added in #1168 but is suitable to use within a Lucky::Page

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [ ] - Lucky builds on docker with `./script/setup`
* [ ] - All builds and specs pass on docker with `./script/test`
