### PR TITLE
Lucky::Router refactor

### DIFF
--- a/spec/lucky/action_spec.cr
+++ b/spec/lucky/action_spec.cr
@@ -431,9 +431,9 @@ describe Lucky::Action do
 end
 
 private def assert_route_added?(expected_route)
-  Lucky::Router.routes.should contain(expected_route)
+  Lucky.router.routes.should contain(expected_route)
 end
 
 private def assert_route_not_added?(expected_route)
-  Lucky::Router.routes.should_not contain(expected_route)
+  Lucky.router.routes.should_not contain(expected_route)
 end

--- a/spec/lucky/action_spec.cr
+++ b/spec/lucky/action_spec.cr
@@ -238,25 +238,25 @@ describe Lucky::Action do
     end
 
     it "adds routes to the router" do
-      assert_route_added? Lucky::Route.new :get, "/tests", Tests::Index
-      assert_route_added? Lucky::Route.new :get, "/tests/new", Tests::New
-      assert_route_added? Lucky::Route.new :get, "/tests/:test_id/edit", Tests::Edit
-      assert_route_added? Lucky::Route.new :get, "/tests/:test_id", Tests::Show
-      assert_route_added? Lucky::Route.new :delete, "/tests/:test_id", Tests::Delete
-      assert_route_added? Lucky::Route.new :put, "/tests/:test_id", Tests::Update
-      assert_route_added? Lucky::Route.new :post, "/tests", Tests::Create
+      assert_route_added?({:get, "/tests", Tests::Index})
+      assert_route_added?({:get, "/tests/new", Tests::New})
+      assert_route_added?({:get, "/tests/:test_id/edit", Tests::Edit})
+      assert_route_added?({:get, "/tests/:test_id", Tests::Show})
+      assert_route_added?({:delete, "/tests/:test_id", Tests::Delete})
+      assert_route_added?({:put, "/tests/:test_id", Tests::Update})
+      assert_route_added?({:post, "/tests", Tests::Create})
     end
 
     it "allows setting custom routes" do
-      assert_route_not_added? Lucky::Route.new :get, "/custom_routes", CustomRoutes::Index
+      assert_route_not_added?({:get, "/custom_routes", CustomRoutes::Index})
 
-      assert_route_added? Lucky::Route.new :get, "/so_custom", CustomRoutes::Index
-      assert_route_added? Lucky::Route.new :put, "/so_custom", CustomRoutes::Put
-      assert_route_added? Lucky::Route.new :post, "/so_custom", CustomRoutes::Post
-      assert_route_added? Lucky::Route.new :patch, "/so_custom", CustomRoutes::Patch
-      assert_route_added? Lucky::Route.new :trace, "/so_custom", CustomRoutes::Trace
-      assert_route_added? Lucky::Route.new :delete, "/so_custom", CustomRoutes::Delete
-      assert_route_added? Lucky::Route.new :options, "/so_custom", CustomRoutes::Match
+      assert_route_added?({:get, "/so_custom", CustomRoutes::Index})
+      assert_route_added?({:put, "/so_custom", CustomRoutes::Put})
+      assert_route_added?({:post, "/so_custom", CustomRoutes::Post})
+      assert_route_added?({:patch, "/so_custom", CustomRoutes::Patch})
+      assert_route_added?({:trace, "/so_custom", CustomRoutes::Trace})
+      assert_route_added?({:delete, "/so_custom", CustomRoutes::Delete})
+      assert_route_added?({:options, "/so_custom", CustomRoutes::Match})
     end
 
     it "works with optional routing paths" do

--- a/spec/lucky/action_spec.cr
+++ b/spec/lucky/action_spec.cr
@@ -238,25 +238,25 @@ describe Lucky::Action do
     end
 
     it "adds routes to the router" do
-      assert_route_added?({:get, "/tests", Tests::Index})
-      assert_route_added?({:get, "/tests/new", Tests::New})
-      assert_route_added?({:get, "/tests/:test_id/edit", Tests::Edit})
-      assert_route_added?({:get, "/tests/:test_id", Tests::Show})
-      assert_route_added?({:delete, "/tests/:test_id", Tests::Delete})
-      assert_route_added?({:put, "/tests/:test_id", Tests::Update})
-      assert_route_added?({:post, "/tests", Tests::Create})
+      assert_route_added?(:get, "/tests", Tests::Index)
+      assert_route_added?(:get, "/tests/new", Tests::New)
+      assert_route_added?(:get, "/tests/:test_id/edit", Tests::Edit)
+      assert_route_added?(:get, "/tests/:test_id", Tests::Show)
+      assert_route_added?(:delete, "/tests/:test_id", Tests::Delete)
+      assert_route_added?(:put, "/tests/:test_id", Tests::Update)
+      assert_route_added?(:post, "/tests", Tests::Create)
     end
 
     it "allows setting custom routes" do
-      assert_route_not_added?({:get, "/custom_routes", CustomRoutes::Index})
+      assert_route_not_added?(:get, "/custom_routes")
 
-      assert_route_added?({:get, "/so_custom", CustomRoutes::Index})
-      assert_route_added?({:put, "/so_custom", CustomRoutes::Put})
-      assert_route_added?({:post, "/so_custom", CustomRoutes::Post})
-      assert_route_added?({:patch, "/so_custom", CustomRoutes::Patch})
-      assert_route_added?({:trace, "/so_custom", CustomRoutes::Trace})
-      assert_route_added?({:delete, "/so_custom", CustomRoutes::Delete})
-      assert_route_added?({:options, "/so_custom", CustomRoutes::Match})
+      assert_route_added?(:get, "/so_custom", CustomRoutes::Index)
+      assert_route_added?(:put, "/so_custom", CustomRoutes::Put)
+      assert_route_added?(:post, "/so_custom", CustomRoutes::Post)
+      assert_route_added?(:patch, "/so_custom", CustomRoutes::Patch)
+      assert_route_added?(:trace, "/so_custom", CustomRoutes::Trace)
+      assert_route_added?(:delete, "/so_custom", CustomRoutes::Delete)
+      assert_route_added?(:options, "/so_custom", CustomRoutes::Match)
     end
 
     it "works with optional routing paths" do
@@ -428,12 +428,4 @@ describe Lucky::Action do
       action.with_array_default.should eq([26, 37, 44])
     end
   end
-end
-
-private def assert_route_added?(expected_route)
-  Lucky.router.routes.should contain(expected_route)
-end
-
-private def assert_route_not_added?(expected_route)
-  Lucky.router.routes.should_not contain(expected_route)
 end

--- a/spec/lucky/namespaced_action_spec.cr
+++ b/spec/lucky/namespaced_action_spec.cr
@@ -18,7 +18,7 @@ describe Lucky::Action do
     end
 
     it "adds routes to the router" do
-      assert_route_added? Lucky::Route.new :get, "/admin/multi_word/users/:user_id", Admin::MultiWord::Users::Show
+      assert_route_added?({:get, "/admin/multi_word/users/:user_id", Admin::MultiWord::Users::Show})
     end
   end
 end

--- a/spec/lucky/namespaced_action_spec.cr
+++ b/spec/lucky/namespaced_action_spec.cr
@@ -18,15 +18,7 @@ describe Lucky::Action do
     end
 
     it "adds routes to the router" do
-      assert_route_added?({:get, "/admin/multi_word/users/:user_id", Admin::MultiWord::Users::Show})
+      assert_route_added?(:get, "/admin/multi_word/users/:user_id", Admin::MultiWord::Users::Show)
     end
   end
-end
-
-private def assert_route_added?(expected_route)
-  Lucky.router.routes.should contain(expected_route)
-end
-
-private def assert_route_not_added?(expected_route)
-  Lucky.router.routes.should_not contain(expected_route)
 end

--- a/spec/lucky/namespaced_action_spec.cr
+++ b/spec/lucky/namespaced_action_spec.cr
@@ -24,9 +24,9 @@ describe Lucky::Action do
 end
 
 private def assert_route_added?(expected_route)
-  Lucky::Router.routes.should contain(expected_route)
+  Lucky.router.routes.should contain(expected_route)
 end
 
 private def assert_route_not_added?(expected_route)
-  Lucky::Router.routes.should_not contain(expected_route)
+  Lucky.router.routes.should_not contain(expected_route)
 end

--- a/spec/lucky/route_prefix_spec.cr
+++ b/spec/lucky/route_prefix_spec.cr
@@ -72,26 +72,22 @@ end
 
 describe "prefixing routes" do
   it "prefixes the URL helpers for the resourceful actions" do
-    assert_route_added?({:get, "/api/v1/prefixed_get", PrefixedActions})
-    assert_route_added?({:put, "/api/v1/prefixed_put/:id", PrefixedActions})
-    assert_route_added?({:post, "/api/v1/prefixed_post/:id", PrefixedActions})
-    assert_route_added?({:patch, "/api/v1/prefixed_patch/:id", PrefixedActions})
-    assert_route_added?({:trace, "/api/v1/prefixed_trace/:id", PrefixedActions})
-    assert_route_added?({:delete, "/api/v1/prefixed_delete/:id", PrefixedActions})
-    assert_route_added?({:options, "/api/v1/prefixed_match_options", PrefixedActions})
+    assert_route_added?(:get, "/api/v1/prefixed_get", PrefixedActions)
+    assert_route_added?(:put, "/api/v1/prefixed_put/:id", PrefixedActions)
+    assert_route_added?(:post, "/api/v1/prefixed_post/:id", PrefixedActions)
+    assert_route_added?(:patch, "/api/v1/prefixed_patch/:id", PrefixedActions)
+    assert_route_added?(:trace, "/api/v1/prefixed_trace/:id", PrefixedActions)
+    assert_route_added?(:delete, "/api/v1/prefixed_delete/:id", PrefixedActions)
+    assert_route_added?(:options, "/api/v1/prefixed_match_options", PrefixedActions)
   end
 
   it "correctly prefixes through inheritance" do
-    assert_route_added?({:get, "/parent_api/has_parent_prefix", ChildApiWithParentPrefix})
-    assert_route_added?({:get, "/child_api/has_own_prefix", ChildApiWithOwnPrefix})
+    assert_route_added?(:get, "/parent_api/has_parent_prefix", ChildApiWithParentPrefix)
+    assert_route_added?(:get, "/child_api/has_own_prefix", ChildApiWithOwnPrefix)
   end
 
   it "correctly prefixes action through included modules" do
-    assert_route_added?({:get, "/module_prefix/has_module_prefix", ActionIncludingModulePrefix})
-    assert_route_added?({:get, "/no_prefix", ActionNotIncludingModulePrefix})
+    assert_route_added?(:get, "/module_prefix/has_module_prefix", ActionIncludingModulePrefix)
+    assert_route_added?(:get, "/no_prefix", ActionNotIncludingModulePrefix)
   end
-end
-
-private def assert_route_added?(expected_route)
-  Lucky.router.routes.should contain(expected_route)
 end

--- a/spec/lucky/route_prefix_spec.cr
+++ b/spec/lucky/route_prefix_spec.cr
@@ -93,5 +93,5 @@ describe "prefixing routes" do
 end
 
 private def assert_route_added?(expected_route)
-  Lucky::Router.routes.should contain(expected_route)
+  Lucky.router.routes.should contain(expected_route)
 end

--- a/spec/lucky/route_prefix_spec.cr
+++ b/spec/lucky/route_prefix_spec.cr
@@ -72,23 +72,23 @@ end
 
 describe "prefixing routes" do
   it "prefixes the URL helpers for the resourceful actions" do
-    assert_route_added? Lucky::Route.new :get, "/api/v1/prefixed_get", PrefixedActions
-    assert_route_added? Lucky::Route.new :put, "/api/v1/prefixed_put/:id", PrefixedActions
-    assert_route_added? Lucky::Route.new :post, "/api/v1/prefixed_post/:id", PrefixedActions
-    assert_route_added? Lucky::Route.new :patch, "/api/v1/prefixed_patch/:id", PrefixedActions
-    assert_route_added? Lucky::Route.new :trace, "/api/v1/prefixed_trace/:id", PrefixedActions
-    assert_route_added? Lucky::Route.new :delete, "/api/v1/prefixed_delete/:id", PrefixedActions
-    assert_route_added? Lucky::Route.new :options, "/api/v1/prefixed_match_options", PrefixedActions
+    assert_route_added?({:get, "/api/v1/prefixed_get", PrefixedActions})
+    assert_route_added?({:put, "/api/v1/prefixed_put/:id", PrefixedActions})
+    assert_route_added?({:post, "/api/v1/prefixed_post/:id", PrefixedActions})
+    assert_route_added?({:patch, "/api/v1/prefixed_patch/:id", PrefixedActions})
+    assert_route_added?({:trace, "/api/v1/prefixed_trace/:id", PrefixedActions})
+    assert_route_added?({:delete, "/api/v1/prefixed_delete/:id", PrefixedActions})
+    assert_route_added?({:options, "/api/v1/prefixed_match_options", PrefixedActions})
   end
 
   it "correctly prefixes through inheritance" do
-    assert_route_added? Lucky::Route.new :get, "/parent_api/has_parent_prefix", ChildApiWithParentPrefix
-    assert_route_added? Lucky::Route.new :get, "/child_api/has_own_prefix", ChildApiWithOwnPrefix
+    assert_route_added?({:get, "/parent_api/has_parent_prefix", ChildApiWithParentPrefix})
+    assert_route_added?({:get, "/child_api/has_own_prefix", ChildApiWithOwnPrefix})
   end
 
   it "correctly prefixes action through included modules" do
-    assert_route_added? Lucky::Route.new :get, "/module_prefix/has_module_prefix", ActionIncludingModulePrefix
-    assert_route_added? Lucky::Route.new :get, "/no_prefix", ActionNotIncludingModulePrefix
+    assert_route_added?({:get, "/module_prefix/has_module_prefix", ActionIncludingModulePrefix})
+    assert_route_added?({:get, "/no_prefix", ActionNotIncludingModulePrefix})
   end
 end
 

--- a/spec/lucky/router_spec.cr
+++ b/spec/lucky/router_spec.cr
@@ -2,25 +2,25 @@ require "../spec_helper"
 
 describe Lucky::Router do
   it "routes based on the method name and path" do
-    Lucky::Router.add :get, "/router-test1", Lucky::Action
+    Lucky.router.add :get, "/router-test1", Lucky::Action
 
-    Lucky::Router.find_action(:get, "/router-test1").should_not be_nil
-    Lucky::Router.find_action("get", "/router-test1").should_not be_nil
-    Lucky::Router.find_action(:post, "/router-test1").should be_nil
+    Lucky.router.find_action(:get, "/router-test1").should_not be_nil
+    Lucky.router.find_action("get", "/router-test1").should_not be_nil
+    Lucky.router.find_action(:post, "/router-test1").should be_nil
   end
 
   it "finds the associated get route by a head method" do
-    Lucky::Router.add :get, "/router-test2", Lucky::Action
+    Lucky.router.add :get, "/router-test2", Lucky::Action
 
-    Lucky::Router.find_action(:head, "/router-test2").should_not be_nil
-    Lucky::Router.find_action("head", "/router-test2").should_not be_nil
+    Lucky.router.find_action(:head, "/router-test2").should_not be_nil
+    Lucky.router.find_action("head", "/router-test2").should_not be_nil
   end
 
   it "finds the route with an optional parts" do
-    Lucky::Router.add :get, "/complex_path/:required/?:optional_a/?:optional_b", Lucky::Action
+    Lucky.router.add :get, "/complex_path/:required/?:optional_a/?:optional_b", Lucky::Action
 
-    Lucky::Router.find_action(:get, "/complex_path/1/2/3").should_not be_nil
-    Lucky::Router.find_action(:get, "/complex_path/1/2").should_not be_nil
-    Lucky::Router.find_action(:get, "/complex_path/1").should_not be_nil
+    Lucky.router.find_action(:get, "/complex_path/1/2/3").should_not be_nil
+    Lucky.router.find_action(:get, "/complex_path/1/2").should_not be_nil
+    Lucky.router.find_action(:get, "/complex_path/1").should_not be_nil
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -3,6 +3,8 @@ require "../src/lucky"
 require "../tasks/**"
 require "./support/**"
 
+include RoutesHelper
+
 Pulsar.enable_test_mode!
 
 Lucky::AssetHelpers.load_manifest

--- a/spec/support/routes_helper.cr
+++ b/spec/support/routes_helper.cr
@@ -1,9 +1,12 @@
 module RoutesHelper
-  private def assert_route_added?(expected_route)
-    Lucky.router.routes.should contain(expected_route)
+  private def assert_route_added?(method, path, expected_action)
+    result = Lucky.router.find_action(method, path)
+    result.should_not be_nil
+    result.not_nil!.payload.should eq expected_action
   end
 
-  private def assert_route_not_added?(expected_route)
-    Lucky.router.routes.should_not contain(expected_route)
+  private def assert_route_not_added?(method, path)
+    result = Lucky.router.find_action(method, path)
+    result.should be_nil
   end
 end

--- a/spec/support/routes_helper.cr
+++ b/spec/support/routes_helper.cr
@@ -1,9 +1,9 @@
 module RoutesHelper
   private def assert_route_added?(expected_route)
-    Lucky::Router.routes.should contain(expected_route)
+    Lucky.router.routes.should contain(expected_route)
   end
 
   private def assert_route_not_added?(expected_route)
-    Lucky::Router.routes.should_not contain(expected_route)
+    Lucky.router.routes.should_not contain(expected_route)
   end
 end

--- a/src/lucky.cr
+++ b/src/lucky.cr
@@ -24,6 +24,8 @@ require "./lucky/paginator/components/*"
 require "./lucky_avram"
 
 module Lucky
+  ROUTER = Lucky::Router.new
+
   Log              = ::Log.for("lucky")
   ContinuedPipeLog = Log.for("continued_pipe_log")
 
@@ -34,5 +36,9 @@ module Lucky
   # find `Dir.current`. If you call `Lucky.root` it will raise a compile-time error directing you to use `Dir.current`
   def self.root
     {% raise "Please use Crystal's 'Dir.current' to return the root folder of your Lucky application." %}
+  end
+
+  def self.router : Lucky::Router
+    ROUTER
   end
 end

--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -164,7 +164,7 @@ module Lucky::Routable
     enforce_route_style({{ path }}, {{ @type.name.id }})
     enforce_route_uniqueness({{method}}, {{ path }})
 
-    Lucky::Router.add({{ method }}, {{ path }}, {{ @type.name.id }})
+    Lucky.router.add({{ method }}, {{ path }}, {{ @type.name.id }})
     {% path_parts = path.split('/').reject(&.empty?) %}
     {% path_params = path_parts.select(&.starts_with?(':')) %}
     {% optional_path_params = path_parts.select(&.starts_with?("?:")) %}

--- a/src/lucky/route.cr
+++ b/src/lucky/route.cr
@@ -1,8 +1,0 @@
-class Lucky::Route
-  getter :method, :path, :action
-
-  def initialize(@method : Symbol, @path : String, @action : Lucky::Action.class)
-  end
-
-  def_equals @method, @path, @action
-end

--- a/src/lucky/route_handler.cr
+++ b/src/lucky/route_handler.cr
@@ -4,7 +4,7 @@ class Lucky::RouteHandler
   include HTTP::Handler
 
   def call(context)
-    handler = Lucky::Router.find_action(context.request)
+    handler = Lucky.router.find_action(context.request)
     if handler
       Lucky::Log.dexter.debug { {handled_by: handler.payload.to_s} }
       handler.payload.new(context, handler.params).perform_action

--- a/src/lucky/router.cr
+++ b/src/lucky/router.cr
@@ -1,37 +1,19 @@
 # :nodoc:
 class Lucky::Router
-  INSTANCE = new
+  getter routes = [] of Lucky::Route
+  @matcher = LuckyRouter::Matcher(Lucky::Action.class).new
 
-  getter :routes
-
-  def initialize
-    @matcher = LuckyRouter::Matcher(Lucky::Action.class).new
-    @routes = [] of Lucky::Route
-  end
-
-  def self.add(method, path, action) : Nil
-    INSTANCE.add(method, path, action)
-  end
-
-  def self.routes : Array(Lucky::Route)
-    INSTANCE.routes
-  end
-
-  def add(method, path, action) : Nil
+  def add(method : Symbol, path : String, action : Lucky::Action.class) : Nil
     route = Lucky::Route.new(method, path, action)
     @routes << route
     @matcher.add(route.method.to_s, route.path, route.action)
   end
 
-  def find_action(method, path) : LuckyRouter::Match(Lucky::Action.class)?
+  def find_action(method : Symbol | String, path : String) : LuckyRouter::Match(Lucky::Action.class)?
     @matcher.match method.to_s.downcase, path
   end
 
-  def self.find_action(method, path) : LuckyRouter::Match(Lucky::Action.class)?
-    INSTANCE.find_action(method, path)
-  end
-
-  def self.find_action(request) : LuckyRouter::Match(Lucky::Action.class)?
-    INSTANCE.find_action(request.method, request.path)
+  def find_action(request : HTTP::Request) : LuckyRouter::Match(Lucky::Action.class)?
+    find_action(request.method, request.path)
   end
 end

--- a/src/lucky/router.cr
+++ b/src/lucky/router.cr
@@ -1,12 +1,11 @@
 # :nodoc:
 class Lucky::Router
-  getter routes = [] of Lucky::Route
+  getter routes = [] of Tuple(Symbol, String, Lucky::Action.class)
   @matcher = LuckyRouter::Matcher(Lucky::Action.class).new
 
   def add(method : Symbol, path : String, action : Lucky::Action.class) : Nil
-    route = Lucky::Route.new(method, path, action)
-    @routes << route
-    @matcher.add(route.method.to_s, route.path, route.action)
+    @routes << {method, path, action}
+    @matcher.add(method.to_s, path, action)
   end
 
   def find_action(method : Symbol | String, path : String) : LuckyRouter::Match(Lucky::Action.class)?

--- a/tasks/routes.cr
+++ b/tasks/routes.cr
@@ -23,7 +23,7 @@ class Routes < LuckyTask::Task
   def call
     routes = [] of Array(String)
 
-    Lucky::Router.routes.each do |route|
+    Lucky.router.routes.each do |route|
       row = [] of String
       row << route.method.to_s.upcase
       row << route.path.colorize.green.to_s

--- a/tasks/routes.cr
+++ b/tasks/routes.cr
@@ -23,15 +23,15 @@ class Routes < LuckyTask::Task
   def call
     routes = [] of Array(String)
 
-    Lucky.router.routes.each do |route|
+    Lucky.router.routes.each do |method, path, action|
       row = [] of String
-      row << route.method.to_s.upcase
-      row << route.path.colorize.green.to_s
-      row << route.action.name
+      row << method.to_s.upcase
+      row << path.colorize.green.to_s
+      row << action.name
       routes << row
 
       if with_params?
-        route.action.query_param_declarations.each do |param|
+        action.query_param_declarations.each do |param|
           param_row = [] of String
           param_row << " "
           param_row << " #{dim_arrow} #{param}"


### PR DESCRIPTION
Some simple refactors I saw while working on https://github.com/luckyframework/lucky/pull/1644

Main two things:
- Remove INSTANCE constant from Lucky::Router along with class methods that used it
- Remove `Lucky::Route` class. Ideally we update LuckyRouter to complete remove the duplicate collection of routes
- Replace all usages except one of `Lucky::Router#routes`