### PR TITLE
Add Lucky::CookieJar#[] and #[]=

### DIFF
--- a/spec/lucky/cookies/cookie_jar_spec.cr
+++ b/spec/lucky/cookies/cookie_jar_spec.cr
@@ -6,11 +6,15 @@ describe Lucky::CookieJar do
 
     jar.set(:symbol_key, "symbol key")
     jar.set("string_key", "string key")
+    jar[:another_symbol] = "symbol key"
+    jar["another_string"] = "string key"
 
     jar.get(:symbol_key).should eq("symbol key")
     jar.get("symbol_key").should eq("symbol key")
     jar.get("string_key").should eq("string key")
     jar.get(:string_key).should eq("string key")
+    jar[:another_symbol].should eq("symbol key")
+    jar["another_string"].should eq("string key")
   end
 
   it "sets and gets raw HTTP::Cookie object with indifferent access" do

--- a/src/lucky/cookies/cookie_jar.cr
+++ b/src/lucky/cookies/cookie_jar.cr
@@ -97,6 +97,10 @@ class Lucky::CookieJar
     get?(key) || raise CookieNotFoundError.new(key)
   end
 
+  def [](key : Key) : String
+    get(key)
+  end
+
   def get?(key : Key) : String?
     cookies[key.to_s]?.try do |cookie|
       decrypt(cookie.value, cookie.name)
@@ -105,8 +109,16 @@ class Lucky::CookieJar
     nil
   end
 
+  def []?(key : Key) : String?
+    get?(key)
+  end
+
   def set(key : Key, value : String) : HTTP::Cookie
     set_raw key, encrypt(value)
+  end
+
+  def []=(key : Key, value : String) : HTTP::Cookie
+    set(key, value)
   end
 
   def set_raw(key : Key, value : String) : HTTP::Cookie


### PR DESCRIPTION
Adds easier access to cookies by adding the typical key/value syntax
for cookies get/set operations

In the future, this could potentially even implement all of Enumerable({K, V}), but
these methods are super helpful as is to provide hash-like access to cookies
