### PR TITLE
Add ability to create route objects with globs

### DIFF
--- a/spec/lucky/action_route_params_spec.cr
+++ b/spec/lucky/action_route_params_spec.cr
@@ -64,3 +64,54 @@ describe "Automatically generated param helpers" do
     typeof(action.leftover).should eq String?
   end
 end
+
+describe "Glob route URL building" do
+  it "builds URL with unnamed glob param using .with" do
+    TestGlobAction.with(glob: "some/path").path.should eq "/test_complex_posts_glob/some/path"
+  end
+
+  it "builds URL with named glob param using .with" do
+    TestNamedGlobAction.with(leftover: "some/path").path.should eq "/test_complex_posts_named_glob/some/path"
+  end
+
+  it "builds URL without glob param" do
+    TestGlobAction.with.path.should eq "/test_complex_posts_glob"
+    TestNamedGlobAction.with.path.should eq "/test_complex_posts_named_glob"
+  end
+
+  it "builds URL with nil glob param" do
+    TestGlobAction.with(glob: nil).path.should eq "/test_complex_posts_glob"
+    TestNamedGlobAction.with(leftover: nil).path.should eq "/test_complex_posts_named_glob"
+  end
+
+  it "URL-encodes special characters in glob segments" do
+    TestGlobAction.with(glob: "path with spaces/and more").path.should eq "/test_complex_posts_glob/path+with+spaces/and+more"
+  end
+
+  it "normalizes consecutive slashes in glob value" do
+    TestGlobAction.with(glob: "a//b").path.should eq "/test_complex_posts_glob/a/b"
+  end
+
+  it "strips leading slashes from glob value" do
+    TestGlobAction.with(glob: "/leading/slash").path.should eq "/test_complex_posts_glob/leading/slash"
+  end
+
+  it "builds URL with glob using .route" do
+    TestNamedGlobAction.route(leftover: "some/path").path.should eq "/test_complex_posts_named_glob/some/path"
+  end
+
+  it "builds path_without_query_params with glob" do
+    TestNamedGlobAction.path_without_query_params(leftover: "some/path").should eq "/test_complex_posts_named_glob/some/path"
+  end
+
+  it "builds url_without_query_params with glob" do
+    Lucky::RouteHelper.temp_config(base_uri: "example.com") do
+      TestNamedGlobAction.url_without_query_params(leftover: "some/path").should eq "example.com/test_complex_posts_named_glob/some/path"
+    end
+  end
+
+  it "returns correct RouteHelper with glob" do
+    route_helper = TestGlobAction.with(glob: "a/b/c")
+    route_helper.should eq Lucky::RouteHelper.new(:get, "/test_complex_posts_glob/a/b/c")
+  end
+end


### PR DESCRIPTION
## Purpose
Fixes #1926

## Description
This allows you to construct a route helper object for an action that contains a glob. This becomes useful for writing specs.

```crystal
class Reporting::Index < BrowserAction
  get "/reporting/*:filter" do
    # ...
  end
end

# this is now possible
Reporting::Index.with(filter: "2025/TPS")
```


## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
