### PR TITLE
Update ExceptionPage and fix the error title.

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -47,7 +47,7 @@ dependencies:
     version: ~> 0.4.3
   exception_page:
     github: crystal-loot/exception_page
-    version: ~> 0.4.1
+    version: ~> 0.5.0
   dexter:
     github: luckyframework/dexter
     version: ~> 0.3.4

--- a/src/lucky/error_action.cr
+++ b/src/lucky/error_action.cr
@@ -79,8 +79,19 @@ abstract class Lucky::ErrorAction
   end
 
   def render_exception_page(error : Exception, status : Int) : Lucky::Response
+    exception_page = Lucky::ExceptionPage.new(
+      error,
+      context.request.method,
+      context.request.path,
+      context.response.status,
+      "Error #{context.response.status.to_i} #{context.response.status.description}",
+      context.request.query_params,
+      context.response.headers,
+      context.response.cookies,
+      error.message,
+    )
     send_text_response(
-      body: Lucky::ExceptionPage.new(context, error).to_s,
+      body: exception_page.to_s,
       content_type: "text/html",
       status: status
     )


### PR DESCRIPTION
## Purpose
Fixes #1920

## Description
The ExceptionPage error messages used to say "Error 404", but they were changed to "Not Found". This updates the title to include both so now it'll say "Error 404 Not Found"

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
