### PR TITLE
Add override for BaseHTTPClient to allow passing a NamedTuple with an action class

### DIFF
--- a/spec/lucky/base_http_client_spec.cr
+++ b/spec/lucky/base_http_client_spec.cr
@@ -59,6 +59,14 @@ describe Lucky::BaseHTTPClient do
         request.body.to_s.should eq({foo: "bar"}.to_json)
       end
 
+      it "allows passing a NamedTuple" do
+        params = {foo: "bar"}
+        response = MyClient.new.exec(HelloWorldAction, params)
+
+        request = TestServer.last_request
+        request.body.to_s.should eq({foo: "bar"}.to_json)
+      end
+
       it "works with array query params" do
         response = MyClient.new.exec ArrayParamAction.with(codes: ["ab", "xy"])
         response.body.should eq "ab--xy"

--- a/src/lucky/base_http_client.cr
+++ b/src/lucky/base_http_client.cr
@@ -94,6 +94,10 @@ abstract class Lucky::BaseHTTPClient
     exec(route_helper, params)
   end
 
+  def exec(action : Lucky::Action.class, params : NamedTuple) : HTTP::Client::Response
+    exec(action.route, **params)
+  end
+
   # See docs for `exec`
   def exec(route_helper : Lucky::RouteHelper, params : NamedTuple) : HTTP::Client::Response
     @client.exec(method: route_helper.method.to_s.upcase, path: route_helper.path, body: params.to_json)

--- a/src/lucky/base_http_client.cr
+++ b/src/lucky/base_http_client.cr
@@ -94,6 +94,7 @@ abstract class Lucky::BaseHTTPClient
     exec(route_helper, params)
   end
 
+  # See docs for `exec`
   def exec(action : Lucky::Action.class, params : NamedTuple) : HTTP::Client::Response
     exec(action.route, **params)
   end


### PR DESCRIPTION
## Purpose
Fixes #1951

## Description
Before this PR, doing `ApiClient.exec(SomeClass, params)` would throw a compile error.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
