### PR TITLE
Adding a spec to test #1591

### DIFF
--- a/spec/lucky/action_spec.cr
+++ b/spec/lucky/action_spec.cr
@@ -149,7 +149,8 @@ end
 
 class OptionalRouteParams::Index < TestAction
   get "/complex_posts/:required/?:optional_1/?:optional_2" do
-    plain_text "test"
+    opt = params.get?(:optional_1)
+    plain_text "test #{required} #{optional_1} #{optional_2} #{opt}"
   end
 end
 
@@ -374,6 +375,11 @@ describe Lucky::Action do
     it "uses a custom content_type for this plain action" do
       response = Tests::PlainActionWithCustomContentType.new(build_context, params).call
       response.content_type.should eq "very/plain; charset=utf-8"
+    end
+
+    it "renders with optional path params" do
+      response = OptionalRouteParams::Index.new(build_context("/complex_posts/1/2/3"), {"required" => "1", "optional_1" => "2", "optional_2" => "3"}).call
+      response.body.to_s.should eq("test 1 2 3 2")
     end
   end
 


### PR DESCRIPTION
## Purpose
Testing #1591 

## Description
In that issue there seemed to be some errors around using the optional path params in an action, but I've been unable to recreate it. This PR adds to existing specs to test this, but it seems specs pass. It's possible we fixed the error previously.... or the error could have been unrelated to Lucky directly (i.e. related to a different shard, or some code in that app)

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [ ] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [ ] - Lucky builds on docker with `./script/setup`
* [ ] - All builds and specs pass on docker with `./script/test`
