### PR TITLE
Don't modify the original request path during route lookup

### DIFF
--- a/spec/lucky/format_integration_spec.cr
+++ b/spec/lucky/format_integration_spec.cr
@@ -19,7 +19,7 @@ private class TestReportsAction < TestAction
   end
 end
 
-describe "Format Integration", focus: true do
+describe "Format Integration" do
   it "handles URL format extensions correctly" do
     # Test CSV format from URL extension
     context = build_context(path: "/reports/123.csv")
@@ -56,15 +56,14 @@ describe "Format Integration", focus: true do
   end
 
   # testing https://github.com/luckyframework/lucky/issues/1999
-  it "handles other routes properly" do
+  it "doesn't modify the original path" do
     context = build_context(path: "/js/main.js")
-    handler = Lucky::RouteHandler.new.call(context)
-    handler.should eq(nil)
-
-    context = build_context(path: "/reports/main.js")
-    expect_raises Lucky::NotAcceptableError do
-      Lucky::RouteHandler.new.call(context)
-    end
+    handler = Lucky::RouteHandler.new
+    handler.next = ->(ctx : HTTP::Server::Context) {
+      ctx.request.path.should eq("/js/main.js")
+    }
+    result = handler.call(context)
+    result.should eq(nil)
   end
 
   it "supports multiple format extensions" do

--- a/src/lucky/route_handler.cr
+++ b/src/lucky/route_handler.cr
@@ -11,14 +11,12 @@ class Lucky::RouteHandler
       context._url_format = url_format
       # Create a modified request with format-stripped path for route matching
       path_without_format = original_path.sub(/^([^?]*)\.[a-zA-Z0-9]+(\?.*)?$/, "\\1\\2")
-      modified_request = context.request.dup
-      modified_request.path = path_without_format
-      lookup_request = modified_request
+      lookup_request_path = path_without_format
     else
-      lookup_request = context.request
+      lookup_request_path = original_path
     end
 
-    handler = Lucky.router.find_action(lookup_request)
+    handler = Lucky.router.find_action(context.request.method, lookup_request_path)
     if handler
       Lucky::Log.dexter.debug { {handled_by: handler.payload.to_s} }
       handler.payload.new(context, handler.params).perform_action


### PR DESCRIPTION
## Purpose
Fixes #1999

## Description
After a change in https://github.com/luckyframework/lucky/pull/1979 it was reported that static assets no longer render. 

This is because `request.dup` only creates a shallow clone. The `request.path` method is just a wrapper around `uri.path`. So when we modify the clone's `uri.path`, it modifies the original. 

Luckily we don't really need the request object to do a route lookup. We just need the HTTP Method and the path. This means we can get rid of the `request.dup` completely.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
