### PR TITLE
Add Crystal 1.3.0 to the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,12 @@ jobs:
           - shard.yml
         crystal_version:
           - 1.0.0
-          - 1.1.1
-          - 1.2.2
           - 1.3.0
         experimental:
           - false
         include:
           - shard_file: shard.edge.yml
-            crystal_version: 1.1.1
+            crystal_version: 1.3.0
             experimental: true
           - shard_file: shard.yml
             crystal_version: nightly
@@ -50,14 +48,12 @@ jobs:
           - shard.yml
         crystal_version:
           - 1.0.0
-          - 1.1.1
-          - 1.2.2
           - 1.3.0
         experimental:
           - false
         include:
           - shard_file: shard.edge.yml
-            crystal_version: 1.1.1
+            crystal_version: 1.3.0
             experimental: true
           - shard_file: shard.yml
             crystal_version: nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,14 +14,10 @@ jobs:
         shard_file:
           - shard.yml
         crystal_version:
-          - 1.0.0
-          - 1.3.0
+          - latest
         experimental:
           - false
         include:
-          - shard_file: shard.edge.yml
-            crystal_version: 1.3.0
-            experimental: true
           - shard_file: shard.yml
             crystal_version: nightly
             experimental: true
@@ -53,7 +49,7 @@ jobs:
           - false
         include:
           - shard_file: shard.edge.yml
-            crystal_version: 1.3.0
+            crystal_version: latest
             experimental: true
           - shard_file: shard.yml
             crystal_version: nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,14 @@ jobs:
           - shard.yml
         crystal_version:
           - 1.0.0
-          - 1.1.0
-          - 1.2.0
+          - 1.1.1
+          - 1.2.2
+          - 1.3.0
         experimental:
           - false
         include:
           - shard_file: shard.edge.yml
-            crystal_version: 1.0.0
+            crystal_version: 1.1.1
             experimental: true
           - shard_file: shard.yml
             crystal_version: nightly
@@ -49,13 +50,14 @@ jobs:
           - shard.yml
         crystal_version:
           - 1.0.0
-          - 1.1.0
-          - 1.2.0
+          - 1.1.1
+          - 1.2.2
+          - 1.3.0
         experimental:
           - false
         include:
           - shard_file: shard.edge.yml
-            crystal_version: 1.0.0
+            crystal_version: 1.1.1
             experimental: true
           - shard_file: shard.yml
             crystal_version: nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           - shard.yml
         crystal_version:
           - 1.0.0
-          - 1.3.0
+          - latest
         experimental:
           - false
         include:


### PR DESCRIPTION
## Purpose
Now that Crystal 1.3.0 is out, make sure we test against that. I'm also bumping the Crystal versions to be the last in those version series. I figure it's probably better to test against 1.2.2 than 1.2.0. 

