### PR TITLE
Better compile time error for link helper usage and actions that require params

### DIFF
--- a/spec/lucky/link_helpers_spec.cr
+++ b/spec/lucky/link_helpers_spec.cr
@@ -8,6 +8,10 @@ class LinkHelpers::Create < TestAction
   post "/link_helpers" { plain_text "foo" }
 end
 
+class LinkHelpers::Show < TestAction
+  get "/link_helpers/:id" { plain_text "foo" }
+end
+
 private class TestPage
   include Lucky::HTMLPage
 

--- a/src/lucky/html_builder.cr
+++ b/src/lucky/html_builder.cr
@@ -1,3 +1,4 @@
+require "./no_required_params_action"
 require "./tags/**"
 require "./page_helpers/**"
 require "./mount_component"

--- a/src/lucky/no_required_params_action.cr
+++ b/src/lucky/no_required_params_action.cr
@@ -1,0 +1,5 @@
+module Lucky::NoRequiredParamsAction
+  def route : Lucky::RouteHelper
+    Lucky::RouteHelper.new(method, path_from_parts).url
+  end
+end

--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -267,6 +267,10 @@ module Lucky::Routable
          params_with_defaults.includes? decl
        end %}
 
+    {% if path_params.empty? && params_without_defaults.empty? %}
+       extend Lucky::NoRequiredParamsAction
+    {% end %}
+
     def self.route(
     # required path variables
     {% for param in path_params %}

--- a/src/lucky/tags/link_helpers.cr
+++ b/src/lucky/tags/link_helpers.cr
@@ -34,17 +34,17 @@ module Lucky::LinkHelpers
     end
   end
 
-  def link(text, to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
+  def link(text, to : Lucky::NoRequiredParamsAction, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
     link(**html_options, to: to, attrs: attrs) do
       text text
     end
   end
 
-  def link(to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
+  def link(to : Lucky::NoRequiredParamsAction, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
     link(**html_options, to: to, attrs: attrs) { }
   end
 
-  def link(to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
+  def link(to : Lucky::NoRequiredParamsAction, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
     link(**html_options, to: to.route, attrs: attrs) do
       yield
     end
@@ -56,6 +56,34 @@ module Lucky::LinkHelpers
     else
       {"href" => route.path, "data_method" => route.method.to_s}
     end
+  end
+
+  def link(text, to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
+    {%
+      raise <<-ERROR
+      Looks like you are trying to pass in an action that needs params. Do better.
+
+      ERROR
+    %}
+  end
+
+  def link(to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
+    {%
+      raise <<-ERROR
+      Looks like you are trying to pass in an action that needs params. Do better.
+
+      ERROR
+    %}
+  end
+
+  def link(to : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
+    {%
+      raise <<-ERROR
+      Looks like you are trying to pass in an action that needs params. Do better.
+
+      ERROR
+    %}
+    yield
   end
 
   def link(text, to : String, attrs : Array(Symbol) = [] of Symbol, **html_options)


### PR DESCRIPTION
## Purpose

Fixes https://github.com/luckyframework/lucky/issues/1652

## Description

This is an attempt at making link helper compile time errors better when passing in a `Lucky::Action` that needs params.

<img width="628" alt="Screen Shot 2022-09-13 at 1 01 09 AM" src="https://user-images.githubusercontent.com/17329408/189821829-92f40e52-2d31-44e8-8e4d-1108a34d1e2d.png">'

🙏 It's really late. I got the code working, but I hope you can see that the error message is a joke at the moment. Please help me with that. I am even wondering if we can access the action class in the error message to print out what is required? That might be a stretch too far though. Another thing I didn't look into is if this is useful anywhere else. I'd check anywhere we currently use `Lucky::Action.class`
