### PR TITLE
Encrypt and sign cookies in the CookieJar.

### DIFF
--- a/spec/lucky/cookies/cookie_jar_spec.cr
+++ b/spec/lucky/cookies/cookie_jar_spec.cr
@@ -84,14 +84,27 @@ describe Lucky::CookieJar do
     # meant to be a regression test to make sure we don't
     # accidentally break cookie decryption
     #
+    # this cookie was created with Lucky 1.5
+    cookie_key = "cookie_key"
+    cookie_value = "bHVja3k=--WyJuaEd0U1poaVRPeUdkTlRSMVVKSURBTUc2bGgyN1l1d3RUZE1rZnR4OVNaVG1vbmNkUU9UT1ZlNzZzWmoySlhjIiwiMHFLa3ZFS1RBMFRMaTZsTFZwT1Z3NFNGMUVzPSJd"
+    cookies = HTTP::Cookies.new
+    cookies[cookie_key] = cookie_value
+    jar = Lucky::CookieJar.from_request_cookies(cookies)
+
+    JSON.parse(jar.get(cookie_key)).should eq({"key" => "value", "abc" => "123"})
+  end
+
+  it "returns nil when a valid cookie from a former Lucky version is decrypted" do
+    # Previous versions of Lucky had a vulnerability
+    # and the encrypted cookie can't be decrypted
+    #
     # this cookie was created with Lucky 0.27
     cookie_key = "cookie_key"
     cookie_value = "bHVja3k=--hY71kbRfob4pb9NS7wJpWKOBRhF+kwYPsHRQQanyXzGSKsCO6MIHCZfRBxDRqqm6"
     cookies = HTTP::Cookies.new
     cookies[cookie_key] = cookie_value
     jar = Lucky::CookieJar.from_request_cookies(cookies)
-
-    JSON.parse(jar.get(cookie_key)).should eq({"key" => "value", "abc" => "123"})
+    jar.get?(cookie_key).should eq(nil)
   end
 
   describe "#set" do

--- a/src/lucky/cookies/cookie_jar.cr
+++ b/src/lucky/cookies/cookie_jar.cr
@@ -138,11 +138,11 @@ class Lucky::CookieJar
   end
 
   private def encrypt(raw_value : String) : String
-    encrypted = encryptor.encrypt(raw_value)
+    encrypted = encryptor.encrypt_and_sign(raw_value)
 
     String.build do |value|
       value << LUCKY_ENCRYPTION_PREFIX
-      value << Base64.strict_encode(encrypted)
+      value << encrypted
     end
   end
 
@@ -150,11 +150,24 @@ class Lucky::CookieJar
     return unless encrypted_with_lucky?(cookie_value)
 
     base_64_encrypted_part = cookie_value.lchop(LUCKY_ENCRYPTION_PREFIX)
-    decoded = Base64.decode(base_64_encrypted_part)
-    String.new(encryptor.decrypt(decoded))
+
+    begin
+      String.new(encryptor.verify_and_decrypt(base_64_encrypted_part))
+    rescue
+      decrypt_unsigned_cookie(base_64_encrypted_part)
+    end
   rescue e
     # an error happened while decrypting the cookie
     # we will treat that as if no cookie was passed
+  end
+
+  # Fallback for cookies encrypted without HMAC signing (pre-Lucky 1.5).
+  # Without HMAC verification, decryption with the wrong key may silently
+  # return garbage data instead of failing (~1/256 chance of valid PKCS padding).
+  @[Deprecated("Unsigned cookie encryption is deprecated. Re-issue cookies to upgrade them to the signed format.")]
+  private def decrypt_unsigned_cookie(base_64_encrypted_part : String) : String?
+    decoded = Base64.decode(base_64_encrypted_part)
+    String.new(encryptor.decrypt(decoded))
   end
 
   private def encrypted_with_lucky?(value : String) : Bool

--- a/src/lucky/cookies/cookie_jar.cr
+++ b/src/lucky/cookies/cookie_jar.cr
@@ -150,24 +150,10 @@ class Lucky::CookieJar
     return unless encrypted_with_lucky?(cookie_value)
 
     base_64_encrypted_part = cookie_value.lchop(LUCKY_ENCRYPTION_PREFIX)
-
-    begin
-      String.new(encryptor.verify_and_decrypt(base_64_encrypted_part))
-    rescue
-      decrypt_unsigned_cookie(base_64_encrypted_part)
-    end
+    String.new(encryptor.verify_and_decrypt(base_64_encrypted_part))
   rescue e
     # an error happened while decrypting the cookie
     # we will treat that as if no cookie was passed
-  end
-
-  # Fallback for cookies encrypted without HMAC signing (pre-Lucky 1.5).
-  # Without HMAC verification, decryption with the wrong key may silently
-  # return garbage data instead of failing (~1/256 chance of valid PKCS padding).
-  @[Deprecated("Unsigned cookie encryption is deprecated. Re-issue cookies to upgrade them to the signed format.")]
-  private def decrypt_unsigned_cookie(base_64_encrypted_part : String) : String?
-    decoded = Base64.decode(base_64_encrypted_part)
-    String.new(encryptor.decrypt(decoded))
   end
 
   private def encrypted_with_lucky?(value : String) : Bool

--- a/src/lucky/support/message_encryptor.cr
+++ b/src/lucky/support/message_encryptor.cr
@@ -12,7 +12,7 @@ module Lucky
     end
 
     # Encrypt and sign a message. We need to sign the message in order to avoid
-    # padding attacks. Reference: http://www.limited-entropy.com/padding-oracle-attacks.
+    # padding attacks. Reference: https://en.wikipedia.org/wiki/Padding_oracle_attack.
     def encrypt_and_sign(value : Slice(UInt8)) : String
       verifier.generate(encrypt(value))
     end
@@ -22,7 +22,7 @@ module Lucky
     end
 
     # Verify and Decrypt a message. We need to verify the message in order to
-    # avoid padding attacks. Reference: http://www.limited-entropy.com/padding-oracle-attacks.
+    # avoid padding attacks. Reference: https://en.wikipedia.org/wiki/Padding_oracle_attack.
     def verify_and_decrypt(value : String) : Bytes
       decrypt(verifier.verify_raw(value))
     end


### PR DESCRIPTION
## Purpose
Fixes #2025

## Description
> [!WARNING]
> This is a breaking change because any cookies out there that were encrypted before this change won't decrypt properly.

I've seen this flaky spec pop up a few times in the past, but it's pretty rare... In fact, it's a 1/256 chance rare lol. This appears to be an oversight that's just never been caught. We've been missing the whole verification part of the encryption.

I'd like to get your opinion on this, @akadusei if you get some time

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
