### PR TITLE
Fixing memoized methods using external arg names.

### DIFF
--- a/spec/lucky/memoize_spec.cr
+++ b/spec/lucky/memoize_spec.cr
@@ -35,6 +35,10 @@ private class ObjectWithMemoizedMethods
     @times_method_5_called += 1
     "Boom!"
   end
+
+  memoize def method_6(for string : String) : String
+    string.upcase
+  end
 end
 
 describe "memoizations" do
@@ -124,5 +128,12 @@ describe "memoizations" do
     object.method_5__uncached!.should eq("Boom!")
     object.method_5__uncached!.should eq("Boom!")
     object.times_method_5_called.should eq(3)
+  end
+
+  it "allows for external arg names" do
+    object = ObjectWithMemoizedMethods.new
+
+    object.method_6("boom").should eq("BOOM")
+    object.method_6(for: "memoize").should eq("MEMOIZE")
   end
 end


### PR DESCRIPTION
## Purpose
Fixes #1814

## Description
When you memoize a method that uses external arg names like `foo(out in : String) : String` it currently doesn't compile. This PR fixes that. 

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
