### PR TITLE
Added remote_ip to request object

### DIFF
--- a/spec/lucky/remote_ip_handler_spec.cr
+++ b/spec/lucky/remote_ip_handler_spec.cr
@@ -9,6 +9,7 @@ describe Lucky::RemoteIpHandler do
 
       run_remote_ip_handler(context)
       context.request.remote_address.should eq nil
+      context.request.remote_ip.should eq nil
     end
 
     it "returns the X_FORWARDED_FOR address" do
@@ -18,7 +19,9 @@ describe Lucky::RemoteIpHandler do
       context = build_context(request)
 
       run_remote_ip_handler(context)
+      context.request.remote_address.should be_a(Socket::IPAddress)
       context.request.remote_address.should eq Socket::IPAddress.new("1.2.3.4", 0)
+      context.request.remote_ip.should eq("1.2.3.4")
     end
 
     it "returns request.remote_address if X_FORWARDED_FOR is not valid" do
@@ -29,8 +32,9 @@ describe Lucky::RemoteIpHandler do
       context = build_context(request)
 
       run_remote_ip_handler(context)
-
+      context.request.remote_address.should be_a(Socket::IPAddress)
       context.request.remote_address.should eq Socket::IPAddress.new("255.255.255.255", 0)
+      context.request.remote_ip.should eq("255.255.255.255")
     end
 
     it "returns nil if the X_FORWARDED_FOR is an empty string, and no default remote_address is found" do
@@ -41,6 +45,7 @@ describe Lucky::RemoteIpHandler do
 
       run_remote_ip_handler(context)
       context.request.remote_address.should eq nil
+      context.request.remote_ip.should eq nil
     end
 
     it "returns the original remote_address" do
@@ -49,7 +54,9 @@ describe Lucky::RemoteIpHandler do
       context = build_context(request)
 
       run_remote_ip_handler(context)
+      context.request.remote_address.should be_a(Socket::IPAddress)
       context.request.remote_address.should eq Socket::IPAddress.new("255.255.255.255", 0)
+      context.request.remote_ip.should eq("255.255.255.255")
     end
   end
 end

--- a/src/charms/request_extensions.cr
+++ b/src/charms/request_extensions.cr
@@ -1,0 +1,9 @@
+class HTTP::Request
+  # This is an alternative to `remote_address`
+  # since that casts to `Socket::Address`, and not all
+  # subclasses have an `address` method to give you the value.
+  # ```
+  # request.remote_address.as?(Socket::IPAddress).try(&.address)
+  # ```
+  property remote_ip : String?
+end


### PR DESCRIPTION
## Purpose
Fixes #1643

## Description
If you need access to the client's IP address, using `remote_address` can be troublesome since it casts to `Socket::Address`, and not all `Socket::Address` subclasses contain an `address` method. So you usually end up with some code like this:

```crystal
context.request.remote_address.as?(Socket::IPAddress).try(&.address) || "127.0.0.1"
```

But now you can just do

```crystal
context.request.remote_ip || "127.0.0.1"
```

In addition, I've also added a new habitat config option `ip_header_names` option. This allows you to configure the header names of where the client IP may come from. e.g. `X-Real-Ip`, `Forwarded-For`, etc...

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
