### PR TITLE
Allow forgery protection to be enabled/disabled app-wide

### DIFF
--- a/src/lucky/protect_from_forgery.cr
+++ b/src/lucky/protect_from_forgery.cr
@@ -11,6 +11,10 @@ module Lucky::ProtectFromForgery
     before protect_from_forgery
   end
 
+  Habitat.create do
+    setting allow_forgery_protection : Bool = true
+  end
+
   # :nodoc:
   def self.get_token(context : HTTP::Server::Context) : String
     context.session.get(SESSION_KEY)
@@ -18,7 +22,7 @@ module Lucky::ProtectFromForgery
 
   private def protect_from_forgery
     set_session_csrf_token
-    if request_does_not_require_protection? || valid_csrf_token?
+    if !settings.allow_forgery_protection? || request_does_not_require_protection? || valid_csrf_token?
       continue
     else
       forbid_access_because_of_bad_token


### PR DESCRIPTION
## Purpose

Resolves #1656

A follow-up pr will need to be made to lucky_cli that adds configuration disabling it in the test environment.

## Description

Needed by https://github.com/luckyframework/lucky_flow/pull/137 to allow using things like links with different request methods that would normally use javascript to set the CSRF token on the request.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
