### PR TITLE
Fixing compilation error on Windows

### DIFF
--- a/src/lucky/errors.cr
+++ b/src/lucky/errors.cr
@@ -249,7 +249,7 @@ module Lucky
         "Expected request to have a subdomain but did not find one."
       else
         <<-MESSAGE
-          Expected subdomain matcher(s): #{@expected.pretty_inspect}
+          Expected subdomain matcher(s): #{@expected}
           Did not match host: #{@host}
         MESSAGE
       end


### PR DESCRIPTION
## Purpose
Fixes #1928

## Description
This call to `pretty_inspect` seems to cause a compilation error on Avram. The error message doesn't seem to change between having it and not, so I'm just removing it.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
