### PR TITLE
Checking Crystal 1.19 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: crystal-lang/install-crystal@v1
         with:
           crystal: latest
@@ -29,11 +29,12 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
+          - macos-latest
           - windows-latest
         shard_file:
           - shard.yml
         crystal_version:
-          - 1.15.1
+          - 1.16.3
           - latest
         experimental:
           - false
@@ -49,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: crystal-lang/install-crystal@v1
         with:
           crystal: ${{matrix.crystal_version}}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,13 +2,13 @@ name: Deploy docs
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: crystal-lang/install-crystal@v1

--- a/shard.yml
+++ b/shard.yml
@@ -1,7 +1,7 @@
 name: lucky
 version: 1.4.0
 
-crystal: ">= 1.15.1"
+crystal: ">= 1.16.3"
 
 authors:
   - Paul Smith <paulcsmith0218@gmail.com>

--- a/spec/lucky/format_edge_cases_spec.cr
+++ b/spec/lucky/format_edge_cases_spec.cr
@@ -245,9 +245,9 @@ describe "Format Detection Edge Cases" do
       long_path = "/very/long/path/" + ("segment/" * 1000) + "file.json"
 
       # Should still extract format efficiently
-      start_time = Time.monotonic
+      start_time = {% if compare_versions(Crystal::VERSION, "1.19.0") < 0 %}Time.monotonic{% else %}Time.instant{% end %}
       format = Lucky::MimeType.extract_format_from_path(long_path)
-      end_time = Time.monotonic
+      end_time = {% if compare_versions(Crystal::VERSION, "1.19.0") < 0 %}Time.monotonic{% else %}Time.instant{% end %}
 
       format.should eq Lucky::Format::Json
       (end_time - start_time).should be < 0.1.seconds # Should be very fast


### PR DESCRIPTION
## Purpose
Validating Crystal 1.19 works

## Description
This bumps the min supported Crystal version to 1.16. Though, lower versions of Crystal may work, Lucky will only guarantee that 1.16.3 at a minimum will be supported. Also making sure all the things are updated.