### PR TITLE
Fix compile error

### DIFF
--- a/src/lucky/error_action.cr
+++ b/src/lucky/error_action.cr
@@ -80,7 +80,7 @@ abstract class Lucky::ErrorAction
 
   def render_exception_page(error : Exception, status : Int) : Lucky::Response
     send_text_response(
-      body: Lucky::ExceptionPage.for_runtime_exception(context, error).to_s,
+      body: Lucky::ExceptionPage.new(context, error).to_s,
       content_type: "text/html",
       status: status
     )


### PR DESCRIPTION
## Purpose

Fixes: #1906

Fix compile error arising from `crystal-loot/exception_page`

## Description

Exception page shard introduced a breaking change on their `master` branch, leading to compile error in Lucky:

```
In src/lucky/error_action.cr:83:34

 83 | body: Lucky::ExceptionPage.for_runtime_exception(context, error).to_s,
                                 ^--------------------
Error: Error: undefined method 'for_runtime_exception' for Lucky::ExceptionPage.class
```

See <https://github.com/crystal-loot/exception_page/pull/49>.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
