### PR TITLE
Close the reponse after a redirect to avoid double redirects.

### DIFF
--- a/spec/lucky/action_redirect_spec.cr
+++ b/spec/lucky/action_redirect_spec.cr
@@ -150,9 +150,7 @@ describe Lucky::Action do
     action.redirect to: "/somewhere"
     should_redirect(action, to: "/somewhere", status: 302)
 
-    expect_raises(IO::Error) do
-      action.redirect to: "/somewhere-else"
-    end
+    action.context.response.closed?.should eq(true)
   end
 end
 

--- a/spec/lucky/action_redirect_spec.cr
+++ b/spec/lucky/action_redirect_spec.cr
@@ -144,6 +144,16 @@ describe Lucky::Action do
     flash = Lucky::FlashStore.from_session(response.context.session)
     flash.success.should eq("Keep me!")
   end
+
+  it "closes the response after a redirect" do
+    action = RedirectAction.new(build_context, params)
+    action.redirect to: "/somewhere"
+    should_redirect(action, to: "/somewhere", status: 302)
+
+    expect_raises(IO::Error) do
+      action.redirect to: "/somewhere-else"
+    end
+  end
 end
 
 private def should_redirect(action, to path, status)

--- a/src/lucky/redirectable.cr
+++ b/src/lucky/redirectable.cr
@@ -123,6 +123,7 @@ module Lucky::Redirectable
     flash.keep
     context.response.headers.add "Location", path
     context.response.status_code = status
+    context.response.close
     Lucky::TextResponse.new(context, "", "")
   end
 

--- a/src/lucky/redirectable_turbolinks_support.cr
+++ b/src/lucky/redirectable_turbolinks_support.cr
@@ -25,6 +25,7 @@ module Lucky::RedirectableTurbolinksSupport
       # ordinary redirect
       context.response.headers.add "Location", path
       context.response.status_code = status
+      context.response.close
       Lucky::TextResponse.new(context, "", "")
     end
   end


### PR DESCRIPTION
## Purpose
Fixes #1735 

## Description
Coming up in Crystal 1.7, HTTP response will have a redirect method built-in. That method calls `close` after setting the Location header. I think this might also fix this elusive bug https://forum.crystal-lang.org/t/help-solving-io-error/130 

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
