### PR TITLE
Allow passing arbitrary arguments for attributes to svg inliner

### DIFF
--- a/spec/lucky/text_helpers/svg_inliner_spec.cr
+++ b/spec/lucky/text_helpers/svg_inliner_spec.cr
@@ -20,6 +20,10 @@ class TextHelperTestPage
   def with_original_styles_and_additional_attributes
     inline_svg("lucky_logo.svg", strip_styling: false, data_very: "lucky")
   end
+
+  def without_file_extension
+    inline_svg("lucky_logo")
+  end
 end
 
 describe Lucky::SvgInliner do
@@ -68,6 +72,11 @@ describe Lucky::SvgInliner do
       inlined_svg = view.tap(&.with_original_styles_and_additional_attributes).render
       inlined_svg.should contain %(data-very="lucky")
       inlined_svg.should_not contain %(strip-styling="false")
+    end
+
+    it "allows passing the svg path name without an extension" do
+      inlined_svg = view.tap(&.without_file_extension).render
+      inlined_svg.should start_with %(<svg data-inline-svg="lucky_logo.svg")
     end
   end
 end

--- a/src/lucky/page_helpers/svg_inliner.cr
+++ b/src/lucky/page_helpers/svg_inliner.cr
@@ -10,6 +10,7 @@ module Lucky::SvgInliner
     {%
       svgs_path = Lucky::SvgInliner.annotation(Lucky::SvgInliner::Path).args.first
       regex = Lucky::SvgInliner.annotation(Lucky::SvgInliner::StripRegex).args.first
+      path = "#{path.id}.svg" unless path.ends_with?(".svg")
       full_path = "#{svgs_path.id}/#{path.id}"
 
       raise "SVG file #{full_path.id} is missing" unless file_exists?(full_path)


### PR DESCRIPTION
## Purpose
Makes it possible to add arbitrary attributes to inline SVGs. 

## Description
More than often I need to add attributes to inline SVGs, especially with ARIA, and sometimes class names or data attributes. Until now I've been adding them manually to the SVG source files, but it's easy to lose oversight and forget adding some attributes (like `aria-hidden` for example).

This PR makes it possible to add arbitrary attributes to the SVG tag:
```crystal
inline_svg("some/icon.svg", aria_hidden: true, class: "icon")
```
It also still works with the strip styling flag:
```crystal
inline_svg("some/icon.svg", false, data_very: "lucky")
# or
inline_svg("some/icon.svg", strip_styling: false, data_very: "lucky")
```
Finally something I wanted to add for a long time already, allowing to pass the file path without the extension:
```crystal
inline_svg("some/icon")
# resolves to "some/icon.svg"
```

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [X] - All specs are formatted with `crystal tool format spec src`
* [X] - Inline documentation has been added and/or updated
* [X] - Lucky builds on docker with `./script/setup`
* [X] - All builds and specs pass on docker with `./script/test`
