### PR TITLE
don't capture blocks in the tags so you can still make custom wrapper…

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -61,7 +61,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.2.0
+    version: ~> 1.1.0
 
 scripts:
   postinstall: BUILD_WITHOUT_DEVELOPMENT=true script/precompile_tasks

--- a/shard.yml
+++ b/shard.yml
@@ -61,7 +61,7 @@ dependencies:
 development_dependencies:
   ameba:
     github: crystal-ameba/ameba
-    version: ~> 1.1.0
+    version: ~> 1.2.0
 
 scripts:
   postinstall: BUILD_WITHOUT_DEVELOPMENT=true script/precompile_tasks

--- a/spec/lucky/form_helpers_spec.cr
+++ b/spec/lucky/form_helpers_spec.cr
@@ -61,6 +61,12 @@ private class TestPage
       text "foo"
     end
   end
+
+  def form_wrapper(action : Lucky::Action.class)
+    form_for action do
+      yield
+    end
+  end
 end
 
 describe Lucky::FormHelpers do
@@ -94,6 +100,16 @@ describe Lucky::FormHelpers do
 
       view(&.form_with_bool_attr).should contain <<-HTML
       <form action="/form_helpers" method="post" class="even-cooler-form" novalidate>foo</form>
+      HTML
+
+      form = view do |page|
+        page.form_wrapper(FormHelpers::Create) do
+          page.text("purple")
+        end
+      end
+
+      form.should contain <<-HTML
+      <form action="/form_helpers" method="post">purple</form>
       HTML
     end
   end

--- a/src/lucky/action_pipes.cr
+++ b/src/lucky/action_pipes.cr
@@ -24,13 +24,13 @@ module Lucky::ActionPipes
 
   # :nodoc:
   macro included
-    AFTER_PIPES = [] of Symbol
-    BEFORE_PIPES = [] of Symbol
+    AFTER_PIPES   = [] of Symbol
+    BEFORE_PIPES  = [] of Symbol
     SKIPPED_PIPES = [] of Symbol
 
     macro inherited
-      AFTER_PIPES = [] of Symbol
-      BEFORE_PIPES = [] of Symbol
+      AFTER_PIPES   = [] of Symbol
+      BEFORE_PIPES  = [] of Symbol
       SKIPPED_PIPES = [] of Symbol
 
       inherit_pipes

--- a/src/lucky/tags/base_tags.cr
+++ b/src/lucky/tags/base_tags.cr
@@ -172,7 +172,7 @@ module Lucky::BaseTags
       {{ method_name.id }}("", options, **other_options)
     end
 
-    def {{method_name.id}}(options = EMPTY_HTML_ATTRS, **other_options, &block) : Nil
+    def {{method_name.id}}(options = EMPTY_HTML_ATTRS, **other_options) : Nil
       merged_options = merge_options(other_options, options)
       tag_attrs = build_tag_attrs(merged_options)
       view << "<{{tag.id}}" << tag_attrs << ">"
@@ -180,7 +180,7 @@ module Lucky::BaseTags
       view << "</{{tag.id}}>"
     end
 
-    def {{method_name.id}}(attrs : Array(Symbol), options = EMPTY_HTML_ATTRS, **other_options, &block) : Nil
+    def {{method_name.id}}(attrs : Array(Symbol), options = EMPTY_HTML_ATTRS, **other_options) : Nil
       boolean_attrs = build_boolean_attrs(attrs)
       merged_options = merge_options(other_options, options)
       tag_attrs = build_tag_attrs(merged_options)
@@ -189,7 +189,7 @@ module Lucky::BaseTags
       view << "</{{tag.id}}>"
     end
 
-    def {{method_name.id}}(&block) : Nil
+    def {{method_name.id}} : Nil
       view << "<{{tag.id}}>"
       check_tag_content!(yield)
       view << "</{{tag.id}}>"

--- a/src/lucky/tags/custom_tags.cr
+++ b/src/lucky/tags/custom_tags.cr
@@ -24,7 +24,7 @@ module Lucky::CustomTags
     tag(tag_name, "", options, **other_options)
   end
 
-  def tag(tag_name : String, attrs : Array(Symbol) = [] of Symbol, options = EMPTY_HTML_ATTRS, **other_options, &block) : Nil
+  def tag(tag_name : String, attrs : Array(Symbol) = [] of Symbol, options = EMPTY_HTML_ATTRS, **other_options) : Nil
     merged_options = merge_options(other_options, options)
     tag_attrs = build_tag_attrs(merged_options)
     boolean_attrs = build_boolean_attrs(attrs)

--- a/src/lucky/tags/form_helpers.cr
+++ b/src/lucky/tags/form_helpers.cr
@@ -11,8 +11,10 @@ module Lucky::FormHelpers
     end
   end
 
-  def form_for(route action : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options, &block) : Nil
-    form_for action.route, attrs, **html_options, &block
+  def form_for(route action : Lucky::Action.class, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil
+    form_for action.route, attrs, **html_options do
+      yield
+    end
   end
 
   def submit(text : String, attrs : Array(Symbol) = [] of Symbol, **html_options) : Nil


### PR DESCRIPTION
## Purpose
Fixes #1755

## Description
Stops capturing blocks when passing down method overloads so you can create your own custom wrapper around some elements.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
