### PR TITLE
Adds the ability to configure the secret key size generated.

### DIFF
--- a/spec/tasks/gen/secret_key_base_spec.cr
+++ b/spec/tasks/gen/secret_key_base_spec.cr
@@ -2,10 +2,18 @@ require "../../spec_helper"
 
 describe Gen::SecretKey do
   it "outputs a new secret key base" do
-    io = IO::Memory.new
+    task = Gen::SecretKey.new
+    task.output = IO::Memory.new
+    task.print_help_or_call(args: [] of String)
 
-    Gen::SecretKey.new.call(io)
+    (task.output.to_s.size >= 32).should be_true
+  end
 
-    (io.to_s.size >= 32).should be_true
+  it "outputs a larger size when configured" do
+    task = Gen::SecretKey.new
+    task.output = IO::Memory.new
+    task.print_help_or_call(args: ["-n 64"])
+
+    (task.output.to_s.size >= 64).should be_true
   end
 end

--- a/tasks/gen/secret_key.cr
+++ b/tasks/gen/secret_key.cr
@@ -3,7 +3,9 @@ require "lucky_task"
 class Gen::SecretKey < LuckyTask::Task
   summary "Generate a new secret key"
 
-  def call(io : IO = STDOUT)
-    io.puts Random::Secure.base64(32)
+  int32 :number, "n random bytes used to encode into base64.", shortcut: "-n", default: 32
+
+  def call
+    output.puts Random::Secure.base64(number)
   end
 end


### PR DESCRIPTION
## Purpose
Fixes #1847

## Description
This allows you to pass an optional argument to the `lucky gen.secret_key` task to generate larger or smaller secret keys. 

```
❯ lucky gen.secret_key
jyy8PODnOkPBUKVFd8pxM4YFbxyYTzYK44QoMiha+68=

❯ lucky gen.secret_key -n 64
uOBfVEGWo+t14g7F9vDA349b2OTURQAMfM13VeiMswNsd0YA0oykDP4XEzJcEjTk3PNV8KuiLwAMV4Vg7EhU3A==
```

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
