### PR TITLE
Update Lucky::BaseHTTPClient to make requests to app directly

### DIFF
--- a/spec/lucky/base_http_client_spec.cr
+++ b/spec/lucky/base_http_client_spec.cr
@@ -1,18 +1,10 @@
 require "../spec_helper"
 
-server = TestServer.new(test_server_port)
-
-spawn do
-  server.listen
-end
-
-Spec.before_each do
-  TestServer.reset
-end
-
 class HelloWorldAction < TestAction
+  accepted_formats [:plain_text]
+
   post "/hello" do
-    plain_text "unused"
+    plain_text "world"
   end
 end
 
@@ -22,15 +14,15 @@ end
 describe Lucky::BaseHTTPClient do
   describe "headers" do
     it "sets headers and allows chaining" do
-      with_fake_server(path: "/hello", response_body: "world") do
-        MyClient.new
-          .headers(accept: "text/csv")
+      with_fake_server do |server|
+        MyClient.for_app(server)
+          .headers(accept: "text/plain")
           .headers(content_type: "application/json")
           .headers("Foo": "bar")
           .exec(HelloWorldAction)
 
         request = server.last_request
-        request.headers["accept"].should eq("text/csv")
+        request.headers["accept"].should eq("text/plain")
         request.headers["content-type"].should eq("application/json")
         request.headers["Foo"].should eq("bar")
       end
@@ -40,8 +32,8 @@ describe Lucky::BaseHTTPClient do
   describe "exec" do
     describe "with Lucky::Action class" do
       it "uses the method and path" do
-        with_fake_server(path: "/hello", response_body: "world") do
-          response = MyClient.new.exec(HelloWorldAction)
+        with_fake_server do |server|
+          response = MyClient.for_app(server).exec(HelloWorldAction)
 
           request = server.last_request
           request.path.should eq "/hello"
@@ -52,8 +44,8 @@ describe Lucky::BaseHTTPClient do
       end
 
       it "allows passing params" do
-        with_fake_server(path: "/hello", response_body: "world") do
-          response = MyClient.new.exec(HelloWorldAction, foo: "bar")
+        with_fake_server do |server|
+          response = MyClient.for_app(server).exec(HelloWorldAction, foo: "bar")
 
           request = server.last_request
           request.body.not_nil!.gets_to_end.should eq({foo: "bar"}.to_json)
@@ -63,8 +55,8 @@ describe Lucky::BaseHTTPClient do
 
     describe "with a Lucky::RouteHelper" do
       it "uses the method and path" do
-        with_fake_server(path: "/hello", response_body: "world") do
-          response = MyClient.new.exec(HelloWorldAction.route)
+        with_fake_server do |server|
+          response = MyClient.for_app(server).exec(HelloWorldAction.route)
 
           request = server.last_request
           request.path.should eq "/hello"
@@ -75,8 +67,8 @@ describe Lucky::BaseHTTPClient do
       end
 
       it "allows passing params" do
-        with_fake_server(path: "/hello", response_body: "world") do
-          response = MyClient.new.exec(HelloWorldAction.route, foo: "bar")
+        with_fake_server do |server|
+          response = MyClient.for_app(server).exec(HelloWorldAction.route, foo: "bar")
 
           request = server.last_request
           request.body.not_nil!.gets_to_end.should eq({foo: "bar"}.to_json)
@@ -88,13 +80,12 @@ describe Lucky::BaseHTTPClient do
   {% for method in [:put, :patch, :post, :delete, :get, :options] %}
     describe "\#{{method.id}}" do
       it "sends correct request to correct uri and gives the correct response" do
-        with_fake_server(path: "hello", response_body: "world") do
-          response = MyClient.new.{{method.id}}(
+        with_fake_server do |server|
+          response = MyClient.for_app(server).{{method.id}}(
             path: "hello",
             foo: "bar"
           )
 
-          response.body.should eq "world"
           request = server.last_request
           request.method.should eq({{ method.id.stringify }}.upcase)
           request.path.should eq "hello"
@@ -103,10 +94,9 @@ describe Lucky::BaseHTTPClient do
       end
 
       it "works without params" do
-        with_fake_server(path: "hello", response_body: "world") do
-          response = MyClient.new.{{method.id}}(path: "hello")
+        with_fake_server do |server|
+          response = MyClient.for_app(server).{{method.id}}(path: "hello")
 
-          response.body.should eq "world"
           request = server.last_request
           request.method.should eq({{ method.id.stringify }}.upcase)
           request.path.should eq "hello"
@@ -119,23 +109,21 @@ end
 
 describe "head" do
   it "sends the correct request to the correct uri and gets an empty response body" do
-    with_fake_server(path: "hello", response_body: "world") do
-      response = MyClient.new.head(
+    with_fake_server do |server|
+      response = MyClient.for_app(server).head(
         path: "hello",
         foo: "bar"
       )
 
-      response.body.should eq ""
       request = server.last_request
       request.method.should eq("HEAD")
       request.path.should eq "hello"
     end
   end
   it "works without params" do
-    with_fake_server(path: "hello", response_body: "world") do
-      response = MyClient.new.head(path: "hello")
+    with_fake_server do |server|
+      response = MyClient.for_app(server).head(path: "hello")
 
-      response.body.should eq ""
       request = server.last_request
       request.method.should eq("HEAD")
       request.path.should eq "hello"
@@ -144,17 +132,9 @@ describe "head" do
   end
 end
 
-private def with_fake_server(path : String, response_body : String)
-  TestServer.route(path: path, response_body: response_body)
-  Lucky::Server.temp_config(host: "localhost", port: test_server_port) do
-    yield
-  end
-end
-
-private def test_server_port
-  6226
-end
-
-Spec.after_suite do
-  server.close
+private def with_fake_server
+  TestServer.middleware << Lucky::RouteHandler.new
+  yield TestServer.new
+ensure
+  TestServer.reset
 end

--- a/spec/lucky/base_http_client_spec.cr
+++ b/spec/lucky/base_http_client_spec.cr
@@ -9,70 +9,61 @@ class HelloWorldAction < TestAction
 end
 
 class MyClient < Lucky::BaseHTTPClient
+  app TestServer.new
 end
 
 describe Lucky::BaseHTTPClient do
   describe "headers" do
     it "sets headers and allows chaining" do
-      with_fake_server do |server|
-        MyClient.for_app(server)
-          .headers(accept: "text/plain")
-          .headers(content_type: "application/json")
-          .headers("Foo": "bar")
-          .exec(HelloWorldAction)
+      MyClient.new
+        .headers(accept: "text/plain")
+        .headers(content_type: "application/json")
+        .headers("Foo": "bar")
+        .exec(HelloWorldAction)
 
-        request = server.last_request
-        request.headers["accept"].should eq("text/plain")
-        request.headers["content-type"].should eq("application/json")
-        request.headers["Foo"].should eq("bar")
-      end
+      request = TestServer.last_request
+      request.headers["accept"].should eq("text/plain")
+      request.headers["content-type"].should eq("application/json")
+      request.headers["Foo"].should eq("bar")
     end
   end
 
   describe "exec" do
     describe "with Lucky::Action class" do
       it "uses the method and path" do
-        with_fake_server do |server|
-          response = MyClient.for_app(server).exec(HelloWorldAction)
+        response = MyClient.new.exec(HelloWorldAction)
 
-          request = server.last_request
-          request.path.should eq "/hello"
-          request.method.should eq("POST")
-          request.body.not_nil!.gets_to_end.should eq("{}")
-          response.body.should eq "world"
-        end
+        request = TestServer.last_request
+        request.path.should eq "/hello"
+        request.method.should eq("POST")
+        request.body.not_nil!.gets_to_end.should eq("{}")
+        response.body.should eq "world"
       end
 
       it "allows passing params" do
-        with_fake_server do |server|
-          response = MyClient.for_app(server).exec(HelloWorldAction, foo: "bar")
+        response = MyClient.new.exec(HelloWorldAction, foo: "bar")
 
-          request = server.last_request
-          request.body.not_nil!.gets_to_end.should eq({foo: "bar"}.to_json)
-        end
+        request = TestServer.last_request
+        request.body.not_nil!.gets_to_end.should eq({foo: "bar"}.to_json)
       end
     end
 
     describe "with a Lucky::RouteHelper" do
       it "uses the method and path" do
-        with_fake_server do |server|
-          response = MyClient.for_app(server).exec(HelloWorldAction.route)
+        response = MyClient.new.exec(HelloWorldAction.route)
 
-          request = server.last_request
-          request.path.should eq "/hello"
-          request.method.should eq("POST")
-          request.body.not_nil!.gets_to_end.should eq("{}")
-          response.body.should eq "world"
-        end
+        request = TestServer.last_request
+        request.path.should eq "/hello"
+        request.method.should eq("POST")
+        request.body.not_nil!.gets_to_end.should eq("{}")
+        response.body.should eq "world"
       end
 
       it "allows passing params" do
-        with_fake_server do |server|
-          response = MyClient.for_app(server).exec(HelloWorldAction.route, foo: "bar")
+        response = MyClient.new.exec(HelloWorldAction.route, foo: "bar")
 
-          request = server.last_request
-          request.body.not_nil!.gets_to_end.should eq({foo: "bar"}.to_json)
-        end
+        request = TestServer.last_request
+        request.body.not_nil!.gets_to_end.should eq({foo: "bar"}.to_json)
       end
     end
   end
@@ -80,61 +71,46 @@ describe Lucky::BaseHTTPClient do
   {% for method in [:put, :patch, :post, :delete, :get, :options] %}
     describe "\#{{method.id}}" do
       it "sends correct request to correct uri and gives the correct response" do
-        with_fake_server do |server|
-          response = MyClient.for_app(server).{{method.id}}(
-            path: "hello",
-            foo: "bar"
-          )
+        response = MyClient.new.{{method.id}}(
+          path: "hello",
+          foo: "bar"
+        )
 
-          request = server.last_request
-          request.method.should eq({{ method.id.stringify }}.upcase)
-          request.path.should eq "hello"
-          request.body.not_nil!.gets_to_end.should eq({foo: "bar"}.to_json)
-        end
+        request = TestServer.last_request
+        request.method.should eq({{ method.id.stringify }}.upcase)
+        request.path.should eq "hello"
+        request.body.not_nil!.gets_to_end.should eq({foo: "bar"}.to_json)
       end
 
       it "works without params" do
-        with_fake_server do |server|
-          response = MyClient.for_app(server).{{method.id}}(path: "hello")
+        response = MyClient.new.{{method.id}}(path: "hello")
 
-          request = server.last_request
-          request.method.should eq({{ method.id.stringify }}.upcase)
-          request.path.should eq "hello"
-          request.body.not_nil!.gets_to_end.should eq("{}")
-        end
+        request = TestServer.last_request
+        request.method.should eq({{ method.id.stringify }}.upcase)
+        request.path.should eq "hello"
+        request.body.not_nil!.gets_to_end.should eq("{}")
       end
     end
   {% end %}
-end
 
-describe "head" do
-  it "sends the correct request to the correct uri and gets an empty response body" do
-    with_fake_server do |server|
-      response = MyClient.for_app(server).head(
+  describe "head" do
+    it "sends the correct request to the correct uri and gets an empty response body" do
+      response = MyClient.new.head(
         path: "hello",
         foo: "bar"
       )
 
-      request = server.last_request
+      request = TestServer.last_request
       request.method.should eq("HEAD")
       request.path.should eq "hello"
     end
-  end
-  it "works without params" do
-    with_fake_server do |server|
-      response = MyClient.for_app(server).head(path: "hello")
+    it "works without params" do
+      response = MyClient.new.head(path: "hello")
 
-      request = server.last_request
+      request = TestServer.last_request
       request.method.should eq("HEAD")
       request.path.should eq "hello"
       request.body.not_nil!.gets_to_end.should eq("{}")
     end
   end
-end
-
-private def with_fake_server
-  TestServer.middleware << Lucky::RouteHandler.new
-  yield TestServer.new
-ensure
-  TestServer.reset
 end

--- a/spec/support/test_server.cr
+++ b/spec/support/test_server.cr
@@ -1,31 +1,29 @@
-require "http/request"
-require "http/server"
-
-class TestServer
-  delegate listen, close, to: @server
-
-  class_property routes : Hash(String, String) = {} of String => String
-
-  property! last_request : HTTP::Request?
-  getter port
-
-  def initialize(@port : Int32)
-    @server = HTTP::Server.new do |context|
-      last_request = context.request.dup
-      last_request.body = last_request.body.try(&.peek)
-      @last_request = last_request
-      response_body = self.class.routes[context.request.path]
-      context.response.content_type = "text/plain"
-      context.response.print response_body
-    end
-    @server.bind_tcp port: port
-  end
-
-  def self.route(path : String, response_body : String)
-    routes[path] = response_body
-  end
+class TestServer < Lucky::BaseAppServer
+  class_property last_request : HTTP::Request?
+  class_getter middleware = [LastRequestHandler.new] of HTTP::Handler
 
   def self.reset
-    self.routes = {} of String => String
+    @@middleware = [LastRequestHandler.new] of HTTP::Handler
+  end
+
+  def middleware : Array(HTTP::Handler)
+    @@middleware
+  end
+
+  def listen
+    raise "unimplemented"
+  end
+
+  def last_request
+    self.class.last_request.not_nil!
+  end
+
+  class LastRequestHandler
+    include HTTP::Handler
+
+    def call(context)
+      TestServer.last_request = context.request
+      call_next(context)
+    end
   end
 end

--- a/spec/support/test_server.cr
+++ b/spec/support/test_server.cr
@@ -1,13 +1,15 @@
 class TestServer < Lucky::BaseAppServer
-  class_property last_request : HTTP::Request?
-  class_getter middleware = [LastRequestHandler.new] of HTTP::Handler
+  class_setter last_request : HTTP::Request?
 
-  def self.reset
-    @@middleware = [LastRequestHandler.new] of HTTP::Handler
+  def self.last_request : HTTP::Request
+    @@last_request.not_nil!
   end
 
   def middleware : Array(HTTP::Handler)
-    @@middleware
+    [
+      LastRequestHandler.new,
+      Lucky::RouteHandler.new,
+    ] of HTTP::Handler
   end
 
   def listen


### PR DESCRIPTION
## Purpose

In Lucky apps, we recommend using `Lucky::BaseHTTPClient` to make request specs against your running application. It's a simple proxy to an underlying `HTTP::Client` that allowed using you actions to make requests. In the quest to make our specs as quick as possible, this removes the need to start up the actual server in a different thread for request specs. It takes the middleware of your app can calls them directly.

In a very unofficial test, I saw ~10% speed improvement from the request specs because of this.

This _might_ also aid us in doing something similar for flow specs.

In a normal app, you are generated an `ApiClient` that looks like this

```crystal
class ApiClient < Lucky::BaseHTTPClient
  def initialize
    super
    headers("Content-Type": "application/json")
  end

  def self.auth(user : User)
    new.headers("Authorization": UserToken.generate(user))
  end
end
```

and a separate setup file boots your app in a fiber.

With this change, only one line will be added to your `ApiClient` and you won't need your app booted anymore

```crystal
class ApiClient < Lucky::BaseHTTPClient
  app AppServer.new # <--- instructs the client to connect to the app directly

  def initialize
    super
    headers("Content-Type": "application/json")
  end

  def self.auth(user : User)
    new.headers("Authorization": UserToken.generate(user))
  end
end
```