### PR TITLE
Avoid intermediate strings

### DIFF
--- a/src/lucky/base_component.cr
+++ b/src/lucky/base_component.cr
@@ -34,6 +34,6 @@ abstract class Lucky::BaseComponent
     String.build do |io|
       view(io)
       render
-    end.to_s
+    end
   end
 end

--- a/src/lucky/force_ssl_handler.cr
+++ b/src/lucky/force_ssl_handler.cr
@@ -62,7 +62,7 @@ class Lucky::ForceSSLHandler
     settings.strict_transport_security.try do |header|
       sts_value = String.build do |s|
         max_age = ensure_time_span(header[:max_age])
-        s << "max-age=#{max_age.total_seconds.to_i}"
+        s << "max-age=" << max_age.total_seconds.to_i
         s << "; includeSubDomains" if header[:include_subdomains]
       end
       context.response.headers["Strict-Transport-Security"] = sts_value

--- a/src/lucky/mime_type.cr
+++ b/src/lucky/mime_type.cr
@@ -11,8 +11,8 @@ class Lucky::MimeType
     def initialize(@type : String, @subtype : String)
     end
 
-    def to_s
-      "#{type}/#{subtype}"
+    def to_s(io : IO)
+      io << type << '/' << subtype
     end
   end
 

--- a/src/lucky/page_helpers/text_helpers.cr
+++ b/src/lucky/page_helpers/text_helpers.cr
@@ -207,10 +207,9 @@ module Lucky::TextHelpers
       @values[previous_index]?.to_s
     end
 
-    def to_s
-      value = @values[@index]?.to_s
+    def to_s(io : IO)
+      io << @values[@index]?
       @index = next_index
-      value
     end
 
     private def next_index : Int32

--- a/src/lucky/tags/specialty_tags.cr
+++ b/src/lucky/tags/specialty_tags.cr
@@ -87,7 +87,7 @@ module Lucky::SpecialtyTags
       options.each_with_index do |key, value, index|
         attrs << ", " if index > 0
         attrs << Wordsmith::Inflector.dasherize(key.to_s) << "="
-        attrs << value.to_s
+        attrs << value
       end
     end
   end

--- a/tasks/watch.cr
+++ b/tasks/watch.cr
@@ -270,7 +270,8 @@ module LuckySentry
         elapsed_time = Time.monotonic - @build_started
         message = String.build do |io|
           io << " DONE ".colorize.on_cyan.black
-          io << " Compiled successfully in #{distance_of_time_in_words(elapsed_time)}".colorize.cyan
+          io << " Compiled successfully in ".colorize.cyan
+          io << distance_of_time_in_words(elapsed_time).colorize.cyan
         end
 
         puts message


### PR DESCRIPTION
## Purpose
Avoid intermediate strings. _No issue exists. Feel free to reject this PR_

## Description
This should improve performance. [Ref](https://crystal-lang.org/reference/1.16/guides/performance.html#dont-create-intermediate-strings-when-writing-to-an-io)

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [ ] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [ ] - Lucky builds on docker with `./script/setup`
* [ ] - All builds and specs pass on docker with `./script/test`
