### PR TITLE
Add .subdomain chainable method for route helpers

### DIFF
--- a/spec/lucky/route_helper_spec.cr
+++ b/spec/lucky/route_helper_spec.cr
@@ -16,6 +16,14 @@ class TestParamAction < TestAction
   end
 end
 
+class TestSubdomainFormatAction < TestAction
+  accepted_formats [:html, :rss, :json], default: :html
+
+  get "/subdomain_reports/:id" do
+    plain_text "report"
+  end
+end
+
 describe Lucky::RouteHelper do
   describe "url" do
     it "returns the host + path" do
@@ -59,26 +67,26 @@ describe Lucky::RouteHelper do
     end
   end
 
-  describe ".with subdomain support" do
-    it "generates URLs with subdomains using .with() method" do
+  describe ".subdomain" do
+    it "generates URLs with subdomains via Action.subdomain" do
       Lucky::RouteHelper.temp_config(base_uri: "https://example.com") do
-        route = TestSubdomainAction.with(subdomain: "admin")
+        route = TestSubdomainAction.subdomain("admin")
 
         route.url.should eq("https://admin.example.com/dashboard")
         route.path.should eq("/dashboard")
       end
     end
 
-    it "generates URLs with subdomains and params using .with() method" do
+    it "generates URLs with subdomains via .with().subdomain()" do
       Lucky::RouteHelper.temp_config(base_uri: "https://example.com") do
-        route = TestParamAction.with(page: 2, subdomain: "blog")
+        route = TestParamAction.with(page: 2).subdomain("blog")
 
         route.url.should eq("https://blog.example.com/posts?page=2")
         route.path.should eq("/posts?page=2")
       end
     end
 
-    it "generates URLs without subdomain when not specified in .with()" do
+    it "generates URLs without subdomain when .subdomain is not called" do
       Lucky::RouteHelper.temp_config(base_uri: "https://example.com") do
         route = TestSubdomainAction.with
 
@@ -89,17 +97,33 @@ describe Lucky::RouteHelper do
 
     it "handles anchors with subdomains" do
       Lucky::RouteHelper.temp_config(base_uri: "https://example.com") do
-        route = TestSubdomainAction.with(subdomain: "admin", anchor: "top")
+        route = TestSubdomainAction.with(anchor: "top").subdomain("admin")
 
         route.url.should eq("https://admin.example.com/dashboard#top")
       end
     end
 
-    it "replaces existing subdomain in base_uri when subdomain is specified" do
+    it "replaces existing subdomain in base_uri" do
       Lucky::RouteHelper.temp_config(base_uri: "https://www.example.com") do
-        route = TestSubdomainAction.with(subdomain: "admin")
+        route = TestSubdomainAction.with.subdomain("admin")
 
         route.url.should eq("https://admin.example.com/dashboard")
+      end
+    end
+
+    it "chains with .as_* in either order" do
+      Lucky::RouteHelper.temp_config(base_uri: "https://example.com") do
+        TestSubdomainFormatAction.with(id: 4).as_json.subdomain("reporting").url
+          .should eq("https://reporting.example.com/subdomain_reports/4.json")
+
+        TestSubdomainFormatAction.with(id: 4).subdomain("reporting").as_json.url
+          .should eq("https://reporting.example.com/subdomain_reports/4.json")
+
+        TestSubdomainFormatAction.as_json.subdomain("reporting").with(id: 4).url
+          .should eq("https://reporting.example.com/subdomain_reports/4.json")
+
+        TestSubdomainFormatAction.subdomain("reporting").as_json.with(id: 4).url
+          .should eq("https://reporting.example.com/subdomain_reports/4.json")
       end
     end
   end

--- a/src/lucky/routable.cr
+++ b/src/lucky/routable.cr
@@ -236,6 +236,10 @@ module Lucky::Routable
     {% end %}
 
     class RouteHelper < Lucky::RouteHelper
+      def subdomain(value : String) : RouteHelper
+        RouteHelper.new(@method, @path, value)
+      end
+
       {% if @type.has_constant?(:ACCEPTED_FORMAT_SYMBOLS) %}
         {% for ext in @type.constant(:ACCEPTED_FORMAT_SYMBOLS) %}
           def as_{{ ext.id }} : Lucky::RouteHelper
@@ -252,16 +256,29 @@ module Lucky::Routable
 
     struct FormatBuilder
       getter extension : String
+      getter subdomain : String?
 
-      def initialize(@extension : String)
+      def initialize(@extension : String, @subdomain : String? = nil)
       end
+
+      def subdomain(value : String) : FormatBuilder
+        FormatBuilder.new(@extension, value)
+      end
+
+      {% if @type.has_constant?(:ACCEPTED_FORMAT_SYMBOLS) %}
+        {% for ext in @type.constant(:ACCEPTED_FORMAT_SYMBOLS) %}
+          def as_{{ ext.id }} : FormatBuilder
+            FormatBuilder.new(Lucky::RouteHelper.resolve_extension({{ ext }}), @subdomain)
+          end
+        {% end %}
+      {% end %}
 
       def with(*args, **named_args) : Lucky::RouteHelper
         route = {{ @type.name.id }}.with(*args, **named_args)
         Lucky::RouteHelper.new(
           route.method,
           Lucky::RouteHelper.insert_extension(route.path, @extension),
-          route.subdomain
+          @subdomain
         )
       end
 
@@ -275,9 +292,13 @@ module Lucky::Routable
         Lucky::RouteHelper.new(
           route.method,
           Lucky::RouteHelper.insert_extension(route.path, @extension),
-          route.subdomain
+          @subdomain
         ).url
       end
+    end
+
+    def self.subdomain(value : String) : FormatBuilder
+      FormatBuilder.new("", value)
     end
 
     {% if @type.has_constant?(:ACCEPTED_FORMAT_SYMBOLS) %}
@@ -306,7 +327,6 @@ module Lucky::Routable
     {% if glob_param_name %}
       {{ glob_param_name.id }} = nil,
     {% end %}
-    subdomain : String? = nil
     ) : String
       path = path_from_parts(
         {% for param in path_params %}
@@ -319,7 +339,7 @@ module Lucky::Routable
           {{ glob_param_name.id }},
         {% end %}
       )
-      Lucky::RouteHelper.new({{ method }}, path, subdomain).url
+      Lucky::RouteHelper.new({{ method }}, path).url
     end
 
     def self.path_without_query_params(
@@ -332,7 +352,6 @@ module Lucky::Routable
     {% if glob_param_name %}
       {{ glob_param_name.id }} = nil,
     {% end %}
-    subdomain : String? = nil
     ) : String
       path = path_from_parts(
         {% for param in path_params %}
@@ -345,7 +364,7 @@ module Lucky::Routable
           {{ glob_param_name.id }},
         {% end %}
       )
-      Lucky::RouteHelper.new({{ method }}, path, subdomain).path
+      Lucky::RouteHelper.new({{ method }}, path).path
     end
 
     {% params_with_defaults = PARAM_DECLARATIONS.select do |decl|
@@ -380,8 +399,7 @@ module Lucky::Routable
     {% if glob_param_name %}
       {{ glob_param_name.id }} = nil,
     {% end %}
-    anchor : String? = nil,
-    subdomain : String? = nil
+    anchor : String? = nil
     ) : RouteHelper
       path = String.build do |io|
         path_from_parts(
@@ -423,7 +441,7 @@ module Lucky::Routable
         end
       end
 
-      RouteHelper.new({{ method }}, path.presence || "/", subdomain)
+      RouteHelper.new({{ method }}, path.presence || "/")
     end
 
     def self.with(
@@ -451,8 +469,7 @@ module Lucky::Routable
       {% if glob_param_name %}
         {{ glob_param_name.id }} = nil,
       {% end %}
-      anchor : String? = nil,
-      subdomain : String? = nil
+      anchor : String? = nil
     ) : RouteHelper
       \{% begin %}
       route(

--- a/src/lucky/route_helper.cr
+++ b/src/lucky/route_helper.cr
@@ -10,6 +10,10 @@ class Lucky::RouteHelper
   def initialize(@method : Symbol, @path : String, @subdomain : String? = nil)
   end
 
+  def subdomain(value : String) : Lucky::RouteHelper
+    Lucky::RouteHelper.new(@method, @path, value)
+  end
+
   def url : String
     if subdomain
       build_subdomain_url


### PR DESCRIPTION
## Purpose

Closes #2033.

Replaces the `subdomain:` keyword argument on `.with()` (added in #1974) with a chainable `.subdomain("admin")` method, matching the builder style introduced by the `.as_*` format methods in #2022.

The motivation from the issue: `subdomain` as a kwarg on `.with()` means no one can ever model a resource with a `subdomain` query or path param without collision. Pulling route modifiers out of the keyword bag avoids that, and reads more naturally alongside `.as_rss`/`.as_json`.

## Description

- Adds `Action.subdomain("admin")` and `Lucky::RouteHelper#subdomain("admin")` builder methods.
- Removes the `subdomain:` keyword from `self.with`, `self.route`, `self.path_without_query_params`, and `self.url_without_query_params`.
- `FormatBuilder` now carries subdomain state, so `.as_*` and `.subdomain(...)` compose in any order.

All four of these produce the same URL:

```crystal
Admin::Reporting.with(id: 4).as_json.subdomain("reporting").url
Admin::Reporting.with(id: 4).subdomain("reporting").as_json.url
Admin::Reporting.as_json.subdomain("reporting").with(id: 4).url
Admin::Reporting.subdomain("reporting").as_json.with(id: 4).url
```

### Breaking change

The `subdomain:` keyword argument is removed. Since it was merged in #1974 after v1.4.0 and has not appeared in a released version, this only affects users tracking `main`.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [ ] - Lucky builds on docker with `./script/setup`
* [ ] - All builds and specs pass on docker with `./script/test`