### PR TITLE
Match content type case-insensitively

### DIFF
--- a/src/lucky/params.cr
+++ b/src/lucky/params.cr
@@ -625,12 +625,12 @@ class Lucky::Params
     parse_form_data.files
   end
 
-  private def json? : Bool
-    !!(/^application\/json/ =~ content_type)
+  private def json? : Bool?
+    content_type.try &.downcase.starts_with?("application/json")
   end
 
-  private def multipart? : Bool
-    !!(/^multipart\/form-data/ =~ content_type)
+  private def multipart? : Bool?
+    content_type.try &.downcase.starts_with?("multipart/form-data")
   end
 
   private def content_type : String?


### PR DESCRIPTION
## Purpose

No issue yet, but this was discussed over on discord. I can open an issue, though, if required.

## Description

Uses case-insensitive content type match in `Lucky::Params`. *[RFC](https://www.rfc-editor.org/rfc/rfc2045#section-5.1)*

This also provides significant performance boost, due to ditching the regexes:

```
starts_with  21.75M ( 45.97ns) (±18.82%)  32.0B/op        fastest
      regex   4.20M (237.94ns) (±25.38%)  32.0B/op   5.18× slower
````

Benchmark code:

```crystal
require "benchmark"

CONTENT_TYPE = "Application/JSON"

def starts_with : Bool
  CONTENT_TYPE.downcase.starts_with?("application/json")
end

def regex : Bool
  !!(/^application\/json/i =~ CONTENT_TYPE)
end

Benchmark.ips do |x|
  x.report("starts_with") { starts_with }
  x.report("regex") { regex }
end
```

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [ ] - Lucky builds on docker with `./script/setup`
* [ ] - All builds and specs pass on docker with `./script/test`
