### PR TITLE
Allow for customizing what files get watched in local dev

### DIFF
--- a/src/lucky/server_settings.cr
+++ b/src/lucky/server_settings.cr
@@ -5,20 +5,35 @@ module Lucky::ServerSettings
 
   extend self
 
+  # The host for your local development.
+  # Depending on your setup, you may need `localhost`, `127.0.0.1`, or `0.0.0.0`
   def host : String
     settings["host"].as_s
   end
 
+  # The port to run your local dev server
   def port : Int32
     ENV["DEV_PORT"]?.try(&.to_i) || settings["port"].as_i
   end
 
+  # This is the port the dev watcher service will run on
   def reload_port : Int32
     ENV["RELOAD_PORT"]?.try(&.to_i) || settings["reload_port"]?.try(&.as_i) || 3001
   end
 
-  private def settings
-    YAML.parse(yaml_settings_file)
+  # Watch additional paths for changes
+  def reload_watch_paths : Array(String)
+    settings["extra_watch_paths"]?.try(&.as_a.map(&.as_s)) || [] of String
+  end
+
+  @@__settings : YAML::Any? = nil
+
+  private def settings : YAML::Any
+    if @@__settings.nil?
+      @@__settings = YAML.parse(yaml_settings_file)
+    else
+      @@__settings.as(YAML::Any)
+    end
   end
 
   private def yaml_settings_file

--- a/tasks/watch.cr
+++ b/tasks/watch.cr
@@ -325,13 +325,13 @@ class Watch < LuckyTask::Task
       when "sse"
         build_commands << "-Dlivereloadsse"
         watcher_class = LuckySentry::ServerSentEventWatcher.new
-        files.push("./public/css/**/*.css", "./public/js/**/*.js")
+        files.concat(Lucky::ServerSettings.reload_watch_paths)
       when "browsersync"
         watcher_class = LuckySentry::BrowsersyncWatcher.new
       else
         build_commands << "-Dlivereloadws"
         watcher_class = LuckySentry::WebSocketWatcher.new
-        files.push("./public/css/**/*.css", "./public/js/**/*.js")
+        files.concat(Lucky::ServerSettings.reload_watch_paths)
       end
     end
 


### PR DESCRIPTION
## Purpose
Fixes #1747
Fixes #920

## Description
Currently, if you use the websocket or SSE watchers, any changes made to your JS or CSS will fire off a recompile of the crystal side. Depending on what you use for your `yarn watch` command, this may already be happening through your js dev server anyway. This PR adds a way to customize this. If you want to watch your css and js in this manner, then you still can.

```yaml
# config/watch.yml
host: 127.0.0.1
port: 3000
reload_port: 3001
extra_watch_paths:
  - ./public/css/**/*.css
  - ./public/js/**/*.js
```

This would also allow you to watch other files as well.


## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
