### PR TITLE
Make BaseComponent fail at compile time for unused arguments

### DIFF
--- a/spec/lucky/component_spec.cr
+++ b/spec/lucky/component_spec.cr
@@ -117,7 +117,7 @@ describe "components rendering" do
     # but the following would fail to compile:
     # ComplexTestComponent.new(title: "test", unused_arg: "fail")
     # Error: no parameter named 'unused_arg'
-    
+
     # This ensures we maintain the expected behavior
     component = ComplexTestComponent.new(title: "test")
     component.render_to_string.should contain("test")

--- a/spec/lucky/component_spec.cr
+++ b/spec/lucky/component_spec.cr
@@ -105,6 +105,24 @@ describe "components rendering" do
     contents.should_not contain("<!--")
   end
 
+  it "accepts exact arguments that match 'needs' declarations" do
+    # Components should work fine when passed exact arguments
+    component = ComplexTestComponent.new(title: "test")
+    component.render_to_string.should contain("test")
+  end
+
+  it "does not accept unused arguments (compile-time validation)" do
+    # NOTE: Components now fail at compile time if passed unused arguments.
+    # This test can't demonstrate the failure since it would prevent compilation,
+    # but the following would fail to compile:
+    # ComplexTestComponent.new(title: "test", unused_arg: "fail")
+    # Error: no parameter named 'unused_arg'
+    
+    # This ensures we maintain the expected behavior
+    component = ComplexTestComponent.new(title: "test")
+    component.render_to_string.should contain("test")
+  end
+
   it "renders to a string" do
     html = ComplexTestComponent.new(title: "passed_in_title").render_to_string
 

--- a/src/lucky/assignable.cr
+++ b/src/lucky/assignable.cr
@@ -95,10 +95,10 @@ module Lucky::Assignable
                !dec.value.is_a?(Nop)
            has_explicit_value ? 1 : 0
          } %}
-      
+
       # Check if this is a BaseComponent - if so, don't accept unused exposures
       {% is_component = @type.ancestors.any? { |ancestor| ancestor.stringify == "Lucky::BaseComponent" } %}
-      
+
       def initialize(
         {% for declaration in sorted_assigns %}
           {% var = declaration.var %}

--- a/src/lucky/assignable.cr
+++ b/src/lucky/assignable.cr
@@ -95,6 +95,10 @@ module Lucky::Assignable
                !dec.value.is_a?(Nop)
            has_explicit_value ? 1 : 0
          } %}
+      
+      # Check if this is a BaseComponent - if so, don't accept unused exposures
+      {% is_component = @type.ancestors.any? { |ancestor| ancestor.stringify == "Lucky::BaseComponent" } %}
+      
       def initialize(
         {% for declaration in sorted_assigns %}
           {% var = declaration.var %}
@@ -103,7 +107,7 @@ module Lucky::Assignable
           {% value = nil if type.stringify.ends_with?("Nil") && value.nil? %}
           @{{ var.id }} : {{ type }}{% if !value.is_a?(Nop) %} = {{ value }}{% end %},
         {% end %}
-        **unused_exposures
+        {% unless is_component %}**unused_exposures{% end %}
         )
       end
     {% end %}


### PR DESCRIPTION
Components now have strict argument validation and will fail at compile time if passed arguments that don't correspond to declared 'needs'.

Pages continue to accept unused exposures for flexibility with global exposures, while components are now stricter to catch developer errors early.

This improves the developer experience by catching unused component arguments at compile time rather than silently ignoring them.

Includes tests documenting the new behavior and ensuring existing functionality remains intact.

Fixes #805

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
