### PR TITLE
Fixing Crystal 1.13 regression issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           - shard_file: shard.edge.yml
             crystal_version: latest
             experimental: true
-          - shard_file: shard.yml
+          - shard_file: shard.override.yml
             crystal_version: nightly
             experimental: true
     runs-on: ubuntu-latest

--- a/shard.override.yml
+++ b/shard.override.yml
@@ -1,0 +1,4 @@
+dependencies:
+  habitat:
+    github: luckyframework/habitat
+    branch: main

--- a/src/lucky/assignable.cr
+++ b/src/lucky/assignable.cr
@@ -89,7 +89,9 @@ module Lucky::Assignable
       {% sorted_assigns = ASSIGNS.sort_by { |dec|
            has_explicit_value =
              dec.type.is_a?(Metaclass) ||
-               dec.type.types.map(&.id).includes?(Nil.id) ||
+               dec.type.types.any? { |t|
+                 (t.is_a?(Metaclass) || t.is_a?(ProcNotation) || t.is_a?(Generic)) ? false : t.names.includes?(Nil.id)
+               } ||
                !dec.value.is_a?(Nop)
            has_explicit_value ? 1 : 0
          } %}
@@ -98,7 +100,7 @@ module Lucky::Assignable
           {% var = declaration.var %}
           {% type = declaration.type %}
           {% value = declaration.value %}
-          {% value = nil if type.stringify.ends_with?("Nil") && !value %}
+          {% value = nil if type.stringify.ends_with?("Nil") && value.nil? %}
           @{{ var.id }} : {{ type }}{% if !value.is_a?(Nop) %} = {{ value }}{% end %},
         {% end %}
         **unused_exposures

--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -260,7 +260,7 @@ module Lucky::Routable
     end
 
     {% params_with_defaults = PARAM_DECLARATIONS.select do |decl|
-         !decl.value.is_a?(Nop) || decl.type.is_a?(Union) && decl.type.types.last.id == Nil.id
+         !decl.value.is_a?(Nop) || decl.type.is_a?(Union) && decl.type.resolve.nilable?
        end %}
     {% params_without_defaults = PARAM_DECLARATIONS.reject do |decl|
          params_with_defaults.includes? decl


### PR DESCRIPTION
## Purpose
Fixes #1872 

## Description
Crystal 1.13 changes how `Nil` is written on the macro side. This broke some of the Lucky code because now `::Nil.id` is not the same as `Nil.id`.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
