### PR TITLE
Fix failed specs in Crystal v1.13

### DIFF
--- a/spec/lucky/base_http_client_spec.cr
+++ b/spec/lucky/base_http_client_spec.cr
@@ -10,6 +10,16 @@ class HelloWorldAction < TestAction
   end
 end
 
+class ArrayParamAction < TestAction
+  accepted_formats [:plain_text]
+
+  param codes : Array(String)
+
+  post "/array_param" do
+    plain_text codes.join("--")
+  end
+end
+
 class MyClient < Lucky::BaseHTTPClient
   app TestServer.new
 end
@@ -50,8 +60,8 @@ describe Lucky::BaseHTTPClient do
       end
 
       it "works with array query params" do
-        response = MyClient.new.exec HelloWorldAction.with(codes: ["ab", "xy"])
-        response.body.should eq "world"
+        response = MyClient.new.exec ArrayParamAction.with(codes: ["ab", "xy"])
+        response.body.should eq "ab--xy"
 
         request = TestServer.last_request
         request.query.should eq("codes%5B%5D=ab&codes%5B%5D=xy")

--- a/spec/lucky/base_http_client_spec.cr
+++ b/spec/lucky/base_http_client_spec.cr
@@ -3,6 +3,8 @@ require "../spec_helper"
 class HelloWorldAction < TestAction
   accepted_formats [:plain_text]
 
+  param codes : Array(String)?
+
   post "/hello" do
     plain_text "world"
   end
@@ -45,6 +47,13 @@ describe Lucky::BaseHTTPClient do
 
         request = TestServer.last_request
         request.body.to_s.should eq({foo: "bar"}.to_json)
+      end
+
+      it "works with array query params" do
+        response = MyClient.new.exec HelloWorldAction.with(codes: ["ab", "xy"])
+
+        request = TestServer.last_request
+        request.query.should eq("codes%5B%5D=ab&codes%5B%5D=xy")
       end
     end
 

--- a/spec/lucky/base_http_client_spec.cr
+++ b/spec/lucky/base_http_client_spec.cr
@@ -51,6 +51,7 @@ describe Lucky::BaseHTTPClient do
 
       it "works with array query params" do
         response = MyClient.new.exec HelloWorldAction.with(codes: ["ab", "xy"])
+        response.body.should eq "world"
 
         request = TestServer.last_request
         request.query.should eq("codes%5B%5D=ab&codes%5B%5D=xy")

--- a/spec/lucky/cookies/cookie_jar_spec.cr
+++ b/spec/lucky/cookies/cookie_jar_spec.cr
@@ -35,7 +35,7 @@ describe Lucky::CookieJar do
   end
 
   it "raises a nicer error for invalid cookie values" do
-    value = "Double Chocolate"
+    value = "Double,Chocolate"
     jar = Lucky::CookieJar.empty_jar
 
     expect_raises(Lucky::InvalidCookieValueError, "Cookie value for 'cookie' is invalid") do


### PR DESCRIPTION
## Purpose
Fix failed `Lucky::CookieJar` specs in Crystal v1.13

## Description 
`Lucky::CookieJar` specs fail in Crystal v1.13. This is related to [crystal-lang/crystal#14455](https://github.com/crystal-lang/crystal/pull/14455). This PR fixes that.

See <https://github.com/luckyframework/lucky/actions/runs/10340714956/job/28621689266>.

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
