### PR TITLE
Adds a new security header for Content-Security-Policy.

### DIFF
--- a/spec/lucky/secure_headers_spec.cr
+++ b/spec/lucky/secure_headers_spec.cr
@@ -74,6 +74,18 @@ class FLoCGGuardRoutes::Index < TestAction
   end
 end
 
+class CSPGuardRoutes::Index < TestAction
+  include Lucky::SecureHeaders::SetCSPGuard
+
+  get "/secure_path8" do
+    plain_text "test"
+  end
+
+  def csp_guard_value : String
+    "script-src 'self'"
+  end
+end
+
 describe Lucky::SecureHeaders do
   describe "SetFrameGuard" do
     it "sets the X-Frame-Options header with sameorigin" do
@@ -123,6 +135,13 @@ describe Lucky::SecureHeaders do
     it "sets the Permissions-Policy to interest-cohort=()" do
       route = FLoCGGuardRoutes::Index.new(build_context, params).call
       route.context.response.headers["Permissions-Policy"].should eq "interest-cohort=()"
+    end
+  end
+
+  describe "SetCSPGuard" do
+    it "sets the Content-Security-Policy header" do
+      route = CSPGuardRoutes::Index.new(build_context, params).call
+      route.context.response.headers["Content-Security-Policy"].should eq "script-src 'self'"
     end
   end
 end

--- a/src/lucky/secure_headers/set_csp_guard.cr
+++ b/src/lucky/secure_headers/set_csp_guard.cr
@@ -1,0 +1,30 @@
+module Lucky
+  module SecureHeaders
+    # This module sets the HTTP header [Content-Security-Policy](https://wiki.owasp.org/index.php/OWASP_Secure_Headers_Project#csp).
+    # It's job is to prevent a wide range of attacks like Cross-Site Scripting.
+    #
+    # Include this module in the actions you want to add this to.
+    # A required method `csp_guard_value` must be defined
+    # ```
+    # class BrowserAction < Lucky::Action
+    #   include Lucky::SecureHeaders::SetCSPGuard
+    #
+    #   def csp_guard_value : String
+    #     "script-src 'self'"
+    #   end
+    # end
+    # ```
+    module SetCSPGuard
+      macro included
+        before set_csp_guard_header
+      end
+
+      abstract def csp_guard_value : String
+
+      private def set_csp_guard_header
+        context.response.headers["Content-Security-Policy"] = csp_guard_value
+        continue
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Purpose
Fixes #1664

## Description
This PR adds a new Security module to set the `Content-Security-Policy` header. 

/cc. @bararchy

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
