### PR TITLE
optimize route building when there's query params.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v1
       - uses: crystal-lang/install-crystal@v1
         with:
-          crystal: 1.6.2
+          crystal: latest
       - name: Install shards
         run: shards install
       - name: Format
@@ -32,7 +32,7 @@ jobs:
         shard_file:
           - shard.yml
         crystal_version:
-          - 1.6.2
+          - 1.9.0
           - latest
         experimental:
           - false

--- a/shard.yml
+++ b/shard.yml
@@ -1,7 +1,7 @@
 name: lucky
 version: 1.1.0
 
-crystal: ">=1.6.0"
+crystal: ">=1.9.0"
 
 authors:
   - Paul Smith <paulcsmith0218@gmail.com>

--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -300,6 +300,7 @@ module Lucky::Routable
         unless query_params.empty?
           io << '?'
           {% if compare_versions(Crystal::VERSION, "1.10.0") < 0 %}
+            {% @type.warning("[Deprecated] Please update your Crystal version #{Crystal::VERSION}. Using Lucky with a version below 1.10.0 is deprecated.") %}
             io << HTTP::Params.encode(query_params)
           {% else %}
             HTTP::Params.encode(io, query_params)

--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -282,29 +282,37 @@ module Lucky::Routable
     {% end %}
     anchor : String? = nil
     ) : Lucky::RouteHelper
-      path = path_from_parts(
-        {% for param in path_params %}
-          {{ param.gsub(/:/, "").id }},
+      path = String.build do |io|
+        path_from_parts(
+          io,
+          {% for param in path_params %}
+            {{ param.gsub(/:/, "").id }},
+          {% end %}
+          {% for param in optional_path_params %}
+            {{ param.gsub(/^\?:/, "").id }},
+          {% end %}
+        )
+        query_params = {} of String => String
+        {% for param in PARAM_DECLARATIONS %}
+          # add query param if given and not nil
+          query_params["{{ param.var }}"] = {{ param.var }}.to_s unless {{ param.var }}.nil?
         {% end %}
-        {% for param in optional_path_params %}
-          {{ param.gsub(/^\?:/, "").id }},
-        {% end %}
-      )
-      query_params = {} of String => String
-      {% for param in PARAM_DECLARATIONS %}
-        # add query param if given and not nil
-        query_params["{{ param.var }}"] = {{ param.var }}.to_s unless {{ param.var }}.nil?
-      {% end %}
-      unless query_params.empty?
-        path += "?#{HTTP::Params.encode(query_params)}"
+        unless query_params.empty?
+          io << '?'
+          {% if compare_versions(Crystal::VERSION, "1.10.0") < 0 %}
+            io << HTTP::Params.encode(query_params)
+          {% else %}
+            HTTP::Params.encode(io, query_params)
+          {% end %}
+        end
+
+        anchor.try do |value|
+          io << '#'
+          URI.encode_www_form(value, io)
+        end
       end
 
-      anchor.try do |value|
-        path += "#"
-        path += URI.encode_www_form(value)
-      end
-
-      Lucky::RouteHelper.new {{ method }}, path
+      Lucky::RouteHelper.new({{ method }}, path.presence || "/")
     end
 
     def self.with(
@@ -339,6 +347,31 @@ module Lucky::Routable
     end
 
     private def self.path_from_parts(
+      io : IO,
+      {% for param in path_params %}
+        {{ param.gsub(/:/, "").id }},
+      {% end %}
+      {% for param in optional_path_params %}
+        {{ param.gsub(/^\?:/, "").id }},
+      {% end %}
+    ) : Nil
+      {% for part in path_parts %}
+        {% if part.starts_with?("?:") %}
+          if {{ part.gsub(/^\?:/, "").id }}
+            io << '/'
+            URI.encode_www_form({{ part.gsub(/^\?:/, "").id }}.to_param, io)
+          end
+        {% elsif part.starts_with?(':') %}
+          io << '/'
+          URI.encode_www_form({{ part.gsub(/:/, "").id }}.to_param, io)
+        {% else %}
+          io << '/'
+          URI.encode_www_form({{ part }}, io)
+        {% end %}
+      {% end %}
+    end
+
+    private def self.path_from_parts(
         {% for param in path_params %}
           {{ param.gsub(/:/, "").id }},
         {% end %}
@@ -346,21 +379,16 @@ module Lucky::Routable
           {{ param.gsub(/^\?:/, "").id }},
         {% end %}
     ) : String
-      path = String.build do |path|
-        {% for part in path_parts %}
-          {% if part.starts_with?("?:") %}
-            if {{ part.gsub(/^\?:/, "").id }}
-              path << '/'
-              URI.encode_www_form({{ part.gsub(/^\?:/, "").id }}.to_param, path)
-            end
-          {% elsif part.starts_with?(':') %}
-            path << '/'
-            URI.encode_www_form({{ part.gsub(/:/, "").id }}.to_param, path)
-          {% else %}
-            path << '/'
-            URI.encode_www_form({{ part }}, path)
+      path = String.build do |io|
+        path_from_parts(
+          io,
+          {% for param in path_params %}
+            {{ param.gsub(/:/, "").id }},
           {% end %}
-        {% end %}
+          {% for param in optional_path_params %}
+            {{ param.gsub(/^\?:/, "").id }},
+          {% end %}
+        )
       end
 
       path.presence || "/"


### PR DESCRIPTION
## Purpose
Fixes #1831

## Description
Crystal 1.10 added a method overload for `HTTP::Params.encode` that takes an IO. This lets us use a single IO to build a route when there's query params.

There doesn't seem to really be a difference when there's no query params involved:

```
# SomeAction.with(id: 1).path
old   1.11k (901.42µs) (± 0.13%)  2.91MB/op        fastest
new   1.10k (906.13µs) (± 0.20%)  2.91MB/op   1.01× slower
```

But when you use query params, it helps

```
# SomeAction.with(id: 1, page: 1, per_page: 10).path
old 459.21  (  2.18ms) (± 1.57%)  6.87MB/op   1.30× slower
new 598.36  (  1.67ms) (± 1.12%)  4.27MB/op        fastest
```

Using a Crystal version below 1.10.0 will show a deprecation warning

```
[Deprecated] Please update your Crystal version "1.9.2". Using Lucky with a version below 1.10.0 is deprecated.
```


## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
