### PR TITLE
Refactor Browser and Page tasks. Added new --with-page flag

### DIFF
--- a/spec/support/generator_helper.cr
+++ b/spec/support/generator_helper.cr
@@ -1,4 +1,11 @@
 module GeneratorHelper
+  private def generate(generator : Class, args : Array(String) = [] of String) : IO
+    task = generator.new
+    task.output = IO::Memory.new
+    task.print_help_or_call(args: args)
+    task.output
+  end
+
   private def should_create_files_with_contents(io : IO, **files_and_contents)
     files_and_contents.each do |file_location, file_contents|
       File.read(file_location.to_s).should contain(file_contents)
@@ -14,5 +21,9 @@ module GeneratorHelper
     filename = Dir.new("./db/migrations").find(&.ends_with?(name))
     filename.should_not be_nil
     File.read("./db/migrations/#{filename}").should contain(content)
+  end
+
+  private def should_have_generated(text : String, inside : String)
+    File.read(inside).should contain(text)
   end
 end

--- a/spec/tasks/gen/action_spec.cr
+++ b/spec/tasks/gen/action_spec.cr
@@ -7,7 +7,7 @@ describe Gen::Action do
   it "generates a basic browser action" do
     with_cleanup do
       valid_action_name = "Users::Index"
-      io = generate valid_action_name, Gen::Action::Browser
+      io = generate Gen::Action::Browser, args: [valid_action_name]
 
       filename = "./src/actions/users/index.cr"
       should_have_generated "#{valid_action_name} < BrowserAction", inside: filename
@@ -17,10 +17,42 @@ describe Gen::Action do
     end
   end
 
+  describe "with_page" do
+    it "generates the action and a page for Browser action" do
+      with_cleanup do
+        valid_action_name = "Users::Index"
+        io = generate Gen::Action::Browser, args: [valid_action_name, "--with-page"]
+
+        action_filename = "./src/actions/users/index.cr"
+        page_filename = "./src/pages/users/index_page.cr"
+        should_have_generated "#{valid_action_name} < BrowserAction", inside: action_filename
+        should_have_generated "#{valid_action_name}Page < MainLayout", inside: page_filename
+
+        io.to_s.should contain(valid_action_name)
+        io.to_s.should contain("/src/actions/users")
+        io.to_s.should contain("/src/pages/users")
+      end
+    end
+
+    it "does not generate a page for Api action" do
+      with_cleanup do
+        valid_action_name = "Users::Index"
+        io = generate Gen::Action::Api, args: [valid_action_name, "--with-page"]
+
+        filename = "./src/actions/api/users/index.cr"
+        should_have_generated "#{valid_action_name} < ApiAction", inside: filename
+
+        io.to_s.should contain(valid_action_name)
+        io.to_s.should contain("/src/actions/api/users")
+        io.to_s.should contain("No page generated for ApiActions")
+      end
+    end
+  end
+
   it "generates a basic api action" do
     with_cleanup do
       valid_action_name = "Users::Index"
-      io = generate valid_action_name, Gen::Action::Api
+      io = generate Gen::Action::Api, args: [valid_action_name]
 
       filename = "./src/actions/api/users/index.cr"
       should_have_generated "#{valid_action_name} < ApiAction", inside: filename
@@ -33,7 +65,7 @@ describe Gen::Action do
   it "generates nested browser and api actions" do
     with_cleanup do
       valid_nested_action_name = "Users::Announcements::Index"
-      io = generate valid_nested_action_name, Gen::Action::Browser
+      io = generate Gen::Action::Browser, args: [valid_nested_action_name]
 
       filename = "src/actions/users/announcements/index.cr"
       should_have_generated "#{valid_nested_action_name} < BrowserAction", inside: filename
@@ -45,7 +77,7 @@ describe Gen::Action do
 
     with_cleanup do
       valid_nested_action_name = "Users::Announcements::Index"
-      io = generate valid_nested_action_name, Gen::Action::Api
+      io = generate Gen::Action::Api, args: [valid_nested_action_name]
 
       filename = "src/actions/api/users/announcements/index.cr"
       should_have_generated "#{valid_nested_action_name} < ApiAction", inside: filename
@@ -56,33 +88,22 @@ describe Gen::Action do
   end
 
   it "fails if called with non-resourceful action name" do
-    io = generate "Users::HostedEvents", Gen::Action::Browser
+    io = generate Gen::Action::Browser, args: ["Users::HostedEvents"]
 
     io.to_s.should contain "Could not infer route for Users::HostedEvents"
   end
 
-  it "displays an error if given no arguments" do
-    io = generate nil, Gen::Action::Browser
-
-    io.to_s.should contain("Action name is required.")
+  it "raises an error if given no arguments" do
+    expect_raises(Exception, /action_name is required/) do
+      generate Gen::Action::Browser
+    end
   end
 
   it "displays an error if given only one class" do
     with_cleanup do
-      io = generate "Users", Gen::Action::Browser
+      io = generate Gen::Action::Browser, args: ["Users"]
 
       io.to_s.should contain("That's not a valid Action.")
     end
   end
-end
-
-private def generate(name, generator : Class)
-  ARGV.push(name) if name
-  io = IO::Memory.new
-  generator.new.call(io)
-  io
-end
-
-private def should_have_generated(text, inside)
-  File.read(inside).should contain(text)
 end

--- a/spec/tasks/gen/page_spec.cr
+++ b/spec/tasks/gen/page_spec.cr
@@ -6,11 +6,8 @@ include GeneratorHelper
 describe Gen::Page do
   it "generates a page" do
     with_cleanup do
-      io = IO::Memory.new
       valid_page_name = "Users::IndexPage"
-      ARGV.push(valid_page_name)
-
-      Gen::Page.new.call(io)
+      io = generate Gen::Page, args: [valid_page_name]
 
       should_create_files_with_contents io,
         "./src/pages/users/index_page.cr": valid_page_name
@@ -19,11 +16,8 @@ describe Gen::Page do
 
   it "generates a root page" do
     with_cleanup do
-      io = IO::Memory.new
       valid_page_name = "::IndexPage"
-      ARGV.push(valid_page_name)
-
-      Gen::Page.new.call(io)
+      io = generate Gen::Page, args: [valid_page_name]
 
       should_create_files_with_contents io,
         "./src/pages/index_page.cr": valid_page_name
@@ -31,20 +25,15 @@ describe Gen::Page do
   end
 
   it "displays an error if given no arguments" do
-    io = IO::Memory.new
-
-    Gen::Page.new.call(io)
-
-    io.to_s.should contain("Page name is required.")
+    expect_raises(Exception, /page_class is required/) do
+      generate Gen::Page
+    end
   end
 
   it "displays an error if given only one class" do
     with_cleanup do
-      io = IO::Memory.new
       invalid_page_name = "Users"
-      ARGV.push(invalid_page_name)
-
-      Gen::Page.new.call(io)
+      io = generate Gen::Page, args: [invalid_page_name]
 
       io.to_s.should contain("That's not a valid Page.")
     end
@@ -52,11 +41,8 @@ describe Gen::Page do
 
   it "displays an error if missing ending 'Page'" do
     with_cleanup do
-      io = IO::Memory.new
       invalid_page_name = "Users::Index"
-      ARGV.push(invalid_page_name)
-
-      Gen::Page.new.call(io)
+      io = generate Gen::Page, args: [invalid_page_name]
 
       io.to_s.should contain("That's not a valid Page.")
     end

--- a/tasks/gen/action/action_generator.cr
+++ b/tasks/gen/action/action_generator.cr
@@ -31,12 +31,12 @@ module Gen::ActionGenerator
 
   private def name_is_present
     @error = "Action name is required. Example: lucky gen.action Users::Index"
-    ARGV.first?
+    action_name.presence
   end
 
   private def name_matches_format
     @error = "That's not a valid Action. Example: lucky gen.action Users::Index"
-    ARGV.first.includes?("::")
+    action_name.includes?("::")
   end
 
   private def route_generated_from_action_name
@@ -51,10 +51,6 @@ module Gen::ActionGenerator
 
   private def route
     @route ||= Lucky::RouteInferrer.new(action_class_name: action_name).generate_inferred_route
-  end
-
-  private def action_name
-    ARGV.first
   end
 
   private def action

--- a/tasks/gen/action/api.cr
+++ b/tasks/gen/action/api.cr
@@ -6,6 +6,9 @@ class Gen::Action::Api < LuckyTask::Task
 
   summary "Generate a new api action"
 
+  positional_arg :action_name, "The name of the action"
+  switch :with_page, "This flag is used with gen.action.browser Only"
+
   def help_message
     <<-TEXT
     #{summary}
@@ -16,12 +19,15 @@ class Gen::Action::Api < LuckyTask::Task
     TEXT
   end
 
-  def call(io : IO = STDOUT)
-    render_action_template(io, inherit_from: "ApiAction")
+  def call
+    render_action_template(output, inherit_from: "ApiAction")
+    if with_page?
+      output.puts "No page generated for ApiActions".colorize.red
+    end
   end
 
   private def action_name
-    name = ARGV.first
+    name = previous_def
     if name.downcase.starts_with?("api")
       name
     else

--- a/tasks/gen/action/browser.cr
+++ b/tasks/gen/action/browser.cr
@@ -7,6 +7,9 @@ class Gen::Action::Browser < LuckyTask::Task
 
   summary "Generate a new browser action"
 
+  positional_arg :action_name, "The name of the action"
+  switch :with_page, "Generate a Page matching this Action"
+
   def help_message
     <<-TEXT
     #{summary}
@@ -17,7 +20,12 @@ class Gen::Action::Browser < LuckyTask::Task
     TEXT
   end
 
-  def call(io : IO = STDOUT)
-    render_action_template(io, inherit_from: "BrowserAction")
+  def call
+    render_action_template(output, inherit_from: "BrowserAction")
+    if with_page?
+      page_task = Gen::Page.new
+      page_task.output = output
+      page_task.print_help_or_call(args: ["#{action_name}Page"])
+    end
   end
 end

--- a/tasks/gen/page.cr
+++ b/tasks/gen/page.cr
@@ -17,12 +17,14 @@ end
 class Gen::Page < LuckyTask::Task
   summary "Generate a new HTML page"
 
-  def call(io : IO = STDOUT)
+  positional_arg :page_class, "The name of the page"
+
+  def call
     if error
-      io.puts error.colorize(:red)
+      output.puts error.colorize(:red)
     else
       Lucky::PageTemplate.new(page_filename, page_class, output_path).render(output_path)
-      io.puts success_message
+      output.puts success_message
     end
   end
 
@@ -41,7 +43,7 @@ class Gen::Page < LuckyTask::Task
   end
 
   private def missing_name_error
-    if ARGV.first?.nil?
+    if page_class.nil?
       "Page name is required."
     end
   end
@@ -50,10 +52,6 @@ class Gen::Page < LuckyTask::Task
     if !page_class.includes?("::") || !page_class.ends_with?("Page")
       "That's not a valid Page. Example: lucky gen.page Users::IndexPage"
     end
-  end
-
-  private def page_class
-    ARGV.first
   end
 
   private def page_filename


### PR DESCRIPTION
## Purpose
Fixes #1795

## Description
This adds in a new `--with-page` CLI flag for the Browser action generator that allows you to generate a page along with the action. 

```
lucky gen.action.browser Reports::Index --with-page
```

In order to do this, I had to refactor both the action and the page tasks (https://github.com/luckyframework/lucky/issues/1247) just a bit. 

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
