### PR TITLE
Make sure css is always reloaded

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -53,6 +53,9 @@ dependencies:
     version: ~> 0.2.0
 
 development_dependencies:
+  lucky_env:
+    github: luckyframework/lucky_env
+    version: ~> 0.3.0
   ameba:
     github: crystal-ameba/ameba
     version: ~> 1.6.4

--- a/spec/lucky/specialty_tags_spec.cr
+++ b/spec/lucky/specialty_tags_spec.cr
@@ -26,14 +26,32 @@ describe Lucky::SpecialtyTags do
     HTML
   end
 
-  it "cache-busts local css links in development" do
+  it "cache-busts non-fingerprinted local css links" do
     html = view(&.css_link("/assets/css/app.css"))
 
     html.should contain "bust="
   end
 
+  it "does not cache-bust fingerprinted local css links" do
+    html = view(&.css_link("/assets/css/app-5e6f7a8b.css"))
+
+    html.should_not contain "bust="
+  end
+
   it "does not cache-bust external css links" do
     html = view(&.css_link("https://fonts.googleapis.com/css?family=Inter"))
+
+    html.should_not contain "bust="
+  end
+
+  it "does not cache-bust protocol-relative css links" do
+    html = view(&.css_link("//cdn.example.com/style.css"))
+
+    html.should_not contain "bust="
+  end
+
+  it "does not cache-bust css links outside the asset path" do
+    html = view(&.css_link("/other/path/style.css"))
 
     html.should_not contain "bust="
   end

--- a/spec/lucky/specialty_tags_spec.cr
+++ b/spec/lucky/specialty_tags_spec.cr
@@ -26,6 +26,18 @@ describe Lucky::SpecialtyTags do
     HTML
   end
 
+  it "cache-busts local css links in development" do
+    html = view(&.css_link("/assets/css/app.css"))
+
+    html.should contain "bust="
+  end
+
+  it "does not cache-bust external css links" do
+    html = view(&.css_link("https://fonts.googleapis.com/css?family=Inter"))
+
+    html.should_not contain "bust="
+  end
+
   it "renders js link tag" do
     view(&.js_link("app.js")).should contain <<-HTML
     <script src="app.js"></script>
@@ -60,6 +72,29 @@ describe Lucky::SpecialtyTags do
     view(&.canonical_link("https://it.is/here")).should contain <<-HTML
     <link href="https://it.is/here" rel="canonical">
     HTML
+  end
+
+  it "renders bun reload script in development" do
+    html = view(&.bun_reload_connect_tag)
+
+    html.should contain "<script>"
+    html.should contain "new WebSocket"
+    html.should contain "ws://127.0.0.1:3002"
+  end
+
+  it "uses bust param for css hmr" do
+    html = view(&.bun_reload_connect_tag)
+
+    html.should contain "searchParams.set('bust'"
+  end
+
+  it "does not render bun reload script in production" do
+    ENV["LUCKY_ENV"] = "production"
+    html = view(&.bun_reload_connect_tag)
+
+    html.should_not contain "<script>"
+  ensure
+    ENV["LUCKY_ENV"] = "development"
   end
 
   it "renders proper non-breaking space entity" do

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,4 +1,5 @@
 require "spec"
+require "lucky_env"
 require "../src/lucky"
 require "../tasks/**"
 require "./support/**"

--- a/src/bun/config.cr
+++ b/src/bun/config.cr
@@ -63,6 +63,8 @@ module LuckyBun
       end
     end
 
+    class_getter instance : Config { load }
+
     def self.load : Config
       Config.from_json(File.read(File.expand_path(CONFIG_PATH)))
     rescue File::NotFoundError

--- a/src/lucky/tags/bun_reload_tag.cr
+++ b/src/lucky/tags/bun_reload_tag.cr
@@ -7,12 +7,11 @@ module Lucky::BunReloadTag
   def bun_reload_connect_tag
     return unless LuckyEnv.development?
 
-    config = LuckyBun::Config.load
     tag "script" do
       raw <<-JS
       (() => {
-        const cssPaths = #{bun_reload_connect_css_files(config).to_json};
-        const ws = new WebSocket('#{config.dev_server.ws_url}')
+        const cssPaths = #{bun_reload_connect_css_files.to_json};
+        const ws = new WebSocket('#{LuckyBun::Config.instance.dev_server.ws_url}')
         let connected = false
 
         ws.onmessage = (event) => {
@@ -49,11 +48,9 @@ module Lucky::BunReloadTag
   end
 
   # Collects all CSS entrypoints at their public paths.
-  private def bun_reload_connect_css_files(
-    config : LuckyBun::Config,
-  ) : Array(String)
+  private def bun_reload_connect_css_files : Array(String)
     Lucky::AssetHelpers.css_entry_points.map do |key|
-      File.join(config.public_path, key)
+      File.join(LuckyBun::Config.instance.public_path, key)
     end
   end
 end

--- a/src/lucky/tags/bun_reload_tag.cr
+++ b/src/lucky/tags/bun_reload_tag.cr
@@ -22,7 +22,7 @@ module Lucky::BunReloadTag
               const linkPath = new URL(link.href).pathname.split('?')[0]
               if (cssPaths.some(p => linkPath.startsWith(p))) {
                 const url = new URL(link.href)
-                url.searchParams.set('r', Date.now())
+                url.searchParams.set('bust', Date.now())
                 link.href = url.toString()
               }
             })

--- a/src/lucky/tags/specialty_tags.cr
+++ b/src/lucky/tags/specialty_tags.cr
@@ -8,10 +8,7 @@ module Lucky::SpecialtyTags
   #
   # Additional tag attributes can be passed in keyword arguments via *options*.
   def css_link(href, **options) : Nil
-    if href.starts_with?(LuckyBun::Config.instance.public_path) &&
-       href !~ /-[0-9a-f]{8}\.css$/
-      href = "#{href}#{href.includes?('?') ? '&' : '?'}bust=#{Time.utc.to_unix_ms}"
-    end
+    href = build_css_link_href_with_timestamp(href)
     options = {href: href, rel: "stylesheet", media: "screen"}.merge(options)
     empty_tag "link", **options
   end
@@ -84,6 +81,24 @@ module Lucky::SpecialtyTags
   def nbsp(how_many : Int32 = 1) : Nil
     how_many.times { raw("&nbsp;") }
     view
+  end
+
+  private def build_css_link_href_with_timestamp(href) : String
+    config = LuckyBun::Config.instance
+    return href unless href.starts_with?(config.public_path)
+    return href if href =~ /-[0-9a-f]{8}\.css$/
+
+    String.build do |io|
+      file_path = href.sub(config.public_path, config.out_dir)
+      io << href
+      io << (href.includes?('?') ? '&' : '?')
+      io << "bust="
+      if File.exists?(file_path)
+        io << File.info(file_path).modification_time.to_unix
+      else
+        io << Time.utc.to_unix
+      end
+    end
   end
 
   private def build_viewport_properties(options) : String

--- a/src/lucky/tags/specialty_tags.cr
+++ b/src/lucky/tags/specialty_tags.cr
@@ -8,6 +8,9 @@ module Lucky::SpecialtyTags
   #
   # Additional tag attributes can be passed in keyword arguments via *options*.
   def css_link(href, **options) : Nil
+    if LuckyEnv.development? && href.starts_with?(LuckyBun::Config.instance.public_path)
+      href = "#{href}#{href.includes?('?') ? '&' : '?'}bust=#{Time.utc.to_unix_ms}"
+    end
     options = {href: href, rel: "stylesheet", media: "screen"}.merge(options)
     empty_tag "link", **options
   end

--- a/src/lucky/tags/specialty_tags.cr
+++ b/src/lucky/tags/specialty_tags.cr
@@ -8,7 +8,8 @@ module Lucky::SpecialtyTags
   #
   # Additional tag attributes can be passed in keyword arguments via *options*.
   def css_link(href, **options) : Nil
-    if LuckyEnv.development? && href.starts_with?(LuckyBun::Config.instance.public_path)
+    if href.starts_with?(LuckyBun::Config.instance.public_path) &&
+       href !~ /-[0-9a-f]{8}\.css$/
       href = "#{href}#{href.includes?('?') ? '&' : '?'}bust=#{Time.utc.to_unix_ms}"
     end
     options = {href: href, rel: "stylesheet", media: "screen"}.merge(options)


### PR DESCRIPTION
## Purpose
Makes sure CSS is always fresh when using libraries like Turbo, HTMX, or AlpineAjax.

## Description
While working on CSS in a project, I noticed that old CSS would be shown after a hot reload when moving away from the page you're working on using Turbo. That is because the CSS hot reload adds a timestamp to get a fresh version in real time, but when moving away using Turbo, the timestamp is gone, and when navigating with Turbo [`Lucky::DevAssetCacheHandler`](https://github.com/luckyframework/lucky/blob/1399ce07f682aede964e0bfa91111024392a3c12/src/lucky/dev_asset_cache_handler.cr#L4) can't do its job. So we also need to add a timestamp to CSS files on the Lucky side in development.

Come to think of it, is lucky_cli adding the header for new apps as well?

```crystal
  def middleware : Array(HTTP::Handler)
    [
      Lucky::RequestIdHandler.new,
      Lucky::ForceSSLHandler.new,
      Lucky::HttpMethodOverrideHandler.new,
      Lucky::LogHandler.new,
      Lucky::ErrorHandler.new(action: Errors::Show),
      Raven::Lucky::ErrorHandler.new,
      Lucky::RemoteIpHandler.new,
      Lucky::RouteHandler.new,
      Lucky::DevAssetCacheHandler.new(enabled: LuckyEnv.development?), # <= this one
      Lucky::StaticCompressionHandler.new("./public", file_ext: "gz", content_encoding: "gzip"),
      Lucky::StaticFileHandler.new("./public", fallthrough: false, directory_listing: false),
      Lucky::RouteNotFoundHandler.new,
    ] of HTTP::Handler
  end
```

And I'm not sure about the `enabled: LuckyEnv.development?` part in the handler. Is that a good pattern? Or should we conditionally add it to the handlers list instead?

Also, I've added lucky_env as a dev dependency. Not sure it that's okay or not, but I needed it for testing the `bun_connect_reload_tag`. Or we could take out the guard and move it to layout head like lucky's reload tag.

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [X] - All specs are formatted with `crystal tool format spec src`
* [X] - Inline documentation has been added and/or updated
* [X] - Lucky builds on docker with `./script/setup`
* [X] - All builds and specs pass on docker with `./script/test`
