### PR TITLE
Fixing regression to detect actions with an explicit extension set

### DIFF
--- a/spec/lucky/format_integration_spec.cr
+++ b/spec/lucky/format_integration_spec.cr
@@ -19,6 +19,17 @@ private class TestReportsAction < TestAction
   end
 end
 
+private class TestExplicitExtensionAction < TestAction
+  accepted_formats [:html, :json], default: :html
+
+  class_property reached = false
+
+  get "/explicit_extension/path.json" do
+    TestExplicitExtensionAction.reached = true
+    plain_text "matched explicit json route"
+  end
+end
+
 describe "Format Integration" do
   it "handles URL format extensions correctly" do
     # Test CSV format from URL extension
@@ -64,6 +75,23 @@ describe "Format Integration" do
     }
     result = handler.call(context)
     result.should be_nil
+  end
+
+  it "matches a route that is explicitly declared with a known extension" do
+    TestExplicitExtensionAction.reached = false
+    context = build_context(path: "/explicit_extension/path.json")
+
+    Lucky::RouteHandler.new.call(context)
+
+    TestExplicitExtensionAction.reached.should be_true
+  end
+
+  it "does not set a url format when the explicit extension route matches" do
+    context = build_context(path: "/explicit_extension/path.json")
+
+    Lucky::RouteHandler.new.call(context)
+
+    context._url_format.should be_nil
   end
 
   it "supports multiple format extensions" do

--- a/spec/lucky/format_integration_spec.cr
+++ b/spec/lucky/format_integration_spec.cr
@@ -22,7 +22,7 @@ end
 private class TestExplicitExtensionAction < TestAction
   accepted_formats [:html, :json], default: :html
 
-  class_property reached = false
+  class_property? reached = false
 
   get "/explicit_extension/path.json" do
     TestExplicitExtensionAction.reached = true
@@ -83,7 +83,7 @@ describe "Format Integration" do
 
     Lucky::RouteHandler.new.call(context)
 
-    TestExplicitExtensionAction.reached.should be_true
+    TestExplicitExtensionAction.reached?.should be_true
   end
 
   it "does not set a url format when the explicit extension route matches" do

--- a/spec/lucky/maximum_request_size_handler_spec.cr
+++ b/spec/lucky/maximum_request_size_handler_spec.cr
@@ -55,6 +55,17 @@ describe Lucky::MaximumRequestSizeHandler do
       end
       context.response.status.should eq(HTTP::Status::PAYLOAD_TOO_LARGE)
     end
+
+    it "honors the request body limit for actions declared with an explicit extension" do
+      context = build_request_context_with_body("/__max_request_size/explicit.json", 50_000, "POST")
+      Lucky::MaximumRequestSizeHandler.temp_config(
+        enabled: true,
+        max_size: 10_000,
+      ) do
+        run_request_size_handler(context)
+      end
+      context.response.status.should eq(HTTP::Status::OK)
+    end
   end
 end
 
@@ -98,5 +109,14 @@ private class SmallUploadAction < Lucky::Action
   end
 end
 
+private class ExplicitExtensionUploadAction < Lucky::Action
+  set_request_body_limit 50_000
+
+  def call : Lucky::Response
+    plain_text "ok"
+  end
+end
+
 Lucky.router.add :post, "/__max_request_size/large", LargeUploadAction
 Lucky.router.add :post, "/__max_request_size/small", SmallUploadAction
+Lucky.router.add :post, "/__max_request_size/explicit.json", ExplicitExtensionUploadAction

--- a/src/lucky/maximum_request_size_handler.cr
+++ b/src/lucky/maximum_request_size_handler.cr
@@ -69,10 +69,13 @@ class Lucky::MaximumRequestSizeHandler
     method = context.request.method
     path = context.request.path
 
-    if Lucky::MimeType.extract_format_from_path(path)
-      path = path.sub(/^([^?]*)\.[a-zA-Z0-9]+(\?.*)?$/, "\\1\\2")
+    # Match the full path first; only fall back to the format-stripped path so
+    # actions declared with an explicit extension keep their request_body_limit.
+    Lucky.router.find_action(method, path) || begin
+      if Lucky::MimeType.extract_format_from_path(path)
+        stripped = path.sub(/^([^?]*)\.[a-zA-Z0-9]+(\?.*)?$/, "\\1\\2")
+        Lucky.router.find_action(method, stripped)
+      end
     end
-
-    Lucky.router.find_action(method, path)
   end
 end

--- a/src/lucky/route_handler.cr
+++ b/src/lucky/route_handler.cr
@@ -3,25 +3,36 @@ require "colorize"
 class Lucky::RouteHandler
   include HTTP::Handler
 
+  # Assuming a request path comes in for `/reports.json`,
+  # we find and actions with an explicit extension set like `/reports.json`. If none are found,
+  # then we look for `/reports` that accepts the json mime type.
   def call(context : HTTP::Server::Context)
     original_path = context.request.path
+    method = context.request.method
+    handler = Lucky.router.find_action(method, original_path)
 
-    # Extract format from URL path and strip it for route matching
     if url_format = Lucky::MimeType.extract_format_from_path(original_path)
-      context._url_format = url_format
-      # Create a modified request with format-stripped path for route matching
-      path_without_format = original_path.sub(/^([^?]*)\.[a-zA-Z0-9]+(\?.*)?$/, "\\1\\2")
-      lookup_request_path = path_without_format
-    else
-      lookup_request_path = original_path
+      if handler.nil? || format_absorbed_by_param?(handler, original_path)
+        context._url_format = url_format
+        path_without_format = original_path.sub(/^([^?]*)\.[a-zA-Z0-9]+(\?.*)?$/, "\\1\\2")
+        handler = Lucky.router.find_action(method, path_without_format)
+      end
     end
 
-    handler = Lucky.router.find_action(context.request.method, lookup_request_path)
     if handler
       Lucky::Log.dexter.debug { {handled_by: handler.payload.to_s} }
       handler.payload.new(context, handler.params).perform_action
     else
       call_next(context)
+    end
+  end
+
+  private def format_absorbed_by_param?(match : LuckyRouter::Match(Lucky::Action.class), path : String) : Bool
+    if extension_match = path.match(/^[^?]*\.([a-zA-Z0-9]+)(?:\?|$)/)
+      extension = extension_match[1]
+      match.params.values.any?(&.ends_with?(".#{extension}"))
+    else
+      false
     end
   end
 end


### PR DESCRIPTION
## Purpose
Fixes #2046

## Description
A previous PR made an update to auto-detect routes based on extensions used in the request.
If a request came in for `/reports.json`, it would look for an action with `/reports` that allowed the JSON mime-type.
If a request came in for `/reports.csv`, then it would find the action with `/reports` that allowed the CSV mime-type.

However, if you defined your action as `/reports.json` explicitly, it would be a 404 :man_facepalming:  This PR
keeps the new auto-detect but also fixes the regression. The downside is that if you rely on the auto-detect now,
it'll technically be 2 route lookups. In the end, correctness is higher priority than performance. We can look at
doing a refactor later that maybe fixes the original issue without breaking compatibility or something.

## Checklist
* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated
* [x] - Lucky builds on docker with `./script/setup`
* [x] - All builds and specs pass on docker with `./script/test`
