### PR TITLE
chore (file_response): implement macro for crystal version check

### DIFF
--- a/src/lucky/file_response.cr
+++ b/src/lucky/file_response.cr
@@ -120,7 +120,7 @@ class Lucky::FileResponse < Lucky::Response
     File.expand_path(path, Dir.current)
   end
 
-  {% if Crystal::VERSION.split(".")[0].to_i > 1 || (Crystal::VERSION.split(".")[0].to_i == 1 && Crystal::VERSION.split(".")[1].to_i > 12) || (Crystal::VERSION.split(".")[0].to_i == 1 && Crystal::VERSION.split(".")[1].to_i == 12 && Crystal::VERSION.split(".")[2].to_i >= 0) %}
+  {% if compare_versions(Crystal::VERSION, "1.13.0") >= 0 %}
     private def file_exists? : Bool
       File.file?(full_path) && File::Info.readable?(full_path)
     end

--- a/src/lucky/file_response.cr
+++ b/src/lucky/file_response.cr
@@ -120,7 +120,13 @@ class Lucky::FileResponse < Lucky::Response
     File.expand_path(path, Dir.current)
   end
 
-  private def file_exists? : Bool
-    File.file?(full_path) && File.readable?(full_path)
-  end
+  {% if Crystal::VERSION.split(".")[0].to_i > 1 || (Crystal::VERSION.split(".")[0].to_i == 1 && Crystal::VERSION.split(".")[1].to_i > 12) || (Crystal::VERSION.split(".")[0].to_i == 1 && Crystal::VERSION.split(".")[1].to_i == 12 && Crystal::VERSION.split(".")[2].to_i >= 0) %}
+    private def file_exists? : Bool
+      File.file?(full_path) && File::Info.readable?(full_path)
+    end
+  {% else %}
+    private def file_exists? : Bool
+      File.file?(full_path) && File.readable?(full_path)
+    end
+  {% end %}
 end


### PR DESCRIPTION
## Purpose
Fixes #1899

## Description

Implemented a macro to check the crystal version. This is to handle the deprecation of `File.readable?` since version 1.13 in favour of `File::Info.readable?`

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
