### PR TITLE
Fix missing nested param error when nested key is set but empty

### DIFF
--- a/spec/lucky/params_spec.cr
+++ b/spec/lucky/params_spec.cr
@@ -443,6 +443,14 @@ describe Lucky::Params do
       end
     end
 
+    it "does not raise if nested key is set but empty" do
+      request = build_request body: {user: NamedTuple.new}.to_json,
+        content_type: "application/json"
+
+      params = Lucky::Params.new(request)
+      params.nested(:user).should eq(Hash(String, String).new)
+    end
+
     it "returns empty hash if nested_params are missing" do
       request = build_request body: "",
         content_type: "application/x-www-form-urlencoded"

--- a/src/lucky/params.cr
+++ b/src/lucky/params.cr
@@ -320,7 +320,7 @@ class Lucky::Params
   # params.nested_file("file")    # Lucky::UploadedFile
   # params.nested_file("missing") # Missing parameter: missing
   # ```
-  def nested_file?(nested_key : String | Symbol) : Hash(String, Lucky::UploadedFile)?
+  def nested_file?(nested_key : String | Symbol) : Hash(String, Lucky::UploadedFile)
     nested_file_params(nested_key.to_s)
   end
 
@@ -333,7 +333,7 @@ class Lucky::Params
     end
   end
 
-  def nested_array_files?(nested_key : String | Symbol) : Hash(String, Array(Lucky::UploadedFile))?
+  def nested_array_files?(nested_key : String | Symbol) : Hash(String, Array(Lucky::UploadedFile))
     nested_array_file_params(nested_key.to_s)
   end
 


### PR DESCRIPTION
## Purpose
Fixes #1949

## Description
The previous implementations was correct and expected for nested arrays and files, so this PR changes only `#nested?` and `#nested`. The rest is just a refactor of the other `#nested_...` methods, to provide a consistent API.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [ ] - Lucky builds on docker with `./script/setup`
* [ ] - All builds and specs pass on docker with `./script/test`
