### PR TITLE
CI fails with missing ECR, so just adding a require just in case

### DIFF
--- a/spec/tasks/gen/action_spec.cr
+++ b/spec/tasks/gen/action_spec.cr
@@ -106,4 +106,15 @@ describe Gen::Action do
       io.to_s.should contain("That's not a valid Action.")
     end
   end
+
+  it "generates the correct template" do
+    template = Lucky::ActionTemplate.new(
+      name: "User::Index",
+      action: "index",
+      inherit_from: "BrowserAction",
+      route: %(get "/users")
+    )
+    folder = template.template_folder
+    LuckyTemplate.snapshot(folder).has_key?("src/actions/user/index.cr").should eq(true)
+  end
 end

--- a/tasks/gen/action/action_generator.cr
+++ b/tasks/gen/action/action_generator.cr
@@ -1,3 +1,4 @@
+require "ecr"
 require "colorize"
 require "lucky_template"
 require "../../../src/lucky/route_inferrer"

--- a/tasks/gen/component.cr
+++ b/tasks/gen/component.cr
@@ -1,3 +1,4 @@
+require "ecr"
 require "lucky_task"
 require "lucky_template"
 require "colorize"

--- a/tasks/gen/page.cr
+++ b/tasks/gen/page.cr
@@ -1,3 +1,4 @@
+require "ecr"
 require "lucky_task"
 require "lucky_template"
 require "colorize"

--- a/tasks/gen/task.cr
+++ b/tasks/gen/task.cr
@@ -1,3 +1,4 @@
+require "ecr"
 require "lucky_task"
 require "lucky_template"
 require "colorize"


### PR DESCRIPTION
## Purpose
Fix this CI https://github.com/luckyframework/lucky_cli/actions/runs/8759728427/job/24044934376?pr=860#step:4:9633

## Description
The e2e specs for LuckyCLI are failing with ECR missing. I don't know why, but hopefully adding these requires will fix it.

One thing to keep in mind is this comment https://github.com/crystal-lang/crystal/issues/14496#issuecomment-2058990690 I'm not sure how ECR plays in, but just in case something weird comes up....
