### PR TITLE
Write html and json directly to response body instead of intermediary

### DIFF
--- a/src/lucky/html_page.cr
+++ b/src/lucky/html_page.cr
@@ -7,8 +7,12 @@ module Lucky::HTMLPage
     setting render_component_comments : Bool = false
   end
 
-  getter view : IO = IO::Memory.new
+  getter view : IO { IO::Memory.new }
   needs context : HTTP::Server::Context
+
+  def view(@view : IO)
+    self
+  end
 
   def to_s(io)
     io << view

--- a/src/lucky/text_response.cr
+++ b/src/lucky/text_response.cr
@@ -14,7 +14,7 @@ class Lucky::TextResponse < Lucky::Response
 
   def initialize(@context : HTTP::Server::Context,
                  @content_type : String,
-                 @body : String | IO,
+                 @body : String | IO | Body,
                  @status : Int32? = nil,
                  @debug_message : String? = nil,
                  @enable_cookies : Bool = true)
@@ -77,5 +77,22 @@ class Lucky::TextResponse < Lucky::Response
     end
 
     response.cookies.add_response_headers(response.headers)
+  end
+
+  struct Body
+    @inner : Proc(IO, Nil)
+
+    def self.new(raw : String | IO)
+      new do |io|
+        io.print(raw)
+      end
+    end
+
+    def initialize(&@inner : IO ->)
+    end
+
+    def to_s(io)
+      @inner.call(io)
+    end
   end
 end


### PR DESCRIPTION
Currently, `Lucky::HTMLPage` writes to an `IO::Memory` and then that is transferred over to the response body. Same goes for json, except it's turned to a string as its intermediary. This change adds functionality to write directly to the response body. In benchmarks I'm seeing the current code as 1.04 to 1.07 times slower. I'd love any ideas as to a better way to do this. I'm not too fond with this implementation.

<details>
<summary>Benchmark</summary>
<br>

```crystal
require "benchmark"
require "./spec/spec_helper"

class BenchmarkPage
  include Lucky::HTMLPage

  def render
    header({class: "header"}) do
      style "body { font-size: 2em; }"
      text "my text"
      h1 "h1"
      br
      div class: "empty-contents"
      br({class: "br"})
      br class: "br"
      img({src: "src"})
      h2 "A bit smaller", {class: "peculiar"}
      h6 class: "h6" do
        small "super tiny", class: "so-small"
        span "wow"
      end
    end
  end
end

Benchmark.ips do |x|
  x.report("rewrite to output io") do
    output = IO::Memory.new
    io = BenchmarkPage.new(ContextHelper.build_context).perform_render
    output.print(io)
  end

  x.report("write directly to output") do
    output = IO::Memory.new
    BenchmarkPage.new(ContextHelper.build_context).view(output).perform_render
  end
end
```

</details>

<details>
<summary>Benchmark Result</summary>
<br>

```bash
❯ crystal run benchmark.cr --release
    rewrite to output io  24.11k ( 41.48µs) (± 1.41%)  40.9kB/op   1.04× slower
write directly to output  24.97k ( 40.05µs) (± 3.04%)  38.8kB/op        fastest
```

</details>
