### PR TITLE
Add macro to inline SVG files

### DIFF
--- a/spec/fixtures/lucky_logo.svg
+++ b/spec/fixtures/lucky_logo.svg
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- lucky logo -->
+<svg width="64" height="64" version="1.1" viewBox="0 0 16.933 16.933" xmlns="http://www.w3.org/2000/svg">
+  <g fill="none" stroke="#2a2a2a" class="logo">
+    <path d="m12.626 15.485h-8.3184a3.4546 3.4546 0 0 1-2.9917-5.1818l4.1592-7.2039a3.4546 3.4546 0 0 1 5.9835 0l4.1592 7.2039a3.4546 3.4546 0 0 1-2.9917 5.1818z" stroke-width="1"/>
+    <path d="m3.9846 15.469c1.6962-5.1849 4.804-10.023 7.1105-12.89" stroke-width="0.5"/>
+    <path d="m5.9305 15.47c1.4755-4.5103 4.179-8.7192 6.1854-11.213" stroke-width="0.5"/>
+  </g>
+</svg>

--- a/spec/lucky/text_helpers/svg_inliner_spec.cr
+++ b/spec/lucky/text_helpers/svg_inliner_spec.cr
@@ -1,0 +1,24 @@
+require "./text_helpers_spec"
+
+@[Lucky::SvgInliner::Path("spec/fixtures")]
+module Lucky::SvgInliner
+end
+
+class TextHelperTestPage
+  def with_inlined_svg
+    inline_svg("lucky_logo.svg")
+  end
+end
+
+describe Lucky::SvgInliner do
+  describe ".inline_svg" do
+    it "inlines an svg in a page" do
+      inlined_svg = view.tap(&.with_inlined_svg).render
+      inlined_svg.should start_with %(<svg data-inline-svg="lucky_logo.svg")
+      inlined_svg.should_not contain %(<?xml version="1.0" encoding="UTF-8"?>)
+      inlined_svg.should_not contain %(<!-- lucky logo -->)
+      inlined_svg.should_not contain "\n"
+      inlined_svg.should_not contain %(fill="none" stroke="#2a2a2a" class="logo")
+    end
+  end
+end

--- a/spec/lucky/text_helpers/svg_inliner_spec.cr
+++ b/spec/lucky/text_helpers/svg_inliner_spec.cr
@@ -8,6 +8,10 @@ class TextHelperTestPage
   def with_inlined_svg
     inline_svg("lucky_logo.svg")
   end
+
+  def with_inlined_and_styled_svg
+    inline_svg("lucky_logo.svg", false)
+  end
 end
 
 describe Lucky::SvgInliner do
@@ -19,6 +23,15 @@ describe Lucky::SvgInliner do
       inlined_svg.should_not contain %(<!-- lucky logo -->)
       inlined_svg.should_not contain "\n"
       inlined_svg.should_not contain %(fill="none" stroke="#2a2a2a" class="logo")
+    end
+
+    it "inlines an svg in a page with its original styling attributes" do
+      inlined_svg = view.tap(&.with_inlined_and_styled_svg).render
+      inlined_svg.should start_with %(<svg data-inline-svg-styled="lucky_logo.svg")
+      inlined_svg.should contain %(fill="none" stroke="#2a2a2a" class="logo")
+      inlined_svg.should_not contain %(<?xml version="1.0" encoding="UTF-8"?>)
+      inlined_svg.should_not contain %(<!-- lucky logo -->)
+      inlined_svg.should_not contain "\n"
     end
   end
 end

--- a/spec/lucky/text_helpers/svg_inliner_spec.cr
+++ b/spec/lucky/text_helpers/svg_inliner_spec.cr
@@ -25,13 +25,30 @@ describe Lucky::SvgInliner do
       inlined_svg.should_not contain %(fill="none" stroke="#2a2a2a" class="logo")
     end
 
-    it "inlines an svg in a page with its original styling attributes" do
+    it "strips the xml declaration" do
+      inlined_svg = view.tap(&.with_inlined_svg).render
+      inlined_svg.should_not contain %(<?xml version="1.0" encoding="UTF-8"?>)
+    end
+
+    it "strips comments" do
+      inlined_svg = view.tap(&.with_inlined_svg).render
+      inlined_svg.should_not contain %(<!-- lucky logo -->)
+    end
+
+    it "strips newlines" do
+      inlined_svg = view.tap(&.with_inlined_svg).render
+      inlined_svg.should_not contain "\n"
+    end
+
+    it "strips styling attributes by default" do
+      inlined_svg = view.tap(&.with_inlined_svg).render
+      inlined_svg.should_not contain %(fill="none" stroke="#2a2a2a" class="logo")
+    end
+
+    it "allows inlinging an svg without stripping its styling attributes" do
       inlined_svg = view.tap(&.with_inlined_and_styled_svg).render
       inlined_svg.should start_with %(<svg data-inline-svg-styled="lucky_logo.svg")
       inlined_svg.should contain %(fill="none" stroke="#2a2a2a" class="logo")
-      inlined_svg.should_not contain %(<?xml version="1.0" encoding="UTF-8"?>)
-      inlined_svg.should_not contain %(<!-- lucky logo -->)
-      inlined_svg.should_not contain "\n"
     end
   end
 end

--- a/src/lucky/html_builder.cr
+++ b/src/lucky/html_builder.cr
@@ -21,6 +21,7 @@ module Lucky::HTMLBuilder
   include Lucky::RenderIfDefined
   include Lucky::TagDefaults
   include Lucky::LiveReloadTag
+  include Lucky::SvgInliner
 
   abstract def view : IO
 

--- a/src/lucky/page_helpers/svg_inliner.cr
+++ b/src/lucky/page_helpers/svg_inliner.cr
@@ -19,8 +19,9 @@ module Lucky::SvgInliner
         .gsub(/<!--[^>]+>/, "")
         .gsub(/\n\s*/, "")
       svg = svg.gsub(regex, "") if strip_styling
+      modifier = strip_styling ? "" : "-styled"
     %}
 
-    raw {{svg.gsub(/<svg/, %(<svg data-inline-svg="#{path.id}"))}}
+    raw {{svg.gsub(/<svg/, %(<svg data-inline-svg#{modifier.id}="#{path.id}"))}}
   end
 end

--- a/src/lucky/page_helpers/svg_inliner.cr
+++ b/src/lucky/page_helpers/svg_inliner.cr
@@ -18,6 +18,7 @@ module Lucky::SvgInliner
         .gsub(/<\?xml[^>]+>/, "")
         .gsub(/<!--[^>]+>/, "")
         .gsub(/\n\s*/, " ")
+        .strip
       svg = svg.gsub(regex, "") if strip_styling
       modifier = strip_styling ? "" : "-styled"
     %}

--- a/src/lucky/page_helpers/svg_inliner.cr
+++ b/src/lucky/page_helpers/svg_inliner.cr
@@ -17,7 +17,7 @@ module Lucky::SvgInliner
       svg = read_file(full_path)
         .gsub(/<\?xml[^>]+>/, "")
         .gsub(/<!--[^>]+>/, "")
-        .gsub(/\n\s*/, "")
+        .gsub(/\n\s*/, " ")
       svg = svg.gsub(regex, "") if strip_styling
       modifier = strip_styling ? "" : "-styled"
     %}

--- a/src/lucky/page_helpers/svg_inliner.cr
+++ b/src/lucky/page_helpers/svg_inliner.cr
@@ -1,0 +1,26 @@
+annotation Lucky::SvgInliner::Path
+end
+annotation Lucky::SvgInliner::StripRegex
+end
+
+@[Lucky::SvgInliner::Path("src/svgs")]
+@[Lucky::SvgInliner::StripRegex(/(class|fill|stroke|stroke-width|style)="[^"]+" ?/)]
+module Lucky::SvgInliner
+  macro inline_svg(path, strip_styling = true)
+    {%
+      svgs_path = Lucky::SvgInliner.annotation(Lucky::SvgInliner::Path).args.first
+      regex = Lucky::SvgInliner.annotation(Lucky::SvgInliner::StripRegex).args.first
+      full_path = "#{svgs_path.id}/#{path.id}"
+
+      raise "SVG file #{full_path.id} is missing" unless file_exists?(full_path)
+
+      svg = read_file(full_path)
+        .gsub(/<\?xml[^>]+>/, "")
+        .gsub(/<!--[^>]+>/, "")
+        .gsub(/\n\s*/, "")
+      svg = svg.gsub(regex, "") if strip_styling
+    %}
+
+    raw {{svg.gsub(/<svg/, %(<svg data-inline-svg="#{path.id}"))}}
+  end
+end


### PR DESCRIPTION
## Purpose
Adds a macro to inline SVG files at compile time.

## Description
SVG logos and icons can be inlined with the `inline_svg` macro in pages and components:

```crystal
button
  inline_svg("buttons/round.svg")
end
```
This will:
- inline the SVG file from `src/svgs` at compile-time (path configurable with an annotation)
- strip the XML declaration, comments newlines and superfluous whitespace
- optionally (and by default) strip styling attributes so the icons can be styled with CSS (also configurable with an annotation)
- raise a compile-time exception when an SVG file is missing
- add a `data-inline-svg` attribute with the path of the icon (e.g. `<svg data-inline-svg="buttons/round.svg">`)

Icons can then be styled with:

```css
[data-inline-svg] {
  fill: none;
  stroke: #222;
  stroke-width: 2px;
}
```

Or:

```css
[data-inline-svg="buttons/round.svg"] {
  fill: #f03;
}
```

I realise Lucky does not use annotations a lot, but I think they are helpful in this case. The settings defined by the annotations are reasonable defaults, I think, but if necessary, users can jump in and override the defaults.

This PR implements #1760.

## Checklist
* [X] - An issue already exists detailing the issue/or feature request that this PR fixes
* [X] - All specs are formatted with `crystal tool format spec src`
* [X] - Inline documentation has been added and/or updated
* [X] - Lucky builds on docker with `./script/setup`
* [X] - All builds and specs pass on docker with `./script/test`
