### PR TITLE
Relax `body` parameter type for `Lucky::BaseHTTPClient#exec_raw`

### DIFF
--- a/src/lucky/base_http_client.cr
+++ b/src/lucky/base_http_client.cr
@@ -102,12 +102,12 @@ abstract class Lucky::BaseHTTPClient
   # `exec_raw` works the same as `exec`, but allows you to pass in a raw string.
   # This is used as an escape hatch as the `string` could be unsafe, or formatted
   # in a custom format.
-  def exec_raw(action : Lucky::Action.class, body : String) : HTTP::Client::Response
+  def exec_raw(action : Lucky::Action.class, body : HTTP::Client::BodyType) : HTTP::Client::Response
     exec_raw(action.route, body)
   end
 
   # See docs for `exec_raw`
-  def exec_raw(route_helper : Lucky::RouteHelper, body : String) : HTTP::Client::Response
+  def exec_raw(route_helper : Lucky::RouteHelper, body : HTTP::Client::BodyType) : HTTP::Client::Response
     @client.exec(method: route_helper.method.to_s.upcase, path: route_helper.path, body: body)
   end
 


### PR DESCRIPTION
## Purpose

This allows the passing any type that the underlying `HTTP::Client` accepts, not just `String`s.

## Description

See <https://github.com/luckyframework/lucky/issues/1145#issuecomment-2719048163>

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [ ] - Lucky builds on docker with `./script/setup`
* [ ] - All builds and specs pass on docker with `./script/test`
