### PR TITLE
small performance improvement when generating a route url.

### DIFF
--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -338,7 +338,6 @@ module Lucky::Routable
       \{% end %}
     end
 
-
     private def self.path_from_parts(
         {% for param in path_params %}
           {{ param.gsub(/:/, "").id }},
@@ -351,22 +350,20 @@ module Lucky::Routable
         {% for part in path_parts %}
           {% if part.starts_with?("?:") %}
             if {{ part.gsub(/^\?:/, "").id }}
-              path << "/"
-              path << URI.encode_www_form({{ part.gsub(/^\?:/, "").id }}.to_param)
+              path << '/'
+              URI.encode_www_form({{ part.gsub(/^\?:/, "").id }}.to_param, path)
             end
           {% elsif part.starts_with?(':') %}
-            path << "/"
-            path << URI.encode_www_form({{ part.gsub(/:/, "").id }}.to_param)
+            path << '/'
+            URI.encode_www_form({{ part.gsub(/:/, "").id }}.to_param, path)
           {% else %}
-            path << "/"
-            path << URI.encode_www_form({{ part }})
+            path << '/'
+            URI.encode_www_form({{ part }}, path)
           {% end %}
         {% end %}
       end
 
-      is_root_path = path == ""
-      path = "/" if is_root_path
-      path
+      path.presence || "/"
     end
   end
 


### PR DESCRIPTION
## Purpose
Ref #1827

## Description
Still investigating what can be done on #1827 for a bit more speed. I don't think we can match the performance of returning a raw string in an action, but little bits like this might help get it closer. This PR utilizes a method overload for `encode_www_form` that takes an IO to reduce the allocations. Here's a benchmark:

```
old 563.31  (  1.78ms) (± 0.65%)  7.17MB/op   1.54× slower
new 866.54  (  1.15ms) (± 0.95%)  3.37MB/op        fastest
```

This is from generating 10k URLs using `Users::Show.with(1).url`

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
