### PR TITLE
Allow customizing manifest retry timeout

### DIFF
--- a/src/lucky/server.cr
+++ b/src/lucky/server.cr
@@ -23,5 +23,11 @@ class Lucky::Server
       text/javascript
       text/plain
     )
+    # Number of times to retry loading the asset manifest file
+    # Can also be set with LUCKY_ASSET_MANIFEST_RETRY_COUNT env var at compile time
+    setting asset_manifest_retry_count : Int32 = 20
+    # Delay in seconds between manifest loading retries
+    # Can also be set with LUCKY_ASSET_MANIFEST_RETRY_DELAY env var at compile time
+    setting asset_manifest_retry_delay : Float64 = 0.25
   end
 end

--- a/src/run_macros/generate_asset_helpers.cr
+++ b/src/run_macros/generate_asset_helpers.cr
@@ -2,18 +2,21 @@ require "json"
 require "colorize"
 
 private class AssetManifestBuilder
-  MAX_RETRIES =   20
-  RETRY_AFTER = 0.25
-
   property retries
   @retries : Int32 = 0
   @manifest_path : String = File.expand_path("./public/mix-manifest.json")
   @use_vite : Bool = false
+  @max_retries : Int32
+  @retry_after : Float64
 
   def initialize
+    @max_retries = ENV["LUCKY_ASSET_MANIFEST_RETRY_COUNT"]?.try(&.to_i) || 20
+    @retry_after = ENV["LUCKY_ASSET_MANIFEST_RETRY_DELAY"]?.try(&.to_f) || 0.25
   end
 
   def initialize(@manifest_path, @use_vite : Bool = false)
+    @max_retries = ENV["LUCKY_ASSET_MANIFEST_RETRY_COUNT"]?.try(&.to_i) || 20
+    @retry_after = ENV["LUCKY_ASSET_MANIFEST_RETRY_DELAY"]?.try(&.to_f) || 0.25
   end
 
   def build_with_retry
@@ -29,9 +32,9 @@ private class AssetManifestBuilder
   end
 
   private def retry_or_raise_error
-    if retries < MAX_RETRIES
+    if retries < @max_retries
       self.retries += 1
-      sleep(RETRY_AFTER)
+      sleep(@retry_after)
       build_with_retry
     else
       raise_missing_manifest_error


### PR DESCRIPTION
The asset manifest retry logic now supports configuration through:
- Lucky::Server.settings.asset_manifest_retry_count (default: 20)
- Lucky::Server.settings.asset_manifest_retry_delay (default: 0.25)

These can also be set via environment variables at compile time:
- LUCKY_ASSET_MANIFEST_RETRY_COUNT
- LUCKY_ASSET_MANIFEST_RETRY_DELAY

This allows users to adjust the timeout based on their specific needs (e.g., slow CI systems, large projects).

Fixes #717

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
