### PR TITLE
reworks the message verifier to remove the magic -- character.

### DIFF
--- a/spec/lucky/support/message_verifier_spec.cr
+++ b/spec/lucky/support/message_verifier_spec.cr
@@ -6,4 +6,10 @@ describe Lucky::MessageVerifier do
     signed_message = verifier.generate("abc123")
     verifier.verified(signed_message).should eq("abc123")
   end
+
+  it "still works with some more complext data" do
+    verifier = Lucky::MessageVerifier.new("mFClXIwWbxfqJwnJ/rXXFK02kO5z8wY2P8mjozsEQDk=", :sha256)
+    signed_message = verifier.generate("#{Time.utc(2022, 1, 15, 10, 12).to_unix}:some_special_dude@hotmail.com:b211cbb5-3cc0-475a-9ebe-45f3fd2fe650")
+    verifier.verified(signed_message).should eq("1642241520:some_special_dude@hotmail.com:b211cbb5-3cc0-475a-9ebe-45f3fd2fe650")
+  end
 end

--- a/src/lucky/support/message_verifier.cr
+++ b/src/lucky/support/message_verifier.cr
@@ -11,7 +11,9 @@ module Lucky
     end
 
     def verified(signed_message : String) : String?
-      data, digest = signed_message.split("--", 2)
+      json_data = ::Base64.decode_string(signed_message)
+      data, digest = Tuple(String, String).from_json(json_data)
+
       if valid_message?(data, digest)
         String.new(decode(data))
       end
@@ -25,7 +27,9 @@ module Lucky
     end
 
     def verify_raw(signed_message : String) : Bytes
-      data, digest = signed_message.split("--", 2)
+      json_data = ::Base64.decode_string(signed_message)
+      data, digest = Tuple(String, String).from_json(json_data)
+
       if valid_message?(data, digest)
         decode(data)
       else
@@ -35,7 +39,7 @@ module Lucky
 
     def generate(value : String | Bytes) : String
       data = encode(value)
-      "#{data}--#{generate_digest(data)}"
+      encode({data, generate_digest(data)}.to_json)
     end
 
     private def encode(data) : String


### PR DESCRIPTION
## Purpose
Fixes #1595

## Description
We were using a magic `--` to split the data in the token generated by the message verifier. In some rare instances, the data on the left or the right of the magic character could also contain `--` themselves. This caused issues when splitting on that. 

This fix removes the magic character completely and just uses some JSON instead.

/cc @robacarp 

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [ x - Lucky builds on docker with `./script/setup`
* [ x - All builds and specs pass on docker with `./script/test`
