### PR TITLE
Bump `exception_page` shard to v0.4.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -47,7 +47,7 @@ dependencies:
     version: ~> 0.4.3
   exception_page:
     github: crystal-loot/exception_page
-    version: ~> 0.3.0
+    version: ~> 0.4.0
   dexter:
     github: luckyframework/dexter
     version: ~> 0.3.4


### PR DESCRIPTION
### Description of the Change

Bumps `exception_page` shard version to `~> 0.4.0`, which includes syntax highlighting and tweaked UX.