### PR TITLE
Adding new exec_raw escape hatch for ApiClient

### DIFF
--- a/spec/lucky/base_http_client_spec.cr
+++ b/spec/lucky/base_http_client_spec.cr
@@ -68,6 +68,36 @@ describe Lucky::BaseHTTPClient do
     end
   end
 
+  describe "exec_raw" do
+    describe "with Lucky::Action class" do
+      it "allows passing raw strings" do
+        test_data = <<-JSON
+          { "event_id": "1"}
+          { "type": "event"}
+          { "event_id": "2", "type": "event", "platform": ""}
+        JSON
+        response = MyClient.new.exec_raw(HelloWorldAction, test_data)
+
+        request = TestServer.last_request
+        request.body.not_nil!.gets_to_end.should eq(test_data)
+      end
+    end
+
+    describe "with a Lucky::RouteHelper" do
+      it "allows passing raw strings" do
+        test_data = <<-JSON
+          { "event_id": "1"}
+          { "type": "event"}
+          { "event_id": "2", "type": "event", "platform": ""}
+        JSON
+        response = MyClient.new.exec_raw(HelloWorldAction.route, test_data)
+
+        request = TestServer.last_request
+        request.body.not_nil!.gets_to_end.should eq(test_data)
+      end
+    end
+  end
+
   {% for method in [:put, :patch, :post, :delete, :get, :options] %}
     describe "\#{{method.id}}" do
       it "sends correct request to correct uri and gives the correct response" do

--- a/src/lucky/base_http_client.cr
+++ b/src/lucky/base_http_client.cr
@@ -101,6 +101,18 @@ abstract class Lucky::BaseHTTPClient
     @client.exec(method: route_helper.method.to_s.upcase, path: route_helper.path, body: params.to_json)
   end
 
+  # `exec_raw` works the same as `exec`, but allows you to pass in a raw string.
+  # This is used as an escape hatch as the `string` could be unsafe, or formatted
+  # in a custom format.
+  def exec_raw(action : Lucky::Action.class, body : String) : HTTP::Client::Response
+    exec_raw(action.route, body)
+  end
+
+  # See docs for `exec_raw`
+  def exec_raw(route_helper : Lucky::RouteHelper, body : String) : HTTP::Client::Response
+    @client.exec(method: route_helper.method.to_s.upcase, path: route_helper.path, body: body)
+  end
+
   {% for method in [:put, :patch, :post, :delete, :get, :options, :head] %}
     def {{ method.id }}(path : String, **params) : HTTP::Client::Response
       {{ method.id }}(path, params)


### PR DESCRIPTION
## Purpose
Fixes #1679

## Description
This adds a new escape hatch for your `ApiClient` `exec_raw` which allows you to send raw strings over. 

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
