### PR TITLE
Add changelog for X-Forwarded-Proto matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Unreleased
+
+- **Breaking change** Updated: Lucky::ForceSSLHandler middleware to match X-Forwarded-Proto == https exactly, which previously accepted uppercase and only required https to be part of the value [#1662](https://github.com/luckyframework/lucky/pull/1662)
+
 ### Changes in 0.29
 
 - Fixed: the binary name generated for the `gen.secret_key` task. [#1556](https://github.com/luckyframework/lucky/pull/1556)


### PR DESCRIPTION
I'm not really sure how you do changelog items, but this should be noted as a "more notable change than just a fixup"