### PR TITLE
Add abstract definition for debug_message

### DIFF
--- a/src/lucky/data_response.cr
+++ b/src/lucky/data_response.cr
@@ -31,7 +31,8 @@
 class Lucky::DataResponse < Lucky::Response
   DEFAULT_STATUS = 200
 
-  getter context, data, content_type, filename, debug_message, headers
+  getter context, data, content_type, filename, headers
+  getter debug_message : String?
 
   def initialize(@context : HTTP::Server::Context,
                  @data : String,

--- a/src/lucky/file_response.cr
+++ b/src/lucky/file_response.cr
@@ -41,7 +41,8 @@
 class Lucky::FileResponse < Lucky::Response
   DEFAULT_STATUS = 200
 
-  getter context, path, filename, debug_message, headers
+  getter context, path, filename, headers
+  getter debug_message : String?
 
   def initialize(@context : HTTP::Server::Context,
                  @path : String,

--- a/src/lucky/response.cr
+++ b/src/lucky/response.cr
@@ -1,4 +1,5 @@
 abstract class Lucky::Response
   abstract def print
   abstract def status : Int
+  abstract def debug_message : String?
 end

--- a/src/lucky/text_response.cr
+++ b/src/lucky/text_response.cr
@@ -10,7 +10,8 @@
 class Lucky::TextResponse < Lucky::Response
   DEFAULT_STATUS = 200
 
-  getter context, content_type, body, debug_message, enable_cookies
+  getter context, content_type, body, enable_cookies
+  getter debug_message : String?
 
   def initialize(@context : HTTP::Server::Context,
                  @content_type : String,


### PR DESCRIPTION
## Purpose

To make it clearer that `debug_message` must be implemented on `Response`.

## Description

I am using lucky to build a microservice that accepts protobuf definitions over http so I created my own `ProtobufResponse` class to stream the protobuf response straight into the response io. While implementing it I discovered that you also have to implement `debug_message` as well as it is required by renderable:

https://github.com/luckyframework/lucky/blob/2c1433d20c3210109585f048af64d5a4d34cf3b3/src/lucky/renderable.cr#L194-L196

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
