### PR TITLE
Allow setting the exec editor by env var.

### DIFF
--- a/tasks/exec.cr
+++ b/tasks/exec.cr
@@ -33,7 +33,7 @@ class Lucky::Exec < LuckyTask::Task
   end
 
   def call
-    editor_to_use = editor || settings.editor
+    editor_to_use = editor || ENV["EDITOR"]? || settings.editor
     repeat = !once?
     sessions_back = (back || 1).to_i
 


### PR DESCRIPTION
## Purpose
Fixes #1698

## Description
This allows you to set your editor using an env var `ENV["EDITOR"]` when running exec.

Now you can set it 3 different ways:

```
# project widde
Lucky::Exec.configure do |settings|
  settings.editor = "mate"
end

# CLI arg
lucky exec -e mate

# ENV var
EDITOR=mate lucky exec
```


## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
