### PR TITLE
Adding new flag for routes task to output routes as JSON

### DIFF
--- a/spec/tasks/routes_spec.cr
+++ b/spec/tasks/routes_spec.cr
@@ -1,0 +1,79 @@
+require "../spec_helper"
+
+# Test action with params for routes JSON output
+private class RoutesTaskTestAction < TestAction
+  param page : Int32?
+  param search : String?
+
+  get "/routes_task_test" do
+    plain_text "test"
+  end
+end
+
+describe Routes do
+  describe "Format JSON" do
+    it "outputs routes as JSON" do
+      task = Routes.new
+      task.output = IO::Memory.new
+      task.print_help_or_call(args: ["--format=json"])
+
+      output = task.output.to_s
+      json = JSON.parse(output)
+
+      json.should be_a(JSON::Any)
+      json.as_a.should_not be_empty
+    end
+
+    it "includes method, path, action, and params in JSON output" do
+      task = Routes.new
+      task.output = IO::Memory.new
+      task.print_help_or_call(args: ["--with-params", "-f", "json"])
+
+      output = task.output.to_s
+      json = JSON.parse(output)
+      routes = json.as_a
+
+      # Find our test action in the routes
+      test_route = routes.find! { |route| route["action"].as_s == "RoutesTaskTestAction" }
+
+      test_route["method"].as_s.should eq "GET"
+      test_route["path"].as_s.should eq "/routes_task_test"
+      test_route["action"].as_s.should eq "RoutesTaskTestAction"
+
+      params = test_route["params"].as_a
+      params.size.should eq 2
+
+      page_param = params.find! { |param| param["name"].as_s == "page" }
+      page_param["type"].as_s.should contain "Int32"
+
+      search_param = params.find! { |param| param["name"].as_s == "search" }
+      search_param["type"].as_s.should contain "String"
+    end
+
+    it "excludes HEAD routes from JSON output" do
+      task = Routes.new
+      task.output = IO::Memory.new
+      task.print_help_or_call(args: ["--format=json"])
+
+      output = task.output.to_s
+      json = JSON.parse(output)
+      routes = json.as_a
+
+      head_routes = routes.select { |route| route["method"].as_s == "HEAD" }
+      head_routes.should be_empty
+    end
+  end
+
+  describe "default table output" do
+    it "still works without format flag" do
+      task = Routes.new
+      task.output = IO::Memory.new
+      task.print_help_or_call(args: [] of String)
+
+      output = task.output.to_s
+      output.should contain "Verb"
+      output.should contain "URI"
+      output.should contain "Action"
+    end
+  end
+end

--- a/tasks/routes.cr
+++ b/tasks/routes.cr
@@ -1,6 +1,7 @@
 require "lucky_task"
 require "colorize"
 require "shell-table"
+require "json"
 
 class Routes < LuckyTask::Task
   summary "Show all the routes for the app"
@@ -12,17 +13,35 @@ class Routes < LuckyTask::Task
 
   example: lucky routes --with-params
 
+  You can also output routes as JSON using the --format flag (-f).
+
+  example: lucky routes --format=json
+
   Routing documentation:
 
       https://luckyframework.org/guides/http-and-routing/routing-and-params
   TEXT
 
   switch :with_params, "Include action params with each route", shortcut: "-p"
+  arg :format, "Output format (table or json)", shortcut: "-f", optional: true
 
   def call
-    routes = [] of Array(String)
+    routes = Lucky.router.list_routes
 
-    Lucky.router.list_routes.each do |path, method, action|
+    formatted = case format
+                when "json"
+                  build_json_from_routes(routes)
+                else
+                  build_table_from_routes(routes)
+                end
+
+    output.puts formatted
+  end
+
+  private def build_table_from_routes(routes : Array(Tuple(String, String, Lucky::Action.class))) : String
+    rows = [] of Array(String)
+
+    routes.each do |path, method, action|
       # skip HEAD routes
       # LuckyRouter creates these routes from any GET routes submitted
       # This could be an issue if users define their own HEAD routes
@@ -32,7 +51,7 @@ class Routes < LuckyTask::Task
       row << method.upcase
       row << path.colorize.green.to_s
       row << action.name
-      routes << row
+      rows << row
 
       if with_params?
         action.query_param_declarations.each do |param|
@@ -40,7 +59,7 @@ class Routes < LuckyTask::Task
           param_row << " "
           param_row << " #{dim_arrow} #{param}"
           param_row << " "
-          routes << param_row
+          rows << param_row
         end
       end
     end
@@ -48,21 +67,55 @@ class Routes < LuckyTask::Task
     table = ShellTable.new(
       labels: ["Verb", "URI", "Action"],
       label_color: :white,
-      rows: routes
+      rows: rows
     )
 
-    output.puts <<-TEXT
+    <<-TEXT
     #{print_banner_message}
 
     #{table}
     TEXT
   end
 
-  private def dim_arrow
+  private def build_json_from_routes(routes : Array(Tuple(String, String, Lucky::Action.class))) : String
+    info = [] of RouteInfo
+    routes.each do |path, method, action|
+      next if method.upcase == "HEAD"
+
+      params = if with_params?
+                 action.query_param_declarations.map do |param|
+                   # param format is "name : Type" - split and trim
+                   parts = param.split(" : ", 2)
+                   ParamInfo.new(name: parts[0], type: parts[1]? || "String")
+                 end
+               else
+                 [] of ParamInfo
+               end
+
+      info << RouteInfo.new(
+        method: method.upcase,
+        path: path,
+        action: action.name,
+        params: params
+      )
+    end
+
+    info.to_pretty_json
+  end
+
+  private record ParamInfo, name : String, type : String do
+    include JSON::Serializable
+  end
+
+  private record RouteInfo, method : String, path : String, action : String, params : Array(ParamInfo) do
+    include JSON::Serializable
+  end
+
+  private def dim_arrow : Colorize::Object(String)
     "▸".colorize.dim
   end
 
-  private def print_banner_message
+  private def print_banner_message : Colorize::Object(String)
     <<-TEXT.colorize.dim
 
     Routing documentation:


### PR DESCRIPTION
## Purpose
Fixes #1852

## Description
This adds a new optional output format to print the routes of your app as a JSON structure that looks like

```
lucky routes --with-params --format=json
```

```json
[
  {
    "method": "GET",
    "path": "/",
    "action": "Home::Index",
    "params": []
  },
  {
    "method": "POST",
    "path": "/alerts",
    "action": "Alerts::Create",
    "params": [
      {
        "name": "title",
        "type": "String"
      }
     ]
  }
]
```

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
