### PR TITLE
chore(shard.yml): bump exception_page version

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -47,7 +47,7 @@ dependencies:
     version: ~> 0.4.3
   exception_page:
     github: crystal-loot/exception_page
-    version: ~> 0.2.2
+    version: ~> 0.3.0
   dexter:
     github: luckyframework/dexter
     version: ~> 0.3.4


### PR DESCRIPTION
removes javascript requirement