### PR TITLE
Add named tuple overload for `Lucky::RequestExpectations#send_json`

### DIFF
--- a/spec/lucky/request_expectations_spec.cr
+++ b/spec/lucky/request_expectations_spec.cr
@@ -44,8 +44,8 @@ describe Lucky::RequestExpectations do
   end
 
   it "passes if the response is exactly the same" do
-    response = build_response(200, {name: "Paul"}.to_json)
-    response.should send_json(200, name: "Paul")
+    response = build_response(200, {status: "success"}.to_json)
+    response.should send_json(200, {status: "success"})
   end
 
   it "passes if nested values are JSON objects" do

--- a/src/lucky/request_expectations.cr
+++ b/src/lucky/request_expectations.cr
@@ -7,6 +7,7 @@ module Lucky::RequestExpectations
   #
   # response = AppClient.new.exec(Users::Show.with(user.id))
   #
+  # response.should send_json(200, {status: "success"})
   # response.should send_json(200, name: user.name, age: user.age)
   # ```
   def send_json(status, **expected)

--- a/src/lucky/request_expectations.cr
+++ b/src/lucky/request_expectations.cr
@@ -10,6 +10,10 @@ module Lucky::RequestExpectations
   # response.should send_json(200, name: user.name, age: user.age)
   # ```
   def send_json(status, **expected)
+    send_json(status, expected)
+  end
+
+  def send_json(status, expected : NamedTuple)
     SendJsonExpectation.new(status, expected.to_json)
   end
 


### PR DESCRIPTION
## Purpose
Fixes #1953 

## Description
Adds named tuple overload for `Lucky::RequestExpectations#send_json`

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [ ] - Lucky builds on docker with `./script/setup`
* [ ] - All builds and specs pass on docker with `./script/test`
