### PR TITLE
Adding the compile time to the watcher for development

### DIFF
--- a/tasks/watch.cr
+++ b/tasks/watch.cr
@@ -152,8 +152,10 @@ module LuckySentry
 
     @app_built : Bool = false
     @successful_compilations : Int32 = 0
+    @build_started : Time::Span
 
     def initialize(@build_commands : Array(String), @run_commands : Array(String), @files : Array(String), @reload_browser : Bool, @watcher : Watcher?)
+      @build_started = Time.monotonic
     end
 
     private def build_app_processes_and_start
@@ -262,7 +264,14 @@ module LuckySentry
       if build_success
         self.app_built = true
         create_app_processes
-        puts "#{" Done ".colorize.on_cyan.black} compiling"
+
+        elapsed_time = Time.monotonic - @build_started
+        message = String.build do |io|
+          io << " DONE ".colorize.on_cyan.black
+          io << " Compiled successfully in #{elapsed_time}".colorize.cyan
+        end
+
+        puts message
       elsif !app_built
         print_error_message
       end

--- a/tasks/watch.cr
+++ b/tasks/watch.cr
@@ -1,9 +1,9 @@
 require "lucky_task"
-require "option_parser"
 require "colorize"
 require "yaml"
 require "http"
 require "../src/lucky/server_settings"
+require "../src/lucky/page_helpers/time_helpers"
 
 # Based on the sentry shard with some modifications to output and build process.
 module LuckySentry
@@ -142,6 +142,7 @@ module LuckySentry
 
   class ProcessRunner
     include LuckyTask::TextHelpers
+    include Lucky::TimeHelpers
 
     getter build_processes = [] of Process
     getter app_processes = [] of Process
@@ -268,7 +269,7 @@ module LuckySentry
         elapsed_time = Time.monotonic - @build_started
         message = String.build do |io|
           io << " DONE ".colorize.on_cyan.black
-          io << " Compiled successfully in #{elapsed_time}".colorize.cyan
+          io << " Compiled successfully in #{distance_of_time_in_words(elapsed_time)}".colorize.cyan
         end
 
         puts message


### PR DESCRIPTION
## Purpose
Fixes #1851

## Description

This adds in the time span of compiling your app when it boots. 

Here's what it looks like
![image](https://github.com/luckyframework/lucky/assets/2391/761948e4-bc35-44ef-bcb7-a0508bb7fdb9)

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
