### PR TITLE
Added overload to distance_of_time_in_words for Time::Span. 

### DIFF
--- a/spec/lucky/time_helpers_spec.cr
+++ b/spec/lucky/time_helpers_spec.cr
@@ -30,6 +30,11 @@ describe Lucky::TimeHelpers do
       view.distance_of_time_in_words(from_time, from_time + 2.years).should eq "over 2 years"
       view.distance_of_time_in_words(from_time, from_time + 10.years).should eq "almost 10 years"
     end
+
+    it "takes a Time::Span" do
+      span = 4.minutes
+      view.distance_of_time_in_words(span).should eq "4 minutes"
+    end
   end
 
   describe "time_ago_in_words" do

--- a/src/lucky/page_helpers/time_helpers.cr
+++ b/src/lucky/page_helpers/time_helpers.cr
@@ -16,10 +16,15 @@ module Lucky::TimeHelpers
   # # => "almost 42 years"
   # ```
   def distance_of_time_in_words(from : Time, to : Time) : String
-    minutes = (to - from).minutes
-    seconds = (to - from).seconds
-    hours = (to - from).hours
-    days = (to - from).days
+    distance_of_time_in_words(to - from)
+  end
+
+  # :ditto:
+  def distance_of_time_in_words(span : Time::Span) : String
+    minutes = span.minutes
+    seconds = span.seconds
+    hours = span.hours
+    days = span.days
 
     return distance_in_days(days) if days != 0
     return distance_in_hours(hours, minutes) if hours != 0


### PR DESCRIPTION
## Purpose
Fixes #1859

## Description
This PR allows you to use the `distance_of_time_in_words` helper method with a single `Time::Span`.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
