### PR TITLE
No longer need the SkipUniqueRoute check. 

### DIFF
--- a/src/lucky/action_pipes.cr
+++ b/src/lucky/action_pipes.cr
@@ -24,13 +24,13 @@ module Lucky::ActionPipes
 
   # :nodoc:
   macro included
-    AFTER_PIPES = [] of Symbol
-    BEFORE_PIPES = [] of Symbol
+    AFTER_PIPES   = [] of Symbol
+    BEFORE_PIPES  = [] of Symbol
     SKIPPED_PIPES = [] of Symbol
 
     macro inherited
-      AFTER_PIPES = [] of Symbol
-      BEFORE_PIPES = [] of Symbol
+      AFTER_PIPES   = [] of Symbol
+      BEFORE_PIPES  = [] of Symbol
       SKIPPED_PIPES = [] of Symbol
 
       inherit_pipes

--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -136,14 +136,7 @@ module Lucky::Routable
       Try this...
 
         ▸ Change the paths in one of the actions to something unique
-
-      Or, skip the uniqueness check
-
-          # Only do this if you are sure the route is unique
-          class #{@type.name}
-        +  include Lucky::SkipUniqueRouteCheck
-          end
-
+        ▸ Run `lucky routes` to verify all of your route paths
 
       ERROR
       %}

--- a/src/lucky/skip_unique_route_check.cr
+++ b/src/lucky/skip_unique_route_check.cr
@@ -1,6 +1,0 @@
-# Include this in an action to skip route uniqueness checks.
-module Lucky::SkipUniqueRouteCheck
-  macro enforce_route_uniqueness(*args, **named_args)
-    # no-op
-  end
-end


### PR DESCRIPTION
## Purpose
Fixes #1541

## Description
We added a compile-time check for route uniqueness, and used this as an escape hatch; however, the LuckyRouter does a runtime unique check too, so you don't actually get an escape hatch here. 

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
