### PR TITLE
Add check for path aliases

### DIFF
--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -28,7 +28,7 @@ module Lucky::Routable
   # and http method (get, put, post, etc..) macros
   macro route_prefix(prefix)
     {% unless prefix.starts_with?("/") %}
-      {% prefix.raise "Prefix must start with a slash. Example: '/#{prefix}'" %}
+      {% prefix.raise %(Prefix must start with a slash. Example: "/#{prefix.id}") %}
     {% end %}
     {% ROUTE_SETTINGS[:prefix] = prefix %}
   end
@@ -85,7 +85,7 @@ module Lucky::Routable
   # Will respond to an `HTTP OPTIONS` request.
   macro match(method, path)
     {% unless path.starts_with?("/") %}
-      {% path.raise "Path must start with a slash. Example: '/#{path}'" %}
+      {% path.raise %(Path must start with a slash. Example: "/#{path.id}") %}
     {% end %}
 
     {% unless method == method.downcase %}


### PR DESCRIPTION
## Purpose
Adds a compile-time error in case a path alias is not prefixed with a `/`.

## Description
I got bitten by this today. Main routes and prefixes already do this check but not the aliases. I also fixed the punctuation on the other checks because they would render like:
```
 Error: Path must start with a slash. Example: '/"about"'
```
Now it's:
```
 Error: Path must start with a slash. Example: "/about"
```

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [X] - All specs are formatted with `crystal tool format spec src`
* [X] - Inline documentation has been added and/or updated
* [X] - Lucky builds on docker with `./script/setup`
* [X] - All builds and specs pass on docker with `./script/test`
