### PR TITLE
Allow setting more custom content types.

### DIFF
--- a/spec/lucky/action_spec.cr
+++ b/spec/lucky/action_spec.cr
@@ -161,6 +161,67 @@ class Tests::ActionWithPrefix < TestAction
   end
 end
 
+class Tests::HtmlActionWithCustomContentType < TestAction
+  get "/tests/new_action_with_custom_html_content_type" do
+    html(Tests::IndexPage)
+  end
+
+  def html_content_type
+    "text/html; charset=utf-8"
+  end
+end
+
+class Tests::JsonActionWithCustomContentType < TestAction
+  param override_content_type : String?
+  get "/tests/new_action_with_custom_json_content_type" do
+    if ct = override_content_type.presence
+      raw_json("{}", content_type: ct)
+    else
+      raw_json("{}")
+    end
+  end
+
+  def json_content_type
+    "application/json; charset=utf-8"
+  end
+end
+
+class Tests::XmlActionWithCustomContentType < TestAction
+  get "/tests/new_action_with_custom_xml_content_type" do
+    xml("<code></code>")
+  end
+
+  def xml_content_type
+    "special/xml; charset=utf-8"
+  end
+end
+
+class Tests::PlainActionWithCustomContentType < TestAction
+  get "/tests/new_action_with_custom_plain_content_type" do
+    plain_text("nothing special")
+  end
+
+  def plain_content_type
+    "very/plain; charset=utf-8"
+  end
+end
+
+private class SimplleTestComponent < Lucky::BaseComponent
+  def render
+    text "hi"
+  end
+end
+
+class Tests::ComponentActionWithCustomContentType < TestAction
+  get "/tests/new_action_with_custom_component_content_type" do
+    component SimplleTestComponent
+  end
+
+  def html_content_type
+    "text/html; charset=utf-8"
+  end
+end
+
 describe Lucky::Action do
   it "has a url helper" do
     Lucky::RouteHelper.temp_config(base_uri: "example.com") do
@@ -285,6 +346,34 @@ describe Lucky::Action do
       response = Tests::Index.new(build_context, params).call
       response.body.to_s.should contain "Rendered from Tests::IndexPage"
       response.content_type.should eq "text/html"
+    end
+
+    it "uses a custom content_type for this html action" do
+      response = Tests::HtmlActionWithCustomContentType.new(build_context, params).call
+      response.content_type.should eq "text/html; charset=utf-8"
+    end
+
+    it "uses a custom content_type for this component action" do
+      response = Tests::ComponentActionWithCustomContentType.new(build_context, params).call
+      response.content_type.should eq "text/html; charset=utf-8"
+    end
+
+    it "uses a custom content_type for this json action" do
+      response = Tests::JsonActionWithCustomContentType.new(build_context, params).call
+      response.content_type.should eq "application/json; charset=utf-8"
+
+      response = Tests::JsonActionWithCustomContentType.new(build_context(path: "/tests/new_action_with_custom_json_content_type?override_content_type=cats/dogs"), params).call
+      response.content_type.should eq "cats/dogs"
+    end
+
+    it "uses a custom content_type for this xml action" do
+      response = Tests::XmlActionWithCustomContentType.new(build_context, params).call
+      response.content_type.should eq "special/xml; charset=utf-8"
+    end
+
+    it "uses a custom content_type for this plain action" do
+      response = Tests::PlainActionWithCustomContentType.new(build_context, params).call
+      response.content_type.should eq "very/plain; charset=utf-8"
     end
   end
 

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -59,7 +59,7 @@ module Lucky::Renderable
     )
     Lucky::TextResponse.new(
       context,
-      "text/html",
+      html_content_type,
       view.perform_render,
       status: {{ _with_status_code }},
       debug_message: log_message(view),
@@ -202,6 +202,26 @@ module Lucky::Renderable
     end
   end
 
+  # The default global content-type header for HTML
+  def html_content_type
+    "text/html"
+  end
+
+  # The default global content-type header for JSON
+  def json_content_type
+    "application/json"
+  end
+
+  # The default global content-type header for XML
+  def xml_content_type
+    "text/xml"
+  end
+
+  # The default global content-type header for Plain text
+  def plain_content_type
+    "text/plain"
+  end
+
   def file(
     path : String,
     content_type : String? = nil,
@@ -246,11 +266,11 @@ module Lucky::Renderable
     )
   end
 
-  def plain_text(body : String, status : Int32? = nil) : Lucky::TextResponse
-    send_text_response(body, "text/plain", status)
+  def plain_text(body : String, status : Int32? = nil, content_type : String = plain_content_type) : Lucky::TextResponse
+    send_text_response(body, content_type, status)
   end
 
-  def plain_text(body : String, status : HTTP::Status) : Lucky::TextResponse
+  def plain_text(body : String, status : HTTP::Status, content_type : String = plain_content_type) : Lucky::TextResponse
     plain_text(body, status: status.value)
   end
 
@@ -263,16 +283,16 @@ module Lucky::Renderable
   end
 
   # allows json-compatible string to be returned directly
-  def raw_json(body : String, status : Int32? = nil) : Lucky::TextResponse
-    send_text_response(body, "application/json", status)
+  def raw_json(body : String, status : Int32? = nil, content_type : String = json_content_type) : Lucky::TextResponse
+    send_text_response(body, content_type, status)
   end
 
-  def raw_json(body : String, status : HTTP::Status) : Lucky::TextResponse
-    raw_json(body, status: status.value)
+  def raw_json(body : String, status : HTTP::Status, content_type : String = json_content_type) : Lucky::TextResponse
+    raw_json(body, status: status.value, content_type: content_type)
   end
 
   # :nodoc:
-  def json(body : String, status : Int32? = nil) : Lucky::TextResponse
+  def json(body : String, status : Int32? = nil, content_type : String = json_content_type) : Lucky::TextResponse
     {%
       raise <<-ERROR
 
@@ -286,20 +306,20 @@ module Lucky::Renderable
     %}
   end
 
-  def json(body, status : Int32? = nil) : Lucky::TextResponse
-    send_text_response(body.to_json, "application/json", status)
+  def json(body, status : Int32? = nil, content_type : String = json_content_type) : Lucky::TextResponse
+    raw_json(body.to_json, status, content_type)
   end
 
-  def json(body, status : HTTP::Status) : Lucky::TextResponse
-    json(body, status: status.value)
+  def json(body, status : HTTP::Status, content_type : String = json_content_type) : Lucky::TextResponse
+    json(body, status: status.value, content_type: content_type)
   end
 
-  def xml(body : String, status : Int32? = nil) : Lucky::TextResponse
-    send_text_response(body, "text/xml", status)
+  def xml(body : String, status : Int32? = nil, content_type : String = xml_content_type) : Lucky::TextResponse
+    send_text_response(body, content_type, status)
   end
 
-  def xml(body, status : HTTP::Status) : Lucky::TextResponse
-    xml(body, status: status.value)
+  def xml(body, status : HTTP::Status, content_type : String = xml_content_type) : Lucky::TextResponse
+    xml(body, status: status.value, content_type: content_type)
   end
 
   # Render a Component as an HTML response.
@@ -312,7 +332,7 @@ module Lucky::Renderable
   def component(comp : Lucky::BaseComponent.class, status : Int32? = nil, **named_args) : Lucky::TextResponse
     send_text_response(
       comp.new(**named_args).context(context).render_to_string,
-      "text/html",
+      html_content_type,
       status
     )
   end


### PR DESCRIPTION
## Purpose
Fixes #1580

## Description
This opens up a new escape hatch for setting the content type header on different responses like `json`, `xml` or `plain_text`. This also creates a new method that can be overridden at the individual action or base action to globally set your content type for each different response type you use. You always have the option to get real custom with `send_text_response` that requires setting your own custom content type.

I didn't a argument to `htrml` or `component` due to the named args that those take in. This would end up causing some conflicts similar to how the status worked for html.

I went with the method option here so you could have this set more globally scoped than if we did a block wrapper or functional style.

```crystal
class BrowserAction < Lucky::Action

  def html_content_type
    "your_custom_html_content_type"
  end
end
``` 

That issue also specified the server response status, but I figure since you can already set that, we may as well just leave that as is for now. This way at least gives us additional escape hatches to push towards 1.0

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
