### PR TITLE
Adding a MaximumRequestSizeHandler

### DIFF
--- a/spec/lucky/maximum_request_size_handler_spec.cr
+++ b/spec/lucky/maximum_request_size_handler_spec.cr
@@ -1,0 +1,51 @@
+require "../spec_helper"
+require "http/server"
+
+include ContextHelper
+
+describe Lucky::MaximumRequestSizeHandler do
+  context "when the handler is disabled" do
+    it "simply serves the request" do
+      context = build_small_request_context("/path")
+      Lucky::MaximumRequestSizeHandler.temp_config(enabled: false) do
+        run_request_size_handler(context)
+      end
+      context.response.status.should eq(HTTP::Status::OK)
+    end
+  end
+
+  context "when the handler is enabled" do
+    it "with a small request, serve the request" do
+      context = build_small_request_context("/path")
+      Lucky::MaximumRequestSizeHandler.temp_config(enabled: true) do
+        run_request_size_handler(context)
+      end
+      context.response.status.should eq(HTTP::Status::OK)
+    end
+
+    it "with a large request, deny the request" do
+      context = build_large_request_context("/path")
+      Lucky::MaximumRequestSizeHandler.temp_config(enabled: true) do
+        run_request_size_handler(context)
+      end
+      context.response.status.should eq(HTTP::Status::PAYLOAD_TOO_LARGE)
+    end
+  end
+end
+
+private def run_request_size_handler(context)
+  handler = Lucky::MaximumRequestSizeHandler.new
+  handler.next = ->(_ctx : HTTP::Server::Context) {}
+  handler.call(context)
+end
+
+private def build_small_request_context(path : String) : HTTP::Server::Context
+  build_context(path: path)
+end
+
+private def build_large_request_context(path : String) : HTTP::Server::Context
+  build_context(path: path).tap do |context|
+    context.request.headers["Content-Length"] = "1000000"
+    context.request.body = "a" * 1000000
+  end
+end

--- a/spec/lucky/maximum_request_size_handler_spec.cr
+++ b/spec/lucky/maximum_request_size_handler_spec.cr
@@ -25,7 +25,10 @@ describe Lucky::MaximumRequestSizeHandler do
 
     it "with a large request, deny the request" do
       context = build_large_request_context("/path")
-      Lucky::MaximumRequestSizeHandler.temp_config(enabled: true) do
+      Lucky::MaximumRequestSizeHandler.temp_config(
+        enabled: true,
+        max_size: 10,
+      ) do
         run_request_size_handler(context)
       end
       context.response.status.should eq(HTTP::Status::PAYLOAD_TOO_LARGE)

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -48,8 +48,4 @@ Lucky::ForceSSLHandler.configure do |settings|
   settings.enabled = true
 end
 
-Lucky::MaximumRequestSizeHandler.configure do |settings|
-  settings.enabled = false
-end
-
 Habitat.raise_if_missing_settings!

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -48,4 +48,8 @@ Lucky::ForceSSLHandler.configure do |settings|
   settings.enabled = true
 end
 
+Lucky::MaximumRequestSizeHandler.configure do |settings|
+  settings.enabled = false
+end
+
 Habitat.raise_if_missing_settings!

--- a/src/lucky/maximum_request_size_handler.cr
+++ b/src/lucky/maximum_request_size_handler.cr
@@ -3,7 +3,7 @@ class Lucky::MaximumRequestSizeHandler
 
   Habitat.create do
     setting enabled : Bool = false
-    setting max_size : Int32 = 1_048_576 # 1MB
+    setting max_size : Int64 = 1_048_576_i64 # 1MB
   end
 
   def call(context)

--- a/src/lucky/maximum_request_size_handler.cr
+++ b/src/lucky/maximum_request_size_handler.cr
@@ -1,0 +1,40 @@
+class Lucky::MaximumRequestSizeHandler
+  include HTTP::Handler
+
+  Habitat.create do
+    setting enabled : Bool = false
+    setting max_size : Int32 = 1_048_576 # 1MB
+  end
+
+  def call(context)
+    return call_next(context) unless settings.enabled
+
+    body_size = 0
+    body = IO::Memory.new
+
+    begin
+      buffer = Bytes.new(8192) # 8KB buffer
+      while (read_bytes = context.request.body.try(&.read(buffer)))
+        body_size += read_bytes
+        body.write(buffer[0, read_bytes])
+
+        if body_size > settings.max_size
+          context.response.status = HTTP::Status::PAYLOAD_TOO_LARGE
+          context.response.print("Request entity too large")
+          return context
+        end
+
+        break if read_bytes < buffer.size # End of body
+      end
+    rescue IO::Error
+      context.response.status = HTTP::Status::BAD_REQUEST
+      context.response.print("Error reading request body")
+      return context
+    end
+
+    # Reset the request body for downstream handlers
+    context.request.body = IO::Memory.new(body.to_s)
+
+    call_next(context)
+  end
+end

--- a/src/lucky/maximum_request_size_handler.cr
+++ b/src/lucky/maximum_request_size_handler.cr
@@ -1,3 +1,15 @@
+# Allows a maximum request size to be set for incoming requests.
+#
+# Configure the max_size to the maximum size in bytes that you
+# want to allow.
+#
+# ```
+# Lucky::MaximumRequestSizeHandler.configure do |settings|
+#   settings.enabled = true
+#   settings.max_size = 1_048_576 # 1MB
+# end
+# ```
+
 class Lucky::MaximumRequestSizeHandler
   include HTTP::Handler
 

--- a/src/lucky/maximum_request_size_handler.cr
+++ b/src/lucky/maximum_request_size_handler.cr
@@ -14,7 +14,7 @@ class Lucky::MaximumRequestSizeHandler
 
     begin
       buffer = Bytes.new(8192) # 8KB buffer
-      while (read_bytes = context.request.body.try(&.read(buffer)))
+      while read_bytes = context.request.body.try(&.read(buffer))
         body_size += read_bytes
         body.write(buffer[0, read_bytes])
 


### PR DESCRIPTION
* Configurable to be on/off. Off by default.
* Configurable to set the maximum request size. Default is 1MB.

## Purpose
A configurable handler for setting a maximum size on requests.

## Description
Fixes #1143

## Checklist
* [X] - An issue already exists detailing the issue/or feature request that this PR fixes
* [X] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [X] - Lucky builds on docker with `./script/setup`
* [X] - All builds and specs pass on docker with `./script/test`
