### PR TITLE
Add bun exclusion clauses and more flag options

### DIFF
--- a/spec/bun/lucky.test.js
+++ b/spec/bun/lucky.test.js
@@ -1,6 +1,6 @@
 import {describe, test, expect, beforeEach, afterAll} from 'bun:test'
 import {mkdirSync, writeFileSync, rmSync, existsSync, readFileSync} from 'fs'
-import {join} from 'path'
+import {join, basename} from 'path'
 import LuckyBun from '../../src/bun/lucky.js'
 
 const TEST_DIR = join(process.cwd(), '.test-tmp')
@@ -14,6 +14,9 @@ beforeEach(() => {
   LuckyBun.debug = false
   LuckyBun.prod = false
   LuckyBun.dev = false
+  LuckyBun.fingerprint = false
+  LuckyBun.minify = false
+  LuckyBun.sourcemap = null
   LuckyBun.root = TEST_DIR
 })
 
@@ -57,9 +60,6 @@ describe('flags', () => {
     LuckyBun.flags({dev: true})
     expect(LuckyBun.dev).toBe(true)
 
-    LuckyBun.flags({prod: true})
-    expect(LuckyBun.prod).toBe(true)
-
     LuckyBun.flags({debug: true})
     expect(LuckyBun.debug).toBe(true)
 
@@ -67,6 +67,50 @@ describe('flags', () => {
     LuckyBun.flags({prod: false})
     expect(LuckyBun.dev).toBe(true)
     expect(LuckyBun.prod).toBe(false)
+  })
+
+  test('--prod implies --fingerprint and --minify', () => {
+    LuckyBun.flags({prod: true})
+    expect(LuckyBun.prod).toBe(true)
+    expect(LuckyBun.fingerprint).toBe(true)
+    expect(LuckyBun.minify).toBe(true)
+  })
+
+  test('explicit fingerprint/minify override prod implication', () => {
+    LuckyBun.flags({prod: true, minify: false})
+    expect(LuckyBun.prod).toBe(true)
+    expect(LuckyBun.fingerprint).toBe(true)
+    expect(LuckyBun.minify).toBe(false)
+  })
+
+  test('fingerprint and minify can be set without prod', () => {
+    LuckyBun.flags({fingerprint: true})
+    expect(LuckyBun.prod).toBe(false)
+    expect(LuckyBun.fingerprint).toBe(true)
+    expect(LuckyBun.minify).toBe(false)
+  })
+
+  test('sourcemap accepts a string value', () => {
+    LuckyBun.flags({sourcemap: 'external'})
+    expect(LuckyBun.sourcemap).toBe('external')
+  })
+
+  test('parses argv arrays', () => {
+    LuckyBun.flags(['--prod', '--sourcemap=none'])
+    expect(LuckyBun.prod).toBe(true)
+    expect(LuckyBun.fingerprint).toBe(true)
+    expect(LuckyBun.minify).toBe(true)
+    expect(LuckyBun.sourcemap).toBe('none')
+  })
+
+  test('bare --sourcemap defaults to linked', () => {
+    LuckyBun.flags(['--sourcemap'])
+    expect(LuckyBun.sourcemap).toBe('linked')
+  })
+
+  test('ignores invalid --sourcemap value', () => {
+    LuckyBun.flags(['--sourcemap=bogus'])
+    expect(LuckyBun.sourcemap).toBe(null)
   })
 })
 
@@ -156,17 +200,17 @@ describe('loadConfig', () => {
   })
 })
 
-describe('fingerprint', () => {
-  test('returns plain filename in dev mode', () => {
-    expect(LuckyBun.fingerprint('app', '.js', 'content')).toBe('app.js')
+describe('fingerprintName', () => {
+  test('returns plain filename when fingerprint is off', () => {
+    expect(LuckyBun.fingerprintName('app', '.js', 'content')).toBe('app.js')
   })
 
-  test('returns consistent, content-dependent hashes in prod mode', () => {
-    LuckyBun.prod = true
-    const hash = LuckyBun.fingerprint('app', '.js', 'content')
+  test('returns consistent, content-dependent hashes when enabled', () => {
+    LuckyBun.fingerprint = true
+    const hash = LuckyBun.fingerprintName('app', '.js', 'content')
     expect(hash).toMatch(/^app-[a-f0-9]{8}\.js$/)
-    expect(LuckyBun.fingerprint('app', '.js', 'content')).toBe(hash)
-    expect(LuckyBun.fingerprint('app', '.js', 'different')).not.toBe(hash)
+    expect(LuckyBun.fingerprintName('app', '.js', 'content')).toBe(hash)
+    expect(LuckyBun.fingerprintName('app', '.js', 'different')).not.toBe(hash)
   })
 })
 
@@ -204,12 +248,48 @@ describe('buildAssets', () => {
     expect(existsSync(join(TEST_DIR, 'public/assets/css/app.css'))).toBe(true)
   })
 
-  test('fingerprints in prod mode', async () => {
-    LuckyBun.prod = true
+  test('fingerprints when fingerprint is enabled', async () => {
+    LuckyBun.fingerprint = true
     await setupProject({'src/js/app.js': 'console.log("prod")'})
     await LuckyBun.buildJS()
 
     expect(LuckyBun.manifest['js/app.js']).toMatch(/^js\/app-[a-f0-9]{8}\.js$/)
+  })
+
+  test('writes linked sourcemap alongside JS', async () => {
+    LuckyBun.sourcemap = 'linked'
+    await setupProject({'src/js/app.js': 'console.log("maps")'})
+    await LuckyBun.buildJS()
+
+    const js = readOutput('js/app.js')
+    expect(existsSync(join(TEST_DIR, 'public/assets/js/app.js.map'))).toBe(true)
+    expect(js).toContain('//# sourceMappingURL=app.js.map')
+  })
+
+  test('renames sourcemap and rewrites URL when fingerprinting', async () => {
+    LuckyBun.fingerprint = true
+    LuckyBun.sourcemap = 'linked'
+    await setupProject({'src/js/app.js': 'console.log("both")'})
+    await LuckyBun.buildJS()
+
+    const fingerprinted = LuckyBun.manifest['js/app.js']
+    const jsPath = join(TEST_DIR, 'public/assets', fingerprinted)
+    const mapPath = `${jsPath}.map`
+    expect(existsSync(jsPath)).toBe(true)
+    expect(existsSync(mapPath)).toBe(true)
+
+    const js = readFileSync(jsPath, 'utf-8')
+    const mapName = basename(mapPath)
+    expect(js).toContain(`//# sourceMappingURL=${mapName}`)
+    expect(js).not.toContain('//# sourceMappingURL=app.js.map')
+  })
+
+  test('omits sourcemap file when set to none', async () => {
+    LuckyBun.sourcemap = 'none'
+    await setupProject({'src/js/app.js': 'console.log("bare")'})
+    await LuckyBun.buildJS()
+
+    expect(existsSync(join(TEST_DIR, 'public/assets/js/app.js.map'))).toBe(false)
   })
 
   test('warns on missing entry point and continues', async () => {
@@ -309,8 +389,8 @@ describe('copyStaticAssets', () => {
     ).toBe(true)
   })
 
-  test('fingerprints static assets in prod mode', async () => {
-    LuckyBun.prod = true
+  test('fingerprints static assets when fingerprint is enabled', async () => {
+    LuckyBun.fingerprint = true
     await copyAssets({'src/images/logo.png': 'fake-image-data'})
 
     expect(LuckyBun.manifest['images/logo.png']).toMatch(

--- a/spec/bun/lucky.test.js
+++ b/spec/bun/lucky.test.js
@@ -91,7 +91,12 @@ describe('loadConfig', () => {
   test('uses defaults without a config file', () => {
     LuckyBun.loadConfig()
     expect(LuckyBun.config.outDir).toBe('public/assets')
-    expect(LuckyBun.config.watchDirs).toEqual(['src/js', 'src/css', 'src/images', 'src/fonts'])
+    expect(LuckyBun.config.watchDirs).toEqual([
+      'src/js',
+      'src/css',
+      'src/images',
+      'src/fonts'
+    ])
     expect(LuckyBun.config.entryPoints.js).toEqual(['src/js/app.js'])
     expect(LuckyBun.config.devServer.port).toBe(3002)
     expect(LuckyBun.config.plugins).toEqual({
@@ -457,7 +462,8 @@ describe('aliases plugin', () => {
   test('replaces $/ references in TypeScript imports', async () => {
     await setupProject(
       {
-        'src/js/app.ts': "import utils from '$/lib/utils.ts'\nconsole.log(utils)",
+        'src/js/app.ts':
+          "import utils from '$/lib/utils.ts'\nconsole.log(utils)",
         'lib/utils.ts': 'const val: number = 99\nexport default val'
       },
       {entryPoints: {js: ['src/js/app.ts']}}
@@ -574,6 +580,37 @@ describe('cssGlobs plugin', () => {
 
     expect(alphaPos).toBeLessThan(middlePos)
     expect(middlePos).toBeLessThan(zebraPos)
+  })
+
+  test('excludes paths matching not clause', async () => {
+    const content = await buildCSS({
+      'src/css/app.css':
+        "@import './components/**/*.css' not './components/admin/**';",
+      'src/css/components/button.css': '.button { color: red }',
+      'src/css/components/admin/panel.css': '.panel { color: blue }',
+      'src/css/components/forms/input.css': '.input { color: pink }'
+    })
+
+    expect(content).toContain('.button')
+    expect(content).toContain('.input')
+    expect(content).not.toContain('.panel')
+  })
+
+  test('supports multiple not clauses', async () => {
+    const content = await buildCSS({
+      'src/css/app.css': [
+        "@import './components/**/*.css'",
+        "  not './components/admin/**'",
+        "  not './components/internal/**';"
+      ].join('\n'),
+      'src/css/components/button.css': '.button { color: red }',
+      'src/css/components/admin/panel.css': '.admin { color: blue }',
+      'src/css/components/internal/debug.css': '.debug { color: green }'
+    })
+
+    expect(content).toContain('.button')
+    expect(content).not.toContain('.admin')
+    expect(content).not.toContain('.debug')
   })
 })
 
@@ -702,6 +739,36 @@ describe('jsGlobs plugin', () => {
 
     expect(alphaPos).toBeLessThan(middlePos)
     expect(middlePos).toBeLessThan(zebraPos)
+  })
+
+  test('excludes paths matching not clause', async () => {
+    const content = await buildJSGlobs({
+      ...jsApp(
+        "import c from 'glob:./components/**/*.js not ./components/admin/**'",
+        'console.log(c)'
+      ),
+      'src/js/components/modal.js': 'export default function modal() {}',
+      'src/js/components/admin/nav.js': 'export default function adminNav() {}'
+    })
+
+    expect(content).toContain('modal')
+    expect(content).not.toContain('adminNav')
+  })
+
+  test('handles absolute glob paths with exclusions', async () => {
+    const absComponents = join(TEST_DIR, 'app/components')
+    const content = await buildJSGlobs({
+      ...jsApp(
+        `import c from 'glob:${absComponents}/**/*_component.js not ${absComponents}/admin/**'`,
+        'console.log(c)'
+      ),
+      'app/components/modal_component.js': 'export default function modal() {}',
+      'app/components/admin/panel_component.js':
+        'export default function panel() {}'
+    })
+
+    expect(content).toContain('modal')
+    expect(content).not.toContain('panel')
   })
 })
 

--- a/src/bun/bake.js
+++ b/src/bun/bake.js
@@ -1,9 +1,5 @@
 import LuckyBun from './lucky.js'
 
-LuckyBun.flags({
-  debug: process.argv.includes('--debug'),
-  dev: process.argv.includes('--dev'),
-  prod: process.argv.includes('--prod')
-})
+LuckyBun.flags(process.argv)
 
 await LuckyBun.bake()

--- a/src/bun/lucky.js
+++ b/src/bun/lucky.js
@@ -21,14 +21,42 @@ export default {
   debug: false,
   dev: false,
   prod: false,
+  fingerprint: false,
+  minify: false,
+  sourcemap: null,
   wsClients: new Set(),
   watchTimers: new Map(),
   plugins: [],
 
-  flags({debug, dev, prod}) {
+  flags(input) {
+    const {debug, dev, prod, fingerprint, minify, sourcemap} =
+      Array.isArray(input) ? this.parseArgv(input) : input
     if (debug != null) this.debug = debug
     if (dev != null) this.dev = dev
     if (prod != null) this.prod = prod
+    if (fingerprint != null) this.fingerprint = fingerprint
+    else if (prod === true) this.fingerprint = true
+    if (minify != null) this.minify = minify
+    else if (prod === true) this.minify = true
+    if (sourcemap != null) this.sourcemap = sourcemap
+  },
+
+  SOURCEMAP_KINDS: ['inline', 'linked', 'external', 'none'],
+
+  parseArgv(argv) {
+    const opts = {}
+    if (argv.includes('--debug')) opts.debug = true
+    if (argv.includes('--dev')) opts.dev = true
+    if (argv.includes('--prod')) opts.prod = true
+    if (argv.includes('--fingerprint')) opts.fingerprint = true
+    if (argv.includes('--minify')) opts.minify = true
+    const sm = argv.find(a => a === '--sourcemap' || a.startsWith('--sourcemap='))
+    if (sm) {
+      const value = sm.includes('=') ? sm.split('=')[1] : 'linked'
+      if (this.SOURCEMAP_KINDS.includes(value)) opts.sourcemap = value
+      else console.warn(` ▸ Ignoring --sourcemap=${value} (valid: ${this.SOURCEMAP_KINDS.join(', ')})`)
+    }
+    return opts
   },
 
   deepMerge(target, source) {
@@ -69,6 +97,9 @@ export default {
       config: this.config,
       dev: this.dev,
       prod: this.prod,
+      fingerprint: this.fingerprint,
+      minify: this.minify,
+      sourcemap: this.sourcemap,
       manifest: this.manifest
     })
   },
@@ -79,8 +110,8 @@ export default {
     return join(this.root, this.config.outDir)
   },
 
-  fingerprint(name, ext, content) {
-    if (!this.prod) return `${name}${ext}`
+  fingerprintName(name, ext, content) {
+    if (!this.fingerprint) return `${name}${ext}`
 
     const hash = Bun.hash(content).toString(16).slice(0, 8)
     return `${name}-${hash}${ext}`
@@ -107,7 +138,7 @@ export default {
       try {
         result = await Bun.build({
           entrypoints: [entryPath],
-          minify: this.prod,
+          minify: this.minify,
           plugins: this.plugins,
           ...options
         })
@@ -124,16 +155,26 @@ export default {
         continue
       }
 
-      const output = result.outputs.find(o => o.path.endsWith(ext))
-      if (!output) {
+      const mainOutput = result.outputs.find(o => o.path.endsWith(ext))
+      if (!mainOutput) {
         console.error(` ▸ No ${type.toUpperCase()} output for ${entry}`)
         continue
       }
+      const mapOutput = result.outputs.find(o => o.kind === 'sourcemap')
 
-      const content = await output.text()
-      const fileName = this.fingerprint(entryName, ext, content)
+      let content = await mainOutput.text()
+      const fileName = this.fingerprintName(entryName, ext, content)
+
+      if (mapOutput) {
+        const mapFileName = `${fileName}.map`
+        content = content.replace(
+          /\/\/# sourceMappingURL=\S+/,
+          () => `//# sourceMappingURL=${mapFileName}`
+        )
+        await Bun.write(join(outDir, mapFileName), await mapOutput.text())
+      }
+
       await Bun.write(join(outDir, fileName), content)
-
       this.manifest[`${type}/${entryName}${ext}`] = `${type}/${fileName}`
     }
   },
@@ -142,7 +183,7 @@ export default {
     await this.buildAssets('js', {
       target: 'browser',
       format: 'iife',
-      sourcemap: this.dev ? 'inline' : 'none'
+      sourcemap: this.sourcemap || (this.dev ? 'inline' : 'linked')
     })
   },
 
@@ -166,7 +207,7 @@ export default {
 
         const ext = extname(file)
         const name = file.slice(0, -ext.length) || file
-        const fileName = this.fingerprint(name, ext, new Uint8Array(content))
+        const fileName = this.fingerprintName(name, ext, new Uint8Array(content))
         const destPath = join(destDir, fileName)
 
         mkdirSync(dirname(destPath), {recursive: true})

--- a/src/bun/plugins/cssGlobs.js
+++ b/src/bun/plugins/cssGlobs.js
@@ -1,46 +1,77 @@
 import {dirname, relative, resolve, join} from 'path'
 import {Glob} from 'bun'
 
-const REGEX = /@import\s+['"]([^'"]*\*[^'"]*)['"]\s*;/g
+const IMPORT_RE =
+  /@import\s+['"]([^'"]*\*[^'"]*)['"]((?:\s+not\s+['"][^'"]*['"])*)\s*;/g
+const NOT_RE = /not\s+['"]([^'"]*)['"]/g
 
-// Expands glob patterns in CSS @import statements.
-// e.g. @import './components/**/*.css' → individual @import lines.
+function parseImport(match) {
+  const nots = [...(match[2] || '').matchAll(NOT_RE)]
+  return {pattern: match[1], excludes: nots.map(m => m[1])}
+}
+
+function splitGlob(pattern) {
+  const i = pattern.lastIndexOf('/', pattern.indexOf('*'))
+  const base = i > 0 ? pattern.slice(0, i) : '.'
+  return {base, glob: pattern.slice(i + 1)}
+}
+
+function stripPrefix(path, prefix) {
+  const p = prefix.replace(/\/$/, '') + '/'
+  return path.startsWith(p) ? path.slice(p.length) : path
+}
+
+function excluded(file, matchers) {
+  return matchers.some(m => m.match(file))
+}
+
+async function scanFiles(fileDir, pattern, excludes) {
+  const {base, glob: globPart} = splitGlob(pattern)
+  const baseDir = resolve(fileDir, base)
+  const matchers = excludes.map(e => new Glob(stripPrefix(e, base)))
+  const glob = new Glob(globPart)
+  const files = []
+
+  for await (const file of glob.scan({cwd: baseDir, onlyFiles: true})) {
+    if (excluded(file, matchers)) continue
+    const abs = join(baseDir, file)
+    const rel = relative(fileDir, abs)
+    files.push(rel.startsWith('.') ? rel : `./${rel}`)
+  }
+
+  return files.sort()
+}
+
 export default function cssGlobs() {
   return async (content, args) => {
     const fileDir = dirname(args.path)
     const replacements = []
 
-    for (const [fullMatch, pattern] of content.matchAll(REGEX)) {
-      const lastSlash = pattern.lastIndexOf('/', pattern.indexOf('*'))
-      const basePath = lastSlash > 0 ? pattern.slice(0, lastSlash) : '.'
-      const baseDir = resolve(fileDir, basePath)
-      const glob = new Glob(pattern.slice(lastSlash + 1))
-      const files = []
+    for (const match of content.matchAll(IMPORT_RE)) {
+      const {pattern, excludes} = parseImport(match)
+      const files = (await scanFiles(fileDir, pattern, excludes)).filter(
+        f => resolve(fileDir, f) !== args.path
+      )
 
-      for await (const file of glob.scan({cwd: baseDir, onlyFiles: true})) {
-        const absPath = join(baseDir, file)
-        if (absPath === args.path) continue
-        const relPath = relative(fileDir, absPath)
-        files.push(relPath.startsWith('.') ? relPath : `./${relPath}`)
-      }
+      const label =
+        pattern +
+        (excludes.length
+          ? ` (${excludes.length} exclusion${excludes.length > 1 ? 's' : ''})`
+          : '')
 
-      files.sort()
+      if (!files.length) console.warn(`  CSS glob matched no files: ${label}`)
 
-      if (!files.length) console.warn(`  CSS glob matched no files: ${pattern}`)
+      const s = files.length !== 1 ? 's' : ''
+      console.log(`  CSS glob: ${label} → ${files.length} file${s}`)
 
       replacements.push({
-        fullMatch,
-        expanded: files.map(f => `@import '${f}';`).join('\n'),
-        count: files.length,
-        pattern
+        fullMatch: match[0],
+        expanded: files.map(f => `@import '${f}';`).join('\n')
       })
     }
 
-    for (const {fullMatch, expanded, count, pattern} of replacements) {
-      const s = count !== 1 ? 's' : ''
-      console.log(`  CSS glob: ${pattern} → ${count} file${s}`)
+    for (const {fullMatch, expanded} of replacements)
       content = content.replace(fullMatch, expanded)
-    }
 
     return content
   }

--- a/src/bun/plugins/jsGlobs.js
+++ b/src/bun/plugins/jsGlobs.js
@@ -1,44 +1,82 @@
-import {dirname, extname} from 'path'
+import {dirname, extname, isAbsolute, relative, join} from 'path'
 import {Glob} from 'bun'
 
 const REGEX = /import\s+(\w+)\s+from\s+['"]glob:([^'"]+)['"]/g
 
-// Compiles an object with a file path => default export mapping from a glob
-// pattern in JS import statements.
-// e.g. import components from 'glob:./components/**/*.js'
-//
-// ... will generate ...
-//
-// import _glob_components_theme from './components/theme.js'
-// import _glob_components_shared_tooltip from './components/shared/tooltip.js'
-// const components = {
-//   'theme': _glob_components_theme,
-//   'shared/tooltip': _glob_components_shared_tooltip
-// }
+function parseImport(raw) {
+  const parts = raw.split(/\s+not\s+/)
+  return {pattern: parts[0], excludes: parts.slice(1)}
+}
+
+function splitBase(pattern) {
+  const clean = pattern.replace(/^\.\//, '')
+  const base = clean.slice(0, clean.search(/[*?{[]|$/)).replace(/\/$/, '')
+  return {clean, base}
+}
+
+function excluded(file, matchers) {
+  return matchers.some(m => m.match(file))
+}
+
+function scanFiles(dir, pattern, excludes) {
+  const {clean, base} = splitBase(pattern)
+  const abs = isAbsolute(clean)
+  const cwd = abs ? base : dir
+  const globPart = abs ? clean.slice(base.length + 1) : clean
+  const matchers = excludes.map(e => {
+    const ex = e.replace(/^\.\//, '')
+    return new Glob(abs && isAbsolute(ex) ? ex.slice(base.length + 1) : ex)
+  })
+  const glob = new Glob(globPart)
+  const files = []
+
+  for (const file of glob.scanSync({cwd})) {
+    if (excluded(file, matchers)) continue
+    const absPath = join(cwd, file)
+    const rel = relative(dir, absPath)
+    files.push(rel)
+  }
+
+  return files.sort()
+}
+
+function keyBase(pattern) {
+  const {base} = splitBase(pattern)
+  if (!isAbsolute(base)) return base
+  const last = base.lastIndexOf('/')
+  return last > 0 ? base.slice(last + 1) : base
+}
+
+function buildImportMap(files, dir, base) {
+  const imports = []
+  const entries = []
+
+  for (const file of files) {
+    const ext = extname(file)
+    const key = file
+      .slice(0, -ext.length)
+      .replace(/^[./]+/, '')
+      .replace(new RegExp(`^.*${base}/`), '')
+    const safe = `_glob_${base}_${key}`.replace(/[^a-zA-Z0-9]/g, '_')
+    const rel = file.startsWith('.') ? file : `./${file}`
+    imports.push(`import ${safe} from '${rel}'`)
+    entries.push(`  '${key}': ${safe}`)
+  }
+
+  return {imports, entries}
+}
+
 export default function jsGlobs() {
   return (content, args) => {
-    return content.replace(REGEX, (_, binding, pattern) => {
+    return content.replace(REGEX, (_, binding, raw) => {
+      const {pattern, excludes} = parseImport(raw)
+      const base = keyBase(pattern)
       const dir = dirname(args.path)
-      const cleanPattern = pattern.replace(/^\.\//, '')
-      const baseDir = cleanPattern.slice(0, cleanPattern.search(/[*?{[]|$/))
-        .replace(/\/$/, '')
-      const glob = new Glob(cleanPattern)
-      const files = Array.from(glob.scanSync({cwd: dir})).sort()
+      const files = scanFiles(dir, pattern, excludes)
 
       if (!files.length) return `const ${binding} = {}`
 
-      const imports = []
-      const entries = []
-
-      for (const file of files) {
-        const ext = extname(file)
-        const relative = baseDir ? file.slice(baseDir.length + 1) : file
-        const key = relative.slice(0, -ext.length)
-        const prefix = baseDir ? `${baseDir}_` : ''
-        const safe = `_glob_${prefix}${key}`.replace(/[^a-zA-Z0-9]/g, '_')
-        imports.push(`import ${safe} from './${file}'`)
-        entries.push(`  '${key}': ${safe}`)
-      }
+      const {imports, entries} = buildImportMap(files, dir, base)
 
       return [
         ...imports,

--- a/src/lucky/tags/bun_reload_tag.cr
+++ b/src/lucky/tags/bun_reload_tag.cr
@@ -14,6 +14,19 @@ module Lucky::BunReloadTag
         const ws = new WebSocket('#{LuckyBun::Config.instance.dev_server.ws_url}')
         let connected = false
 
+        const scrollKey = 'bun-scroll:' + location.pathname
+        addEventListener('load', () => {
+          const saved = sessionStorage.getItem(scrollKey)
+          if (saved !== null) {
+            sessionStorage.removeItem(scrollKey)
+            scrollTo(0, parseInt(saved, 10))
+          }
+        })
+        const reload = () => {
+          sessionStorage.setItem(scrollKey, String(scrollY))
+          location.reload()
+        }
+
         ws.onmessage = (event) => {
           const data = JSON.parse(event.data)
 
@@ -31,7 +44,7 @@ module Lucky::BunReloadTag
             console.error('✖ Build error:', data.message)
           } else {
             console.log('▸ Reloading...')
-            location.reload()
+            reload()
           }
         }
 
@@ -40,7 +53,7 @@ module Lucky::BunReloadTag
           console.log('▸ Live reload connected')
         }
         ws.onclose = () => {
-          if (connected) setTimeout(() => location.reload(), 2000)
+          if (connected) setTimeout(reload, 2000)
         }
       })()
       JS


### PR DESCRIPTION
## Purpose
We've been using this setup for a while in Rails and a few suggestions came up from our front-end dev. This PR includes those tweaks.

## Description
There are three improvements.

### Exclusions in glob patterns
Allows exclusion of sub-dirs or files from a CSS import with glob using the `not` clause:
```css
@import './components/**/*.css' not './components/admin/**';
```
Or with multiple:
```css
@import './components/**/*.css'
  not './components/admin/**'
  not './components/internal/**';
```
This also works for JS globs:
```js
import components from 'glob:./components/**/*.js not ./components/admin/**'
```

### More granular control for build flags
The only ~~two~~ three flags we had were:
- no flag: just build, no fingerprinting, no minification and inline sourcemap
- `--dev`: build and start dev server with watcher
- `--prod`: build with minification and fingerprinting, no soucemap
- `--debug`: more verbose WebSocket output

There were cases where we wanted to have fingerprinting, but no minification. And in hindsight, not having sourcemap in production was not a good idea. So we've added the following:
- `--fingerprint`: build without minification but with fingerprints
- `--minify`: build without fingerprints but with minification
- `--sourcemap=[inline, linked, external, none]`: this now hinges on the `--dev` flag where it’s `inline` and `linked` for builds

The `--prod` flag is now just a shortcut for `--fingerprint --minify`, so this is all backwards compatible.

### Retain scroll position on full reloads
CSS is hot reloaded, so changes are instant and don't affect the scroll position. With JS and other assets, a full page reload was triggered which inevitably reset the scroll position to `0`. Now the scroll position is stored in `sessionStorage` and restored after the reload.

This made me think, should we add that as well to Lucky's live reload tag? It's a really nice thing to have.

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [X] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [X] - Lucky builds on docker with `./script/setup`
* [X] - All builds and specs pass on docker with `./script/test`
