### PR TITLE
Raise the missing-watcher-config error instead of returning it (#1988)

### DIFF
--- a/spec/lucky/server_settings_spec.cr
+++ b/spec/lucky/server_settings_spec.cr
@@ -1,0 +1,11 @@
+require "../spec_helper"
+
+describe Lucky::ServerSettings do
+  describe "when the watcher config file is missing" do
+    it "raises the helpful guidance message instead of a cryptic YAML error" do
+      expect_raises(Exception, /Expected config file for the watcher/) do
+        Lucky::ServerSettings.host
+      end
+    end
+  end
+end

--- a/src/lucky/server_settings.cr
+++ b/src/lucky/server_settings.cr
@@ -40,7 +40,7 @@ module Lucky::ServerSettings
     if File.exists?(YAML_SETTINGS_PATH)
       File.read YAML_SETTINGS_PATH
     else
-      <<-ERROR
+      raise <<-ERROR
         Expected config file for the watcher at #{YAML_SETTINGS_PATH}.
 
         Try this...


### PR DESCRIPTION
Fixes #1988.

### Problem

When `./config/watch.yml` does not exist, `Lucky::ServerSettings.yaml_settings_file` **returns** its guidance heredoc as a plain `String` instead of raising it:

```crystal
if File.exists?(YAML_SETTINGS_PATH)
  File.read YAML_SETTINGS_PATH
else
  <<-ERROR
    Expected config file for the watcher at #{YAML_SETTINGS_PATH}.
    ...
  ERROR
end
```

That string is then passed to `YAML.parse`, producing a scalar `YAML::Any`, so the first settings lookup crashes with a cryptic error instead of the helpful message:

```
Unhandled exception: Expected Array or Hash, not String (Exception)
  from yaml/any.cr ... in 'Lucky::ServerSettings.host'
```

This happens on the live startup path: generated apps call `Lucky::ServerSettings.host` (via `config/server.cr`), e.g. a production static binary deployed without `watch.yml`. The carefully written guidance message (which even says "If this is Production, be sure to set LUCKY_ENV=production") is effectively dead code and can never surface.

### Fix

Prepend `raise` to the heredoc so the intended guidance is raised. `raise` is `NoReturn`, so the method's `: String` return type is still satisfied and the other branch is unchanged.

### Test

Added `spec/lucky/server_settings_spec.cr` asserting that, with no watcher config present, `ServerSettings.host` raises the guidance message. Red-green verified with `crystal spec spec/lucky/server_settings_spec.cr`: before the change the spec fails (the raised message is the cryptic `Expected Array or Hash, not String`); after, it passes. `crystal tool format --check` and `ameba` are clean.

---
Disclosure: I used AI assistance (Claude) while preparing this change. I verified the crash, ran the tests (red-green), and take responsibility for the contribution.
