### PR TITLE
Remove default turbolinks support

### DIFF
--- a/spec/lucky/action_redirect_spec.cr
+++ b/spec/lucky/action_redirect_spec.cr
@@ -3,6 +3,8 @@ require "../spec_helper"
 include ContextHelper
 
 class RedirectAction < TestAction
+  include Lucky::RedirectableTurbolinksSupport
+
   get "/redirect_test" do
     plain_text "does not matter"
   end

--- a/src/lucky/action.cr
+++ b/src/lucky/action.cr
@@ -17,6 +17,5 @@ abstract class Lucky::Action
   include Lucky::ParamHelpers
   include Lucky::ActionPipes
   include Lucky::Redirectable
-  include Lucky::RedirectableTurbolinksSupport
   include Lucky::VerifyAcceptsFormat
 end


### PR DESCRIPTION
## Purpose
Ref: https://github.com/luckyframework/lucky_cli/issues/629

## Description
Starts the removal of Turbolinks support. Instead of including this module by default, you can just include it in your `BrowserAction` or whichever actions need Turbolinks support. 


