### PR TITLE
Fix documented Avram version for lucky 1.1.0

### DIFF
--- a/UPGRADE_NOTES.md
+++ b/UPGRADE_NOTES.md
@@ -18,7 +18,7 @@ brew upgrade lucky
 - Update versions in `shard.yml`
   - Lucky should be `~> 1.1.0`
   - Avram should be `~> 1.1.0`
-  - Authentic should be `~> 1.1.0`
+  - Authentic should be `~> 1.0.0`
   - Carbon should be `~> 0.4.0`
   - LuckyTask should be `~> 0.3.0`
   - LuckyFlow should be `~> 0.9.2`


### PR DESCRIPTION
As I upgraded to lucky 1.1.0 I followed these instructions and ran into this error from shards:

```
Unable to satisfy the following requirements:

- `authentic (~> 1.1.0)` required by `shard.yml` Failed to resolve dependencies
```

Because authentic 1.1.0 does not currently exist (latest version is 1.0.0)