### PR TITLE
make done compiling message more visible (#1606)

### DIFF
--- a/tasks/watch.cr
+++ b/tasks/watch.cr
@@ -155,7 +155,7 @@ module LuckySentry
     def restart_app
       build_in_progress = @build_processes.any?(&.exists?)
       stop_all_processes
-      puts build_in_progress ? "Recompiling..." : "Compiling..."
+      puts build_in_progress ? "Recompiling..." : "\nCompiling..."
       build_app_processes_and_start
     end
 
@@ -176,7 +176,7 @@ module LuckySentry
       if build_success
         self.app_built = true
         create_app_processes()
-        puts "Done compiling"
+        puts "#{" Done ".colorize.on_cyan.black} compiling"
       elsif !app_built
         print_error_message
       end


### PR DESCRIPTION
fixes https://github.com/luckyframework/lucky/issues/1606

Colorize "Done" in "Done compiling" to make it more visible

<img width="679" alt="Screen Shot 2022-01-23 at 14 38 22" src="https://user-images.githubusercontent.com/8044/150676644-c7de99de-baab-4e0e-b9f1-4ca6b67a3dfe.png">