### PR TITLE
give error actions access to params

### DIFF
--- a/src/lucky/error_action.cr
+++ b/src/lucky/error_action.cr
@@ -2,6 +2,7 @@ require "./*"
 
 abstract class Lucky::ErrorAction
   include Lucky::ActionDelegates
+  include Lucky::ParamHelpers
   include Lucky::Renderable
   include Lucky::Redirectable
   include Lucky::Exposable


### PR DESCRIPTION
## Purpose
Fixes #1647 

## Description
Error actions now have access to params instead of going through `context.params`

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
