### PR TITLE
Fix nilable params with missing values.

### DIFF
--- a/spec/lucky/action_spec.cr
+++ b/spec/lucky/action_spec.cr
@@ -131,7 +131,7 @@ class OptionalParams::Index < TestAction
   param nilable_with_explicit_nil : Int32? = nil
   param nilable_array_with_default : Array(String)? = [] of String
   param with_array_default : Array(Int32) = [26, 37, 44]
-  # This is to test that
+  # This is to test passing with no value at all still treats it as 'nil'
   param optional_bool_with_no_default : Bool?
 
   get "/optional_params" do

--- a/spec/lucky/action_spec.cr
+++ b/spec/lucky/action_spec.cr
@@ -131,6 +131,8 @@ class OptionalParams::Index < TestAction
   param nilable_with_explicit_nil : Int32? = nil
   param nilable_array_with_default : Array(String)? = [] of String
   param with_array_default : Array(Int32) = [26, 37, 44]
+  # This is to test that
+  param optional_bool_with_no_default : Bool?
 
   get "/optional_params" do
     plain_text "optional param: #{page} #{with_int_default} #{with_int_never_nil}"
@@ -411,7 +413,7 @@ describe Lucky::Action do
     end
 
     it "returns optional param declarations" do
-      OptionalParams::Index.query_param_declarations.size.should eq 8
+      OptionalParams::Index.query_param_declarations.size.should eq 9
       OptionalParams::Index.query_param_declarations.should contain "bool_with_false_default : Bool | ::Nil"
     end
   end
@@ -537,6 +539,11 @@ describe Lucky::Action do
     it "allows required arrays with defaults" do
       action = OptionalParams::Index.new(build_context(path: "/?with_array_default=2222222"), params)
       action.with_array_default.should eq([26, 37, 44])
+    end
+
+    it "returns nil when the key is passed with no value for an optional param" do
+      action = OptionalParams::Index.new(build_context(path: "/?optional_bool_with_no_default"), params)
+      action.optional_bool_with_no_default.should eq(nil)
     end
   end
 end

--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -498,7 +498,7 @@ module Lucky::Routable
       {% if is_array %}
       val = params.get_all?(:{{ type_declaration.var.id }})
       {% else %}
-      val = params.get?(:{{ type_declaration.var.id }})
+      val = params.get?(:{{ type_declaration.var.id }}).presence
       {% end %}
 
       if val.nil?


### PR DESCRIPTION
## Purpose
Fixes #1935

## Description
I noticed in my Nuxt fronend I had some params being passed to `useFetch` and instead of removing the query params that were left `undefined`, it just added the key with no value... This caused Lucky to bork because the value comes through as an empty string and Lucky couldn't cast the empty string to Bool. This PR fixes that issue.

## Checklist
* [ x - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
