### PR TITLE
Add config property to silence exception stacktraces from logs

### DIFF
--- a/src/lucky/error_handler.cr
+++ b/src/lucky/error_handler.cr
@@ -3,6 +3,7 @@ class Lucky::ErrorHandler
 
   Habitat.create do
     setting show_debug_output : Bool
+    setting log_error_exception : Bool = true
   end
 
   private getter action
@@ -17,7 +18,7 @@ class Lucky::ErrorHandler
   end
 
   private def call_error_action(context : HTTP::Server::Context, error : Exception) : HTTP::Server::Context
-    Lucky::Log.error(exception: error) { "" }
+    Lucky::Log.error(exception: error) { "" } if settings.log_error_exception
     action.new(context).perform_action(error)
     context
   end


### PR DESCRIPTION
## Purpose
Fixes #1768

## Description
This gives you a new property to allow you to silence the exception stacktraces from your logs without having to tune down all of your logs. This may be a great option if you ship off your bugs where you'd read the stacktrace elsewhere.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
