### PR TITLE
add attrs as parameter to submit helper

### DIFF
--- a/spec/lucky/form_helpers_spec.cr
+++ b/spec/lucky/form_helpers_spec.cr
@@ -130,6 +130,16 @@ describe Lucky::FormHelpers do
     <input type="submit" value="Save" class="cool">
     HTML
   end
+
+  it "renders submit input with attributes" do
+    view(&.submit("Save", attrs: [:disabled])).should contain <<-HTML
+    <input type="submit" value="Save" disabled>
+    HTML
+
+    view(&.submit("Save", class: "cool", attrs: [:hidden, :disabled])).should contain <<-HTML
+    <input type="submit" value="Save" class="cool" hidden disabled>
+    HTML
+  end
 end
 
 private def without_csrf_protection

--- a/src/lucky/tags/form_helpers.cr
+++ b/src/lucky/tags/form_helpers.cr
@@ -15,8 +15,8 @@ module Lucky::FormHelpers
     form_for action.route, attrs, **html_options, &block
   end
 
-  def submit(text : String, **html_options) : Nil
-    input merge_options(html_options, {"type" => "submit", "value" => text})
+  def submit(text : String, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
+    input attrs, merge_options(html_options, {"type" => "submit", "value" => text})
   end
 
   private def form_method(route) : String


### PR DESCRIPTION
## Purpose
Fixes #1758 

## Description
add `attrs` to submit helper, then it is passed down into the `input`

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
