### PR TITLE
Revert #1736

### DIFF
--- a/spec/lucky/action_redirect_spec.cr
+++ b/spec/lucky/action_redirect_spec.cr
@@ -146,14 +146,6 @@ describe Lucky::Action do
     flash = Lucky::FlashStore.from_session(response.context.session)
     flash.success.should eq("Keep me!")
   end
-
-  it "closes the response after a redirect" do
-    action = RedirectAction.new(build_context, params)
-    action.redirect to: "/somewhere"
-    should_redirect(action, to: "/somewhere", status: 302)
-
-    action.context.response.closed?.should eq(true)
-  end
 end
 
 private def should_redirect(action, to path, status)

--- a/src/lucky/redirectable.cr
+++ b/src/lucky/redirectable.cr
@@ -123,7 +123,6 @@ module Lucky::Redirectable
     flash.keep
     context.response.headers.add "Location", path
     context.response.status_code = status
-    context.response.close
     Lucky::TextResponse.new(context, "", "")
   end
 

--- a/src/lucky/redirectable_turbolinks_support.cr
+++ b/src/lucky/redirectable_turbolinks_support.cr
@@ -25,7 +25,6 @@ module Lucky::RedirectableTurbolinksSupport
       # ordinary redirect
       context.response.headers.add "Location", path
       context.response.status_code = status
-      context.response.close
       Lucky::TextResponse.new(context, "", "")
     end
   end


### PR DESCRIPTION
The original PR's motivation was because I saw in [this PR](https://github.com/crystal-lang/crystal/pull/12526/files#diff-6a2414740a6a8fe92b941bc74760af6bb1dd5733ef9c8d7f4eb48bcaa2be78cbR192) the response was being closed after a redirect which made me wonder if [this error](https://forum.crystal-lang.org/t/help-solving-io-error/130) I always see in all of my Lucky apps was caused by this.

I originally tested it in the Lucky website, and it was fine. However, it turns out that when we do redirect after a POST/PATCH, we are trying to write to the response body *after* it's been closed. This made things like sign-in break :joy: (Lucky website probably isn't a good test box :grimacing: )

After talking with several people, and a bit of research, I found that Kemal closes the response conditionally, Athena always closes it, Amber never closes it, and neither does Lucky. It turns out that the Crystal HTTP server will close the response for you automatically, so there's no reason for us to do it.

https://github.com/crystal-lang/crystal/blob/b262838dee4d4a61a2b0c5d1a50a007f1dca1385/src/http/server/request_processor.cr#L63
