### PR TITLE
Moving the serialization to a module with Lucky::Serialzable

### DIFF
--- a/spec/lucky/serializable_spec.cr
+++ b/spec/lucky/serializable_spec.cr
@@ -1,0 +1,45 @@
+require "../spec_helper"
+
+private abstract struct BaseSerializerStruct
+  include Lucky::Serializable
+end
+
+private struct FoodSerializer < BaseSerializerStruct
+  def initialize(@name : String)
+  end
+
+  def render
+    {name: @name}
+  end
+end
+
+private abstract class BaseSerializerClass
+  include Lucky::Serializable
+end
+
+private class DrinksSerializer < BaseSerializerClass
+  def initialize(@name : String)
+  end
+
+  def render
+    {name: @name}
+  end
+end
+
+describe Lucky::Serializable do
+  context "with structs" do
+    describe "#to_json" do
+      it "calls to_json on the render data" do
+        FoodSerializer.new("tacos").to_json.should eq(%({"name":"tacos"}))
+      end
+    end
+  end
+
+  context "with classes" do
+    describe "#to_json" do
+      it "calls to_json on the render data" do
+        DrinksSerializer.new("water").to_json.should eq(%({"name":"water"}))
+      end
+    end
+  end
+end

--- a/src/lucky/serializable.cr
+++ b/src/lucky/serializable.cr
@@ -1,0 +1,9 @@
+require "uuid/json"
+
+module Lucky::Serializable
+  abstract def render
+
+  def to_json(io)
+    render.to_json(io)
+  end
+end

--- a/src/lucky/serializer.cr
+++ b/src/lucky/serializer.cr
@@ -1,9 +1,4 @@
-require "uuid/json"
-
+@[Deprecated("include `Lucky::Serializable` instead of inheriting from `Lucky::Serializer`")]
 abstract class Lucky::Serializer
-  abstract def render
-
-  def to_json(io)
-    render.to_json(io)
-  end
+  include Lucky::Serializable
 end


### PR DESCRIPTION
## Purpose
Fixes #1930

## Description
Instead of forcing you to use a class, this moves the serializer setup to a module. Now you can make your serializers a struct if you want.

[This file](https://github.com/luckyframework/lucky_cli/blob/main/src/web_app_skeleton/src/serializers/base_serializer.cr.ecr) in LuckyCLI will still need to be updated.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
