### PR TITLE
Fix reload after rebuilds of the target extension

### DIFF
--- a/src/bun/lucky.js
+++ b/src/bun/lucky.js
@@ -276,9 +276,11 @@ export default {
   },
 
   async watch() {
+    const cssBase = ['css']
+    const jsBase = ['js', 'ts', 'jsx', 'tsx']
     const extras = this.config.watchExtensions || {}
-    const cssExts = ['css', ...(extras.css || [])]
-    const jsExts = ['js', 'ts', 'jsx', 'tsx', ...(extras.js || [])]
+    const cssExts = [...cssBase, ...(extras.css || [])]
+    const jsExts = [...jsBase, ...(extras.js || [])]
 
     const handler = (event, filename) => {
       if (!filename) return
@@ -306,12 +308,20 @@ export default {
       console.log(` ▸ ${normalizedFilename} changed`)
       ;(async () => {
         try {
-          if (cssExts.includes(ext)) await this.buildCSS()
-          else if (jsExts.includes(ext)) await this.buildJS()
-          else if (base.includes('.')) await this.copyStaticAssets()
+          let kind = null
+          if (cssExts.includes(ext)) {
+            await this.buildCSS()
+            if (cssBase.includes(ext)) kind = 'css'
+          } else if (jsExts.includes(ext)) {
+            await this.buildJS()
+            if (jsBase.includes(ext)) kind = 'full'
+          } else if (base.includes('.')) {
+            await this.copyStaticAssets()
+            kind = 'full'
+          }
 
           await this.writeManifest()
-          this.reload(ext === 'css' ? 'css' : 'full')
+          if (kind) this.reload(kind)
         } catch (err) {
           console.error(' ✖ Build error:', err.message)
           if (err.errors) for (const e of err.errors) console.error(e)


### PR DESCRIPTION
## Purpose
Fixed unnecessary reloads for watched files that are not the target build type.

## Description
A reload should not be triggered when watching Crystal files to do a CSS rebuild. Only changes to CSS files should trigger a CSS reload. This is precisely what we touched on before, Bun is responsible for reloads after front-end asset changes, Lucky is responsible for the backend. I came across this when working on the Bun setup with Tailwind for the Lucky website.

Sorry for all those tiny PR's BTW 😬. If this bothers you we could extract the JS part into a separate repo and register is as a git submodule.

## Checklist
* [ ] - An issue already exists detailing the issue/or feature request that this PR fixes
* [X] - All specs are formatted with `crystal tool format spec src`
* [ ] - Inline documentation has been added and/or updated
* [X] - Lucky builds on docker with `./script/setup`
* [X] - All builds and specs pass on docker with `./script/test`
