### PR TITLE
Ensure actions can have early returns

### DIFF
--- a/spec/lucky/action_spec.cr
+++ b/spec/lucky/action_spec.cr
@@ -223,12 +223,28 @@ class Tests::ComponentActionWithCustomContentType < TestAction
   end
 end
 
+class Tests::MultiConditionWithEarlyReturn < TestAction
+  get "/tests/multi_condition_with_early_return" do
+    data = {check: 1}
+    if data
+      return json(data)
+    end
+
+    raw_json("{}")
+  end
+end
+
 describe Lucky::Action do
   it "has a url helper" do
     Lucky::RouteHelper.temp_config(base_uri: "example.com") do
       Tests::Index.url.should eq "example.com/tests"
       Tests::ActionWithPrefix.url.should eq "example.com/prefix/so_custom2"
     end
+  end
+
+  it "allows for early returns" do
+    response = Tests::MultiConditionWithEarlyReturn.new(build_context, params).call
+    response.body.to_s.should eq "{\"check\":1}"
   end
 
   describe ".url_without_query_params" do

--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -87,6 +87,12 @@ module Lucky::Routable
 
   # :nodoc:
   macro setup_call_method(body)
+    # Return a response with `html`, `redirect`, or `json` at the end of your action.
+    # Ensure all conditionals (like if/else) return a response with html, redirect, json, etc.
+    private def action_call_body : Lucky::Response
+      {{ body }}
+    end
+
     def call
       # Ensure clients_desired_format is cached by calling it
       clients_desired_format
@@ -96,7 +102,7 @@ module Lucky::Routable
       %response = if %pipe_result.is_a?(Lucky::Response)
         %pipe_result
       else
-        {{ body }}
+        action_call_body
       end
 
       %pipe_result = run_after_pipes


### PR DESCRIPTION
## Purpose
Fixes #1843

## Description
This may not actually have been a problem to start and possibly just something weird we had in our app [ref](https://github.com/luckyframework/lucky/issues/1843#issuecomment-2016976781); however, I decided to still make this change anyway.  By moving the call body in to a separate method, the compile-time error is a lot more accurate. Though, it's not as pretty as before, I think the clarity and accuracy outweighs the custom error message.

Also by adding a few comments above the method, you get a little bit of documentation, and the actual action that's failing which should lead you to a fix a bit quicker.

![Screenshot from 2024-03-24 16-04-41](https://github.com/luckyframework/lucky/assets/2391/8495dda1-e1cf-4464-9a8c-fd59e3591313)

See #1843 for more info on the error message change

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
