### PR TITLE
ENV to override the server host

### DIFF
--- a/src/lucky/server_settings.cr
+++ b/src/lucky/server_settings.cr
@@ -8,7 +8,7 @@ module Lucky::ServerSettings
   # The host for your local development.
   # Depending on your setup, you may need `localhost`, `127.0.0.1`, or `0.0.0.0`
   def host : String
-    settings["host"].as_s
+    ENV["DEV_HOST"]? || settings["host"].as_s
   end
 
   # The port to run your local dev server


### PR DESCRIPTION
## Purpose
Fixes #1787

## Description
This adds the option to override the server host by using an ENV. We've had the ability to do this for the PORT for a while now, so it made sense to add host too.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
