### PR TITLE
Fix Cycle text helper thread safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Changes in 1.5.0
 
+- Fixed: isolate text helper cycles between page instances. [#2048](https://github.com/luckyframework/lucky/issues/2048)
 - Updated: HTML Components will fail at compile-time for unused arguments. [#1978](https://github.com/luckyframework/lucky/pull/1978)
 - Added: format detection from URL extensions in actions. [#1979](https://github.com/luckyframework/lucky/pull/1979)
 - Added: Allow customizing the manifest retry timeout. [#1977](https://github.com/luckyframework/lucky/pull/1977)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 ### Changes in 1.5.0
 
-- Fixed: isolate text helper cycles between page instances. [#2048](https://github.com/luckyframework/lucky/issues/2048)
 - Updated: HTML Components will fail at compile-time for unused arguments. [#1978](https://github.com/luckyframework/lucky/pull/1978)
 - Added: format detection from URL extensions in actions. [#1979](https://github.com/luckyframework/lucky/pull/1979)
 - Added: Allow customizing the manifest retry timeout. [#1977](https://github.com/luckyframework/lucky/pull/1977)

--- a/spec/lucky/text_helpers/cycle_spec.cr
+++ b/spec/lucky/text_helpers/cycle_spec.cr
@@ -1,10 +1,6 @@
 require "./text_helpers_spec"
 
 describe Lucky::TextHelpers do
-  Spec.before_each do
-    view.reset_cycles
-  end
-
   describe "cycle" do
     describe Lucky::TextHelpers::Cycle do
       it "cycles when converted to a string" do
@@ -21,99 +17,119 @@ describe Lucky::TextHelpers do
     end
 
     it "cycles" do
-      view.cycle("one", 2, "3").should eq "one"
-      view.cycle("one", 2, "3").should eq "2"
-      view.cycle("one", 2, "3").should eq "3"
-      view.cycle("one", 2, "3").should eq "one"
-      view.cycle("one", 2, "3").should eq "2"
-      view.cycle("one", 2, "3").should eq "3"
+      page = view
+      page.cycle("one", 2, "3").should eq "one"
+      page.cycle("one", 2, "3").should eq "2"
+      page.cycle("one", 2, "3").should eq "3"
+      page.cycle("one", 2, "3").should eq "one"
+      page.cycle("one", 2, "3").should eq "2"
+      page.cycle("one", 2, "3").should eq "3"
     end
 
     it "cycles with array" do
+      page = view
       array = [1, 2, 3]
-      view.cycle(array).should eq "1"
-      view.cycle(array).should eq "2"
-      view.cycle(array).should eq "3"
+      page.cycle(array).should eq "1"
+      page.cycle(array).should eq "2"
+      page.cycle(array).should eq "3"
+    end
+
+    it "keeps cycles isolated between pages" do
+      first_page = view
+      second_page = view
+
+      first_page.cycle("even", "odd").should eq "even"
+      second_page.cycle("even", "odd").should eq "even"
     end
 
     it "cycle resets with new values" do
-      view.cycle("even", "odd").should eq "even"
-      view.cycle("even", "odd").should eq "odd"
-      view.cycle("even", "odd").should eq "even"
-      view.cycle(1, 2, 3).should eq "1"
-      view.cycle(1, 2, 3).should eq "2"
-      view.cycle(1, 2, 3).should eq "3"
-      view.cycle(1, 2, 3).should eq "1"
+      page = view
+      page.cycle("even", "odd").should eq "even"
+      page.cycle("even", "odd").should eq "odd"
+      page.cycle("even", "odd").should eq "even"
+      page.cycle(1, 2, 3).should eq "1"
+      page.cycle(1, 2, 3).should eq "2"
+      page.cycle(1, 2, 3).should eq "3"
+      page.cycle(1, 2, 3).should eq "1"
     end
 
     it "cycles named cycles" do
-      view.cycle(1, 2, 3, name: "numbers").should eq "1"
-      view.cycle("red", "blue", name: "colors").should eq "red"
-      view.cycle(1, 2, 3, name: "numbers").should eq "2"
-      view.cycle("red", "blue", name: "colors").should eq "blue"
-      view.cycle(1, 2, 3, name: "numbers").should eq "3"
-      view.cycle("red", "blue", name: "colors").should eq "red"
+      page = view
+      page.cycle(1, 2, 3, name: "numbers").should eq "1"
+      page.cycle("red", "blue", name: "colors").should eq "red"
+      page.cycle(1, 2, 3, name: "numbers").should eq "2"
+      page.cycle("red", "blue", name: "colors").should eq "blue"
+      page.cycle(1, 2, 3, name: "numbers").should eq "3"
+      page.cycle("red", "blue", name: "colors").should eq "red"
     end
 
     it "gets current cycle with default name" do
-      view.cycle("even", "odd")
-      view.current_cycle.should eq "even"
-      view.cycle("even", "odd")
-      view.current_cycle.should eq "odd"
-      view.cycle("even", "odd")
-      view.current_cycle.should eq "even"
+      page = view
+      page.cycle("even", "odd")
+      page.current_cycle.should eq "even"
+      page.cycle("even", "odd")
+      page.current_cycle.should eq "odd"
+      page.cycle("even", "odd")
+      page.current_cycle.should eq "even"
     end
 
     it "gets current cycle with named cycles" do
-      view.cycle("red", "blue", name: "colors")
-      view.current_cycle("colors").should eq "red"
-      view.cycle("red", "blue", name: "colors")
-      view.current_cycle("colors").should eq "blue"
-      view.cycle("red", "blue", name: "colors")
-      view.current_cycle("colors").should eq "red"
+      page = view
+      page.cycle("red", "blue", name: "colors")
+      page.current_cycle("colors").should eq "red"
+      page.cycle("red", "blue", name: "colors")
+      page.current_cycle("colors").should eq "blue"
+      page.cycle("red", "blue", name: "colors")
+      page.current_cycle("colors").should eq "red"
     end
 
     it "gets current cycle with no exceptions" do
-      view.current_cycle.should be_nil
-      view.current_cycle("colors").should be_nil
+      page = view
+      page.current_cycle.should be_nil
+      page.current_cycle("colors").should be_nil
     end
 
     it "gets current cycle with more than two names" do
-      view.cycle(1, 2, 3)
-      view.current_cycle.should eq "1"
-      view.cycle(1, 2, 3)
-      view.current_cycle.should eq "2"
-      view.cycle(1, 2, 3)
-      view.current_cycle.should eq "3"
-      view.cycle(1, 2, 3)
-      view.current_cycle.should eq "1"
+      page = view
+      page.cycle(1, 2, 3)
+      page.current_cycle.should eq "1"
+      page.cycle(1, 2, 3)
+      page.current_cycle.should eq "2"
+      page.cycle(1, 2, 3)
+      page.current_cycle.should eq "3"
+      page.cycle(1, 2, 3)
+      page.current_cycle.should eq "1"
     end
 
     it "cycles with default named" do
-      view.cycle(1, 2, 3).should eq "1"
-      view.cycle(1, 2, 3, name: "default").should eq "2"
-      view.cycle(1, 2, 3).should eq "3"
+      page = view
+      page.cycle(1, 2, 3).should eq "1"
+      page.cycle(1, 2, 3, name: "default").should eq "2"
+      page.cycle(1, 2, 3).should eq "3"
     end
 
     it "resets cycle" do
-      view.cycle(1, 2, 3).should eq "1"
-      view.cycle(1, 2, 3).should eq "2"
-      view.reset_cycle
-      view.cycle(1, 2, 3).should eq "1"
+      page = view
+      page.cycle(1, 2, 3).should eq "1"
+      page.cycle(1, 2, 3).should eq "2"
+      page.reset_cycle
+      page.cycle(1, 2, 3).should eq "1"
     end
 
     it "resets unknown cycle" do
-      view.reset_cycle("colors")
+      page = view
+      page.reset_cycle("colors")
     end
 
     it "resets named cycle" do
-      view.cycle(1, 2, 3, name: "numbers").should eq "1"
-      view.cycle("red", "blue", name: "colors").should eq "red"
-      view.reset_cycle("numbers")
-      view.cycle(1, 2, 3, name: "numbers").should eq "1"
-      view.cycle("red", "blue", name: "colors").should eq "blue"
-      view.cycle(1, 2, 3, name: "numbers").should eq "2"
-      view.cycle("red", "blue", name: "colors").should eq "red"
+      page = view
+      page.cycle(1, 2, 3, name: "numbers").should eq "1"
+      page.cycle("red", "blue", name: "colors").should eq "red"
+      page.reset_cycle("numbers")
+      page.cycle(1, 2, 3, name: "numbers").should eq "1"
+      page.cycle("red", "blue", name: "colors").should eq "blue"
+      page.cycle(1, 2, 3, name: "numbers").should eq "2"
+      page.cycle("red", "blue", name: "colors").should eq "red"
     end
   end
 end

--- a/src/lucky/page_helpers/cycle.cr
+++ b/src/lucky/page_helpers/cycle.cr
@@ -1,0 +1,45 @@
+module Lucky::TextHelpers
+  class Cycle
+    @values : Array(String)
+    getter :values
+    @index = 0
+
+    def initialize(*values)
+      string_values = Array(String).new
+      values.each { |v| string_values << v.to_s }
+      @values = string_values
+      reset
+    end
+
+    def initialize(values : Array(String))
+      @values = Array(String).new
+      @values = values
+      reset
+    end
+
+    def reset : Int32
+      @index = 0
+    end
+
+    def current_value : String
+      @values[previous_index]?.to_s
+    end
+
+    def to_s(io : IO)
+      io << @values[@index]?
+      @index = next_index
+    end
+
+    private def next_index : Int32
+      step_index(1)
+    end
+
+    private def previous_index : Int32
+      step_index(-1)
+    end
+
+    private def step_index(n : Int32) : Int32
+      (@index + n) % @values.size
+    end
+  end
+end

--- a/src/lucky/page_helpers/text_helpers.cr
+++ b/src/lucky/page_helpers/text_helpers.cr
@@ -1,7 +1,5 @@
 # These helper methods will return a `String`.
 module Lucky::TextHelpers
-  @@_cycles = Hash(String, Cycle).new
-
   # Shorten text after a length point.
   #
   # Unlike `truncate`, this method can be used inside of other tags because it
@@ -181,60 +179,20 @@ module Lucky::TextHelpers
     cycle.reset if cycle
   end
 
-  class Cycle
-    @values : Array(String)
-    getter :values
-    @index = 0
-
-    def initialize(*values)
-      string_values = Array(String).new
-      values.each { |v| string_values << v.to_s }
-      @values = string_values
-      reset
-    end
-
-    def initialize(values : Array(String))
-      @values = Array(String).new
-      @values = values
-      reset
-    end
-
-    def reset : Int32
-      @index = 0
-    end
-
-    def current_value : String
-      @values[previous_index]?.to_s
-    end
-
-    def to_s(io : IO)
-      io << @values[@index]?
-      @index = next_index
-    end
-
-    private def next_index : Int32
-      step_index(1)
-    end
-
-    private def previous_index : Int32
-      step_index(-1)
-    end
-
-    private def step_index(n : Int32) : Int32
-      (@index + n) % @values.size
-    end
-  end
-
   def reset_cycles : Hash(String, Cycle)
-    @@_cycles = Hash(String, Cycle).new
+    @cycles = Hash(String, Cycle).new
   end
 
   private def get_cycle(name : String) : Cycle?
-    @@_cycles[name]?
+    cycles[name]?
   end
 
   private def set_cycle(name : String, cycle_object : Cycle) : Cycle
-    @@_cycles[name] = cycle_object
+    cycles[name] = cycle_object
+  end
+
+  private def cycles : Hash(String, Cycle)
+    @cycles ||= Hash(String, Cycle).new
   end
 
   private def cut_excerpt_part(part_position : Symbol, part : String?, separator : String, radius : Int32, omission : String)


### PR DESCRIPTION
## Purpose

Fixes #2048.

## Description

I moved cycle state from a module-level class variable to an instance variable on each page. This keeps `cycle`, `current_cycle`, and reset operations isolated between concurrently rendered pages.

I also moved `Lucky::TextHelpers::Cycle` into its own file and updated the specs so each example exercises one page instance. The new regression spec verifies that starting a cycle on one page does not advance the same named cycle on another page.

## Verification

- `crystal spec spec/lucky/text_helpers/cycle_spec.cr` — 14 examples, 0 failures
- `crystal spec` — 818 examples, 0 failures
- `crystal tool format --check src spec`
- Ameba — 230 files inspected, 0 failures
- `git diff --check`

The Docker wrapper was not run because the local Docker socket is unavailable; the equivalent Crystal suite and formatting checks above were run directly.

## Checklist

* [x] - An issue already exists detailing the issue/or feature request that this PR fixes
* [x] - All specs are formatted with `crystal tool format spec src`
* [x] - Inline documentation has been added and/or updated where needed
* [ ] - Lucky builds on docker with `./script/setup`
* [ ] - All builds and specs pass on docker with `./script/test`
