### PR TITLE
Changing form_method to a public method.

### DIFF
--- a/src/lucky/action_pipes.cr
+++ b/src/lucky/action_pipes.cr
@@ -24,13 +24,13 @@ module Lucky::ActionPipes
 
   # :nodoc:
   macro included
-    AFTER_PIPES = [] of Symbol
-    BEFORE_PIPES = [] of Symbol
+    AFTER_PIPES   = [] of Symbol
+    BEFORE_PIPES  = [] of Symbol
     SKIPPED_PIPES = [] of Symbol
 
     macro inherited
-      AFTER_PIPES = [] of Symbol
-      BEFORE_PIPES = [] of Symbol
+      AFTER_PIPES   = [] of Symbol
+      BEFORE_PIPES  = [] of Symbol
       SKIPPED_PIPES = [] of Symbol
 
       inherit_pipes

--- a/src/lucky/tags/form_helpers.cr
+++ b/src/lucky/tags/form_helpers.cr
@@ -19,7 +19,7 @@ module Lucky::FormHelpers
     input merge_options(html_options, {"type" => "submit", "value" => text})
   end
 
-  private def form_method(route) : String
+  def form_method(route) : String
     if route.method == :get
       "get"
     else


### PR DESCRIPTION
## Purpose
In reference to #1824

## Description
Changing the method from private to public

## Checklist
* [X] - An issue already exists detailing the issue/or feature request that this PR fixes
* [X] - All specs are formatted with `crystal tool format spec src`
* [X] - Inline documentation has been added and/or updated
* [X] - Lucky builds on docker with `./script/setup`
* [X] - All builds and specs pass on docker with `./script/test`
