### PR TITLE
Make sure to check the arg type restrictions for the memoize.

### DIFF
--- a/src/lucky/memoizable.cr
+++ b/src/lucky/memoizable.cr
@@ -22,7 +22,7 @@ module Lucky::Memoizable
   macro memoize(method_def)
     {% raise "You must define a return type for memoized methods" if method_def.return_type.is_a?(Nop) %}
     {%
-      raise "All arguments must have an explicit type for memoized methods" if method_def.args.any? &.is_a?(Nop)
+      raise "All arguments must have an explicit type restriction for memoized methods" if method_def.args.any? &.restriction.is_a?(Nop)
     %}
 
     @__memoized_{{method_def.name}} : Tuple(


### PR DESCRIPTION
## Purpose
Fixes #1722 

## Description
A macro `Arg` uses the [restriction](https://crystal-lang.org/api/1.5.0/Crystal/Macros/Arg.html#restriction%3AASTNode%7CNop-instance-method) method to check if it's a `Nop`.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
