### PR TITLE
Add bun watcher patch

### DIFF
--- a/spec/bun/lucky.test.js
+++ b/spec/bun/lucky.test.js
@@ -289,7 +289,9 @@ describe('buildAssets', () => {
     await setupProject({'src/js/app.js': 'console.log("bare")'})
     await LuckyBun.buildJS()
 
-    expect(existsSync(join(TEST_DIR, 'public/assets/js/app.js.map'))).toBe(false)
+    expect(existsSync(join(TEST_DIR, 'public/assets/js/app.js.map'))).toBe(
+      false
+    )
   })
 
   test('warns on missing entry point and continues', async () => {
@@ -567,7 +569,9 @@ describe('aliases plugin', () => {
   test('resolves $/ inside prefixed strings like glob:$/', async () => {
     const aliases = (await import('../../src/bun/plugins/aliases.js')).default
     const transform = aliases({root: '/root'})
-    const result = transform("import c from 'glob:$/lib/components/*.js'")
+    const result = transform("import c from 'glob:$/lib/components/*.js'", {
+      path: 'app.js'
+    })
 
     expect(result).toBe("import c from 'glob:/root/lib/components/*.js'")
   })
@@ -576,7 +580,7 @@ describe('aliases plugin', () => {
     const aliases = (await import('../../src/bun/plugins/aliases.js')).default
     const transform = aliases({root: '/root'})
     const input = "s.replace(/.*components\\//, '').replace(/_component$/, '')"
-    const result = transform(input)
+    const result = transform(input, {path: 'app.js'})
 
     expect(result).toBe(input)
   })

--- a/src/bun/lucky.js
+++ b/src/bun/lucky.js
@@ -29,8 +29,11 @@ export default {
   plugins: [],
 
   flags(input) {
-    const {debug, dev, prod, fingerprint, minify, sourcemap} =
-      Array.isArray(input) ? this.parseArgv(input) : input
+    const {debug, dev, prod, fingerprint, minify, sourcemap} = Array.isArray(
+      input
+    )
+      ? this.parseArgv(input)
+      : input
     if (debug != null) this.debug = debug
     if (dev != null) this.dev = dev
     if (prod != null) this.prod = prod
@@ -50,11 +53,16 @@ export default {
     if (argv.includes('--prod')) opts.prod = true
     if (argv.includes('--fingerprint')) opts.fingerprint = true
     if (argv.includes('--minify')) opts.minify = true
-    const sm = argv.find(a => a === '--sourcemap' || a.startsWith('--sourcemap='))
+    const sm = argv.find(
+      a => a === '--sourcemap' || a.startsWith('--sourcemap=')
+    )
     if (sm) {
       const value = sm.includes('=') ? sm.split('=')[1] : 'linked'
       if (this.SOURCEMAP_KINDS.includes(value)) opts.sourcemap = value
-      else console.warn(` ▸ Ignoring --sourcemap=${value} (valid: ${this.SOURCEMAP_KINDS.join(', ')})`)
+      else
+        console.warn(
+          ` ▸ Ignoring --sourcemap=${value} (valid: ${this.SOURCEMAP_KINDS.join(', ')})`
+        )
     }
     return opts
   },
@@ -207,7 +215,11 @@ export default {
 
         const ext = extname(file)
         const name = file.slice(0, -ext.length) || file
-        const fileName = this.fingerprintName(name, ext, new Uint8Array(content))
+        const fileName = this.fingerprintName(
+          name,
+          ext,
+          new Uint8Array(content)
+        )
         const destPath = join(destDir, fileName)
 
         mkdirSync(dirname(destPath), {recursive: true})
@@ -264,6 +276,10 @@ export default {
   },
 
   async watch() {
+    const extras = this.config.watchExtensions || {}
+    const cssExts = ['css', ...(extras.css || [])]
+    const jsExts = ['js', 'ts', 'jsx', 'tsx', ...(extras.js || [])]
+
     const handler = (event, filename) => {
       if (!filename) return
 
@@ -290,9 +306,8 @@ export default {
       console.log(` ▸ ${normalizedFilename} changed`)
       ;(async () => {
         try {
-          if (ext === 'css') await this.buildCSS()
-          else if (['js', 'ts', 'jsx', 'tsx'].includes(ext))
-            await this.buildJS()
+          if (cssExts.includes(ext)) await this.buildCSS()
+          else if (jsExts.includes(ext)) await this.buildJS()
           else if (base.includes('.')) await this.copyStaticAssets()
 
           await this.writeManifest()
@@ -339,7 +354,8 @@ export default {
         },
         close(ws) {
           wsClients.delete(ws)
-          if (debug) console.log(` ▸ Client disconnected (${wsClients.size})\n\n`)
+          if (debug)
+            console.log(` ▸ Client disconnected (${wsClients.size})\n\n`)
         },
         message() {}
       }

--- a/src/bun/plugins/aliases.js
+++ b/src/bun/plugins/aliases.js
@@ -1,9 +1,14 @@
-const REGEX = /(url\(\s*['"]?|(?<!\w)['"](?:glob:)?)\$\//g
+const CSS_REGEX = /((?:url\(\s*|@import\s+)['"]?(?:glob:)?)\$\//g
+const JS_REGEX =
+  /((?:from\s+|require\s*\(\s*|import\s*\(\s*)['"](?:glob:)?)\$\//g
 
 // Resolves `$/` root aliases in CSS url() references and JS/CSS imports.
 // e.g. url('$/src/images/foo.png') → url('/absolute/root/src/images/foo.png')
 //      import x from '$/lib/utils.js' → import x from '/absolute/root/lib/utils.js'
 //      @import '$/src/css/reset.css' → @import '/absolute/root/src/css/reset.css'
 export default function aliases({root}) {
-  return content => content.replace(REGEX, `$1${root}/`)
+  return (content, args) => {
+    const regex = args.path.endsWith('.css') ? CSS_REGEX : JS_REGEX
+    return content.replace(regex, `$1${root}/`)
+  }
 }


### PR DESCRIPTION
## Purpose
This adds a `watchExtensions` to allow watching file types other than the target file type.

## Description
Tailwind CSS setups require a rebuild of the CSS whenever a template file (Crystal, HTML, ECR, etc.) changes because Tailwind scans those templates for class candidates. Before the watcher only rebuilds CSS when a .css file itself changes, so template edits leave the stylesheet stale until the next CSS change.

This PR adds a `watchExtensions` option in config/bun.json that routes extra extensions into the CSS or JS rebuild path:                                                                                            

```json                                                                                                                                                                                                              
  {
    "watchDirs": ["src"],
    "watchExtensions": {
      "css": ["cr"],
      "js": []
    }
  }
```                                

With this config option a change to any .cr file under `watchDirs` triggers `buildCSS()`, so Tailwind re-scans the templates and the stylesheet updates.
     
## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [X] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [X] - Lucky builds on docker with `./script/setup`
* [X] - All builds and specs pass on docker with `./script/test`
