### PR TITLE
Experimenting with optional vite integration. 

### DIFF
--- a/public/vite-manifest.json
+++ b/public/vite-manifest.json
@@ -1,0 +1,10 @@
+{
+  "src/images/lucky_logo.png": {
+    "file": "images/lucky_logo.a54cc67e.png",
+    "src": "src/images/lucky_logo.png"
+  },
+  "src/assets/js/app.js": {
+    "file": "assets/js/app.a54cc67e.js",
+    "src": "src/assets/js/app.js"
+  }
+}

--- a/spec/lucky/asset_helpers_spec.cr
+++ b/spec/lucky/asset_helpers_spec.cr
@@ -5,9 +5,12 @@ module Shared::ComponentWithAsset
     asset("images/logo.png")
   end
 
-  def dynamic_asset_inside_component
-    interpolated = "logo"
+  def dynamic_asset_inside_component(interpolated = "logo")
     dynamic_asset("images/#{interpolated}.png")
+  end
+
+  def vite_asset_inside_component
+    asset("images/lucky_logo.png")
   end
 end
 
@@ -23,18 +26,25 @@ private class TestPage
     asset("images/inside-assets-folder.png")
   end
 
-  def dynamic_asset_path
-    interpolated = "logo"
+  def dynamic_asset_path(interpolated = "logo")
     dynamic_asset("images/#{interpolated}.png")
   end
 
   def missing_dynamic_asset_path
     dynamic_asset("woops!.png")
   end
+
+  def asset_path_from_vite
+    asset("images/lucky_logo.png")
+  end
 end
 
 describe Lucky::AssetHelpers do
   describe "compile time asset helper" do
+    Spec.before_each do
+      Lucky::AssetHelpers.load_manifest("./public/mix-manifest.json")
+    end
+
     it "returns the fingerprinted path" do
       Lucky::AssetHelpers.asset("images/logo.png").should eq "/images/logo-with-hash.png"
     end
@@ -59,6 +69,10 @@ describe Lucky::AssetHelpers do
   end
 
   describe "dynamic asset helper" do
+    Spec.before_each do
+      Lucky::AssetHelpers.load_manifest("./public/mix-manifest.json")
+    end
+
     it "returns the fingerprinted path" do
       TestPage.new.dynamic_asset_path.should eq "/images/logo-with-hash.png"
     end
@@ -76,6 +90,50 @@ describe Lucky::AssetHelpers do
     it "prepends the asset_host configuration option" do
       Lucky::Server.temp_config(asset_host: "https://production.com") do
         TestPage.new.dynamic_asset_path.should eq "https://production.com/images/logo-with-hash.png"
+      end
+    end
+  end
+
+  describe "testing with vite manifest" do
+    Spec.before_each do
+      Lucky::AssetHelpers.load_manifest("./public/vite-manifest.json", use_vite: true)
+    end
+
+    it "returns the fingerprinted path" do
+      Lucky::AssetHelpers.asset("images/lucky_logo.png").should eq "/images/lucky_logo.a54cc67e.png"
+    end
+
+    it "works when included in another class" do
+      TestPage.new.asset_path_from_vite.should eq "/images/lucky_logo.a54cc67e.png"
+    end
+
+    it "works when used from an included module" do
+      TestPage.new.vite_asset_inside_component.should eq "/images/lucky_logo.a54cc67e.png"
+    end
+
+    it "prepends the asset_host configuration option" do
+      Lucky::Server.temp_config(asset_host: "https://production.com") do
+        TestPage.new.asset_path_from_vite.should eq "https://production.com/images/lucky_logo.a54cc67e.png"
+      end
+    end
+
+    it "returns the fingerprinted path" do
+      TestPage.new.dynamic_asset_path("lucky_logo").should eq "/images/lucky_logo.a54cc67e.png"
+    end
+
+    it "works inside included module" do
+      TestPage.new.dynamic_asset_inside_component("lucky_logo").should eq "/images/lucky_logo.a54cc67e.png"
+    end
+
+    it "raises a helpful error" do
+      expect_raises Exception, "Missing asset: woops!.png" do
+        TestPage.new.missing_dynamic_asset_path
+      end
+    end
+
+    it "prepends the asset_host configuration option" do
+      Lucky::Server.temp_config(asset_host: "https://production.com") do
+        TestPage.new.dynamic_asset_path("lucky_logo").should eq "https://production.com/images/lucky_logo.a54cc67e.png"
       end
     end
   end

--- a/spec/lucky/asset_helpers_spec.cr
+++ b/spec/lucky/asset_helpers_spec.cr
@@ -41,10 +41,6 @@ end
 
 describe Lucky::AssetHelpers do
   describe "compile time asset helper" do
-    Spec.before_each do
-      Lucky::AssetHelpers.load_manifest("./public/mix-manifest.json")
-    end
-
     it "returns the fingerprinted path" do
       Lucky::AssetHelpers.asset("images/logo.png").should eq "/images/logo-with-hash.png"
     end
@@ -69,10 +65,6 @@ describe Lucky::AssetHelpers do
   end
 
   describe "dynamic asset helper" do
-    Spec.before_each do
-      Lucky::AssetHelpers.load_manifest("./public/mix-manifest.json")
-    end
-
     it "returns the fingerprinted path" do
       TestPage.new.dynamic_asset_path.should eq "/images/logo-with-hash.png"
     end
@@ -95,10 +87,6 @@ describe Lucky::AssetHelpers do
   end
 
   describe "testing with vite manifest" do
-    Spec.before_each do
-      Lucky::AssetHelpers.load_manifest("./public/vite-manifest.json", use_vite: true)
-    end
-
     it "returns the fingerprinted path" do
       Lucky::AssetHelpers.asset("images/lucky_logo.png").should eq "/images/lucky_logo.a54cc67e.png"
     end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -7,7 +7,7 @@ include RoutesHelper
 
 Pulsar.enable_test_mode!
 
-Lucky::AssetHelpers.load_manifest
+# Lucky::AssetHelpers.load_manifest
 
 Spec.before_each do
   ARGV.clear

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -7,7 +7,8 @@ include RoutesHelper
 
 Pulsar.enable_test_mode!
 
-# Lucky::AssetHelpers.load_manifest
+Lucky::AssetHelpers.load_manifest
+Lucky::AssetHelpers.load_manifest("./public/vite-manifest.json", use_vite: true)
 
 Spec.before_each do
   ARGV.clear

--- a/src/lucky/asset_helpers.cr
+++ b/src/lucky/asset_helpers.cr
@@ -13,6 +13,13 @@ module Lucky::AssetHelpers
     {% CONFIG[:has_loaded_manifest] = true %}
   end
 
+  # EXPERIMENTAL: This feature is experimental. Use this to test
+  # vite integration with Lucky
+  macro load_manifest(manifest_file, use_vite)
+    {{ run "../run_macros/generate_asset_helpers", manifest_file, use_vite }}
+    {% CONFIG[:has_loaded_manifest] = true %}
+  end
+
   # Return the string path to an asset
   #
   # ```


### PR DESCRIPTION
## Purpose
Ref #1724

## Description
This is an experiment to test if we can keep mix integration while allowing for vite to be used optionally. In theory, you would just need to update your `load_manifest()` call to point to `./public/manifest.json`, and a second `use_vite: true` arg. The actual setup for [Vite](https://vitejs.dev/) would still need to be done, but you can use https://github.com/jwoertink/vite_lucky/ as a sort of reference.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
