### PR TITLE
Adds Date response header.

### DIFF
--- a/src/lucky/text_response.cr
+++ b/src/lucky/text_response.cr
@@ -28,6 +28,7 @@ class Lucky::TextResponse < Lucky::Response
     end
     context.response.content_type = content_type
     context.response.status_code = status
+    context.response.headers.add "Date", HTTP.format_time(Time.utc)
     gzip if should_gzip?
     context.response.print(body) if should_print?
   rescue e : IO::Error


### PR DESCRIPTION
## Purpose
Fixes #1863

## Description
Apparently all servers should respond with a Date header. Kemal just added it in, so why not? :smile: 

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
