### PR TITLE
Adding in the specific host for the watcher.

### DIFF
--- a/tasks/watch.cr
+++ b/tasks/watch.cr
@@ -34,7 +34,7 @@ module LuckySentry
     end
 
     def start : Nil
-      @server.bind_tcp Lucky::ServerSettings.reload_port
+      @server.bind_tcp(Lucky::ServerSettings.host, Lucky::ServerSettings.reload_port)
       spawn { @server.listen }
     end
 
@@ -80,7 +80,7 @@ module LuckySentry
     end
 
     def start : Nil
-      @server.bind_tcp Lucky::ServerSettings.reload_port
+      @server.bind_tcp(Lucky::ServerSettings.host, Lucky::ServerSettings.reload_port)
       spawn { @server.listen }
     end
 


### PR DESCRIPTION
## Purpose
Fixes #1785

## Description
Crystal's `bind_tcp` will always default to 127.0.0.1 when no host is specified https://crystal-lang.org/api/1.7.3/HTTP/Server.html#bind_tcp%28port%3AInt32%2Creuse_port%3ABool%3Dfalse%29%3ASocket%3A%3AIPAddress-instance-method

If you change your host to say 0.0.0.0, the watcher will continue to try and run on 127 which may fail if you're running in Docker.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
