### PR TITLE
locking down to Crystal 1.4.0 or later.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: crystal-lang/install-crystal@v1
         with:
-          crystal: 1.3.2
+          crystal: 1.4.1
       - name: Install shards
         run: shards install
       - name: Format
@@ -32,7 +32,7 @@ jobs:
         shard_file:
           - shard.yml
         crystal_version:
-          - 1.0.0
+          - 1.4.0
           - latest
         experimental:
           - false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM crystallang/crystal:1.0.0
+FROM crystallang/crystal:1.4.1
 WORKDIR /data
 
 RUN apt-get update && \

--- a/shard.yml
+++ b/shard.yml
@@ -1,7 +1,7 @@
 name: lucky
 version: 0.30.1
 
-crystal: ">=1.0.0"
+crystal: ">=1.4.0"
 
 authors:
   - Paul Smith <paulcsmith0218@gmail.com>
@@ -68,7 +68,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 0.14.4
+    version: ~> 1.0.0
 
 scripts:
   postinstall: BUILD_WITHOUT_DEVELOPMENT=true script/precompile_tasks


### PR DESCRIPTION
## Purpose
Locks Lucky to Crystal version 1.4.0 or later.

## Description
With the release of the new Crystal book being focused on 1.4.0, and shards like Ameba locking to that version, as well as Crystal 1.5.0 is slated to come out in the next 2 months, it makes sense that we start pushing to have everyone use a later version of Crystal. This will also allow us to clean up some code with the assumption that the user is using 1.4.0 or later.

