### PR TITLE
Fixing references to habitat settings

### DIFF
--- a/spec/lucky/subdomain_spec.cr
+++ b/spec/lucky/subdomain_spec.cr
@@ -3,6 +3,8 @@ require "../spec_helper"
 include ContextHelper
 
 abstract class BaseAction < Lucky::Action
+  # https://github.com/luckyframework/lucky/issues/1685
+  include Lucky::ProtectFromForgery
   include Lucky::Subdomain
   accepted_formats [:html], default: :html
 end

--- a/src/lucky/protect_from_forgery.cr
+++ b/src/lucky/protect_from_forgery.cr
@@ -22,7 +22,7 @@ module Lucky::ProtectFromForgery
 
   private def protect_from_forgery
     set_session_csrf_token
-    if !settings.allow_forgery_protection? || request_does_not_require_protection? || valid_csrf_token?
+    if !Lucky::ProtectFromForgery.settings.allow_forgery_protection? || request_does_not_require_protection? || valid_csrf_token?
       continue
     else
       forbid_access_because_of_bad_token

--- a/src/lucky/subdomain.cr
+++ b/src/lucky/subdomain.cr
@@ -47,7 +47,7 @@ module Lucky::Subdomain
     return if host.nil? || IP_HOST_REGEXP.matches?(host)
 
     parts = host.split('.')
-    parts.pop(settings.tld_length + 1)
+    parts.pop(Lucky::Subdomain.settings.tld_length + 1)
 
     parts.empty? ? nil : parts.join(".")
   end


### PR DESCRIPTION
## Purpose
Fixes #1685

## Description
When a module creates a Habitat config, it will create both an instance and a class method called `settings`. If you include more than 1 module with habitat settings, then the last included one ends up overriding the previous ones.

This fixes the two areas where these could collide. 

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
