### PR TITLE
Adding lots of types

### DIFF
--- a/src/lucky/asset_helpers.cr
+++ b/src/lucky/asset_helpers.cr
@@ -90,7 +90,7 @@ module Lucky::AssetHelpers
   # NOTE: This method does *not* check assets at compile time. The asset path
   # is found at runtime so it is possible the asset does not exist. Be sure to
   # manually test that the asset is returned as expected.
-  def dynamic_asset(path) : String
+  def dynamic_asset(path : String) : String
     fingerprinted_path = Lucky::AssetHelpers::ASSET_MANIFEST[path]?
     if fingerprinted_path
       Lucky::Server.settings.asset_host + fingerprinted_path

--- a/src/lucky/base_http_client.cr
+++ b/src/lucky/base_http_client.cr
@@ -132,7 +132,7 @@ abstract class Lucky::BaseHTTPClient
     @host = ""
     @port = -1
 
-    def self.from_app(app : Lucky::BaseAppServer)
+    def self.from_app(app : Lucky::BaseAppServer) : self
       self.new(HTTP::Server.build_middleware(app.middleware))
     end
 

--- a/src/lucky/cookies/flash_store.cr
+++ b/src/lucky/cookies/flash_store.cr
@@ -35,7 +35,7 @@ class Lucky::FlashStore
       get?(:{{ shortcut.id }})
     end
 
-    def {{ shortcut.id }}=(message : String)
+    def {{ shortcut.id }}=(message : String) : String
       set(:{{ shortcut.id }}, message)
     end
   {% end %}

--- a/src/lucky/data_response.cr
+++ b/src/lucky/data_response.cr
@@ -43,7 +43,7 @@ class Lucky::DataResponse < Lucky::Response
                  @debug_message : String? = nil)
   end
 
-  def print
+  def print : Nil
     set_response_headers
     context.response.print data
   end

--- a/src/lucky/error_action.cr
+++ b/src/lucky/error_action.cr
@@ -13,13 +13,13 @@ abstract class Lucky::ErrorAction
 
   getter context
 
-  def _dont_report
+  def _dont_report : Array(Exception.class)
     [] of Exception.class
   end
 
   macro dont_report(exception_classes)
     {% if exception_classes.is_a?(ArrayLiteral) %}
-      def _dont_report
+      def _dont_report : Array(Exception.class)
         {{ exception_classes }} of Exception.class
       end
     {% else %}

--- a/src/lucky/file_response.cr
+++ b/src/lucky/file_response.cr
@@ -53,7 +53,7 @@ class Lucky::FileResponse < Lucky::Response
                  @debug_message : String? = nil)
   end
 
-  def print
+  def print : Nil
     raise Lucky::MissingFileError.new(path) unless file_exists?
 
     set_response_headers
@@ -78,7 +78,7 @@ class Lucky::FileResponse < Lucky::Response
     !!filename
   end
 
-  def content_type
+  def content_type : String
     @content_type || content_type_from_file
   end
 

--- a/src/lucky/force_ssl_handler.cr
+++ b/src/lucky/force_ssl_handler.cr
@@ -32,7 +32,7 @@ class Lucky::ForceSSLHandler
     setting strict_transport_security : NamedTuple(max_age: Time::Span | Time::MonthSpan, include_subdomains: Bool)?
   end
 
-  def call(context)
+  def call(context : HTTP::Server::Context)
     if disabled?
       call_next(context)
     elsif secure?(context)
@@ -51,14 +51,14 @@ class Lucky::ForceSSLHandler
     context.request.headers["X-Forwarded-Proto"]? == "https"
   end
 
-  private def redirect_to_secure_version(context : HTTP::Server::Context)
+  private def redirect_to_secure_version(context : HTTP::Server::Context) : Nil
     context.response.status_code = settings.redirect_status
     context.response.headers["Location"] =
       "#{URI.new("https", context.request.headers["Host"]?)}#{context.request.resource}"
   end
 
   # Read more about [Strict-Transport-Security](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security)
-  private def add_transport_header_if_enabled(context : HTTP::Server::Context)
+  private def add_transport_header_if_enabled(context : HTTP::Server::Context) : Nil
     settings.strict_transport_security.try do |header|
       sts_value = String.build do |s|
         max_age = ensure_time_span(header[:max_age])

--- a/src/lucky/form_data_parser.cr
+++ b/src/lucky/form_data_parser.cr
@@ -3,7 +3,7 @@ class Lucky::FormDataParser
   getter body : String
   getter request : HTTP::Request
 
-  def initialize(@body, @request)
+  def initialize(@body : String, @request : HTTP::Request)
   end
 
   def form_data : Lucky::FormData

--- a/src/lucky/http_method_override_handler.cr
+++ b/src/lucky/http_method_override_handler.cr
@@ -1,21 +1,21 @@
 class Lucky::HttpMethodOverrideHandler
   include HTTP::Handler
 
-  def call(context)
+  def call(context : HTTP::Server::Context)
     http_method = overridden_http_method(context)
 
-    if override_allowed?(context, http_method) && http_method
+    if http_method && override_allowed?(context, http_method)
       context.request.method = http_method
     end
 
     call_next(context)
   end
 
-  private def override_allowed?(context, http_method) : Bool
+  private def override_allowed?(context : HTTP::Server::Context, http_method : String) : Bool
     (context.request.method == "POST") && ["PATCH", "PUT", "DELETE"].includes?(http_method)
   end
 
-  private def overridden_http_method(context) : String?
+  private def overridden_http_method(context : HTTP::Server::Context) : String?
     context.params.get?(:_method).try(&.upcase)
   rescue Lucky::ParamParsingError
     nil

--- a/src/lucky/log_handler.cr
+++ b/src/lucky/log_handler.cr
@@ -22,7 +22,7 @@ class Lucky::LogHandler
 
   delegate logger, to: Lucky
 
-  def call(context)
+  def call(context : HTTP::Server::Context)
     should_skip_logging = settings.skip_if.try &.call(context)
 
     if should_skip_logging

--- a/src/lucky/maximum_request_size_handler.cr
+++ b/src/lucky/maximum_request_size_handler.cr
@@ -18,7 +18,7 @@ class Lucky::MaximumRequestSizeHandler
     setting max_size : Int64 = 1_048_576_i64 # 1MB
   end
 
-  def call(context)
+  def call(context : HTTP::Server::Context)
     return call_next(context) unless settings.enabled
 
     body_size = 0

--- a/src/lucky/page_helpers/text_helpers.cr
+++ b/src/lucky/page_helpers/text_helpers.cr
@@ -151,7 +151,7 @@ module Lucky::TextHelpers
     "#{list[0..-2].join(word_connector)}#{last_word_connector}#{list.last}"
   end
 
-  private def normalize_values(values) : Array(String)
+  private def normalize_values(values : Enumerable) : Array(String)
     string_values = Array(String).new
     values.each { |v| string_values << v.to_s }
     string_values

--- a/src/lucky/page_helpers/url_helpers.cr
+++ b/src/lucky/page_helpers/url_helpers.cr
@@ -114,7 +114,7 @@ module Lucky::UrlHelpers
     URI.decode(query_params.map(&.join).sort!.join)
   end
 
-  private def referrer_header
+  private def referrer_header : String?
     request = context.request
     return unless request.headers.has_key?("Referer")
 

--- a/src/lucky/paginator/gap.cr
+++ b/src/lucky/paginator/gap.cr
@@ -2,7 +2,7 @@
 #
 # Used to represent a gap in a pagination series
 class Lucky::Paginator::Gap
-  def ==(other : self)
+  def ==(other : self) : Bool
     true # All gaps are equal to each other
   end
 end

--- a/src/lucky/paginator/page.cr
+++ b/src/lucky/paginator/page.cr
@@ -5,7 +5,7 @@ class Lucky::Paginator::Page
   def initialize(@pages : Lucky::Paginator, @number : Int32 | Int64)
   end
 
-  def path
+  def path : String
     @pages.path_to_page(number)
   end
 end

--- a/src/lucky/params.cr
+++ b/src/lucky/params.cr
@@ -649,11 +649,11 @@ class Lucky::Params
     Lucky::RequestBodyReader.new(request).body
   end
 
-  private def empty_params
+  private def empty_params : Hash(String, String)
     {} of String => String
   end
 
-  private def empty_file_params
+  private def empty_file_params : Hash(String, Lucky::UploadedFile)
     {} of String => Lucky::UploadedFile
   end
 
@@ -661,14 +661,14 @@ class Lucky::Params
     request.query_params
   end
 
-  private def get_all_json(key : String)
+  private def get_all_json(key : String) : Array(String)?
     val = parsed_json[key]?
-    return if val.nil?
+    return nil if val.nil?
 
     val.as_a?.try(&.map(&.to_s)) || [val.to_s]
   end
 
-  private def get_all_params(params, key : String)
+  private def get_all_params(params, key : String) : Array(String)?
     vals = params.fetch_all(key + "[]")
     if !vals.empty?
       vals

--- a/src/lucky/pretty_log_formatter.cr
+++ b/src/lucky/pretty_log_formatter.cr
@@ -28,7 +28,7 @@ struct Lucky::PrettyLogFormatter < Dexter::BaseFormatter
 
     abstract def write : Nil
 
-    def local_context
+    def local_context : Hash(String, ::Log::Metadata::Value)
       res = Hash(String, ::Log::Metadata::Value).new
 
       entry.context[:local]?.try &.as_h.each do |key, value|
@@ -42,7 +42,7 @@ struct Lucky::PrettyLogFormatter < Dexter::BaseFormatter
       io << " #{arrow} "
     end
 
-    private def arrow : String
+    private def arrow : Colorize::Object(String)
       arrow = "▸"
 
       case severity.value
@@ -134,7 +134,7 @@ struct Lucky::PrettyLogFormatter < Dexter::BaseFormatter
       end.join(". ")
     end
 
-    private def colored(value : String)
+    private def colored(value : String) : Colorize::Object(String)
       if printing_first_value_of_warning?
         value.colorize.bold.yellow
       else
@@ -142,7 +142,7 @@ struct Lucky::PrettyLogFormatter < Dexter::BaseFormatter
       end
     end
 
-    private def printing_first_value_of_warning?
+    private def printing_first_value_of_warning? : Bool
       severity.value == ::Log::Severity::Warn.value && index.zero?
     end
   end

--- a/src/lucky/pretty_log_formatter.cr
+++ b/src/lucky/pretty_log_formatter.cr
@@ -42,7 +42,7 @@ struct Lucky::PrettyLogFormatter < Dexter::BaseFormatter
       io << " #{arrow} "
     end
 
-    private def arrow
+    private def arrow : String
       arrow = "▸"
 
       case severity.value

--- a/src/lucky/protect_from_forgery.cr
+++ b/src/lucky/protect_from_forgery.cr
@@ -29,12 +29,12 @@ module Lucky::ProtectFromForgery
     end
   end
 
-  private def set_session_csrf_token
+  private def set_session_csrf_token : Nil
     session.get?(SESSION_KEY) ||
       session.set(SESSION_KEY, Random::Secure.urlsafe_base64(32))
   end
 
-  private def request_does_not_require_protection?
+  private def request_does_not_require_protection? : Bool
     ALLOWED_METHODS.includes? request.method
   end
 

--- a/src/lucky/remote_ip_handler.cr
+++ b/src/lucky/remote_ip_handler.cr
@@ -18,7 +18,7 @@ class Lucky::RemoteIpHandler
     setting ip_header_name : String = "X-Forwarded-For"
   end
 
-  def call(context)
+  def call(context : HTTP::Server::Context)
     context.request.remote_address = fetch_remote_ip(context)
     if ip_value = context.request.remote_address.as?(Socket::IPAddress).try(&.address.presence)
       context.request.remote_ip = ip_value

--- a/src/lucky/renderable.cr
+++ b/src/lucky/renderable.cr
@@ -112,12 +112,12 @@ module Lucky::Renderable
   # ```
   #
   macro disable_cookies
-    private def enable_cookies?
+    private def enable_cookies? : Bool
       false
     end
   end
 
-  private def enable_cookies?
+  private def enable_cookies? : Bool
     true
   end
 
@@ -197,22 +197,22 @@ module Lucky::Renderable
   end
 
   # The default global content-type header for HTML
-  def html_content_type
+  def html_content_type : String
     "text/html"
   end
 
   # The default global content-type header for JSON
-  def json_content_type
+  def json_content_type : String
     "application/json"
   end
 
   # The default global content-type header for XML
-  def xml_content_type
+  def xml_content_type : String
     "text/xml"
   end
 
   # The default global content-type header for Plain text
-  def plain_content_type
+  def plain_content_type : String
     "text/plain"
   end
 

--- a/src/lucky/request_id_handler.cr
+++ b/src/lucky/request_id_handler.cr
@@ -18,7 +18,7 @@ class Lucky::RequestIdHandler
     setting set_request_id : Proc(HTTP::Server::Context, String)? = nil
   end
 
-  def call(context)
+  def call(context : HTTP::Server::Context)
     context.request_id = settings.set_request_id.try &.call(context)
 
     call_next(context)

--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -93,7 +93,7 @@ module Lucky::Routable
       {{ body }}
     end
 
-    def call
+    def call : Lucky::Response
       # Ensure clients_desired_format is cached by calling it
       clients_desired_format
 

--- a/src/lucky/route_handler.cr
+++ b/src/lucky/route_handler.cr
@@ -3,7 +3,7 @@ require "colorize"
 class Lucky::RouteHandler
   include HTTP::Handler
 
-  def call(context)
+  def call(context : HTTP::Server::Context)
     handler = Lucky.router.find_action(context.request)
     if handler
       Lucky::Log.dexter.debug { {handled_by: handler.payload.to_s} }

--- a/src/lucky/route_not_found_handler.cr
+++ b/src/lucky/route_not_found_handler.cr
@@ -9,7 +9,7 @@ class Lucky::RouteNotFoundHandler
   include HTTP::Handler
   class_property fallback_action : Lucky::Action.class | Nil
 
-  def call(context)
+  def call(context : HTTP::Server::Context)
     if has_fallback?(context)
       Lucky::Log.dexter.debug { {handled_by_fallback: fallback_action.name.to_s} }
       fallback_action.new(context, {} of String => String).perform_action

--- a/src/lucky/secure_headers/disable_floc.cr
+++ b/src/lucky/secure_headers/disable_floc.cr
@@ -25,7 +25,7 @@ module Lucky
         continue
       end
 
-      private def floc_guard_value
+      private def floc_guard_value : String
         "interest-cohort=()"
       end
     end

--- a/src/lucky/secure_headers/set_frame_guard.cr
+++ b/src/lucky/secure_headers/set_frame_guard.cr
@@ -34,7 +34,7 @@ module Lucky
         continue
       end
 
-      private def check_frame_guard_value!(value : String)
+      private def check_frame_guard_value!(value : String) : String
         v = value.downcase
         case v
         when "sameorigin", "deny"

--- a/src/lucky/secure_headers/set_xss_guard.cr
+++ b/src/lucky/secure_headers/set_xss_guard.cr
@@ -24,7 +24,7 @@ module Lucky
         continue
       end
 
-      private def xss_guard_value
+      private def xss_guard_value : String
         useragent = context.request.headers.fetch("User-Agent", "").downcase
         value = "1; mode=block"
         useragent.match(/msie\s+(\d+)/).try { |match|

--- a/src/lucky/static_compression_handler.cr
+++ b/src/lucky/static_compression_handler.cr
@@ -18,7 +18,7 @@ class Lucky::StaticCompressionHandler
   def initialize(@public_dir : String, @file_ext = "gz", @content_encoding = "gzip")
   end
 
-  def call(context)
+  def call(context : HTTP::Server::Context)
     original_path = context.request.path.to_s
     request_path = URI.decode(original_path)
     file_path = File.join(@public_dir, request_path)

--- a/src/lucky/support/message_encryptor.cr
+++ b/src/lucky/support/message_encryptor.cr
@@ -58,7 +58,7 @@ module Lucky
       decrypted_data.to_slice
     end
 
-    private def set_cipher_key(cipher)
+    private def set_cipher_key(cipher) : Nil
       cipher.key = @secret
     rescue error : ArgumentError
       raise InvalidSecretKeyBase.new(<<-MESSAGE

--- a/src/lucky/support/message_verifier.cr
+++ b/src/lucky/support/message_verifier.cr
@@ -47,11 +47,11 @@ module Lucky
       encode({data, generate_digest(data)}.to_json)
     end
 
-    private def encode(data) : String
+    private def encode(data : String | Bytes) : String
       ::Base64.urlsafe_encode(data)
     end
 
-    private def decode(data) : Bytes
+    private def decode(data : String) : Bytes
       ::Base64.decode(data)
     end
 

--- a/src/lucky/verify_accepts_format.cr
+++ b/src/lucky/verify_accepts_format.cr
@@ -5,7 +5,7 @@ module Lucky::VerifyAcceptsFormat
   macro included
     before verify_accepted_format
 
-    def self._accepted_formats
+    def self._accepted_formats : Array(Symbol)
       [] of Symbol
     end
   end
@@ -59,7 +59,7 @@ module Lucky::VerifyAcceptsFormat
       {% formats.raise "#{@type} default format should be a symbol. Example: :html" %}
     {% end %}
 
-    def self._accepted_formats
+    def self._accepted_formats : Array(Symbol)
       {{ formats }}
     end
     default_format {{ default }}


### PR DESCRIPTION
## Purpose
In most cases, there were many areas just missing some simple types. Adding these helps with documentation, as well as all of the typesafety. This will also allow us to come back later and look at refactors where we can get rid of some of the Union types that may be unnecessary.

## Description


## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
